### PR TITLE
feat: add signed evidence gate enforcement

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -1,0 +1,98 @@
+# Comparison With Supply-Chain And Policy Tools
+
+Vouch should be honest about where it fits. It is not a replacement for
+Sigstore, SLSA, in-toto, OPA, or Conftest. The defensible position is that
+Vouch is an obligation-oriented control plane that can compose with those tools.
+
+One-sentence version: Vouch turns human-owned product intent into obligation IDs
+and evidence requirements, then uses supply-chain identity, policy engines, and
+runner artifacts to decide whether an agent change can ship.
+
+## What Existing Tools Cover
+
+| Tool | Primary Job | What It Gives Vouch | What It Does Not Give Vouch |
+| --- | --- | --- | --- |
+| [Sigstore/cosign](https://docs.sigstore.dev/cosign/signing/overview/) | Keyless signing, identity-bound verification, transparency logging. | A way to prove an artifact was signed by an expected runner identity and recorded with auditable signing metadata. | A product contract language, obligation IR, or mapping from feature intent to required evidence. |
+| [SLSA](https://slsa.dev/spec/v1.2/) | Supply-chain security levels and provenance expectations for source/build artifacts. | A vocabulary for provenance quality and build trustworthiness. | A release contract for behavior, security invariants, runtime metrics, and rollback obligations. |
+| [in-toto](https://in-toto.io/docs/getting-started/) | Layouts and signed link metadata for expected supply-chain steps. | A mature model for authorized steps, materials/products, and signed supply-chain metadata. | A compiler from product intent into obligations or policy decisions over changed feature contracts. |
+| [OPA/Rego](https://www.openpolicyagent.org/docs/policy-language) | General policy evaluation over structured input. | A policy engine that can replace hard-coded release-decision logic. | Vouch-specific IR, evidence collection, artifact linking, or contract authoring. |
+| [Conftest](https://www.conftest.dev/) | Rego tests for structured configuration data. | A simple way to run policy checks over JSON/YAML/TOML inputs. | Vouch-specific evidence import, obligation coverage, or release-result semantics. |
+
+## Why Not Just Compose Existing Tools Directly?
+
+For some workflows, direct composition is enough:
+
+```sh
+cosign verify-blob artifact.json \
+  --bundle artifact.sigstore.json \
+  --certificate-identity "$RUNNER_IDENTITY" \
+  --certificate-oidc-issuer "$OIDC_ISSUER"
+conftest test manifest.json
+```
+
+That proves useful things: the artifact may have a valid signer, and the
+manifest may satisfy a policy. It does not answer the Vouch-specific question:
+
+> For the contracts this change touches, which compiled obligations are required,
+> which evidence artifacts cover them, and what release posture follows from the
+> contract risk and evidence quality?
+
+Vouch should use existing tools for signing, provenance, and policy execution
+where possible. The unique surface is the typed contract-to-obligation pipeline:
+
+1. Human-owned intent.
+2. Spec and obligation IR.
+3. Changed-file to touched-contract traceability.
+4. Evidence artifact linking by obligation ID and evidence kind.
+5. Deterministic release result.
+
+## How Vouch Should Compose With Them
+
+### Sigstore/cosign
+
+Vouch should not invent a long-term signing system. The production path should
+verify detached evidence bundles signed by approved runner identities.
+`gate --require-signed` already rejects unsigned artifacts and asks cosign to
+verify the artifact blob against its Sigstore bundle and expected signer
+identity. The next hardening step is to sign a canonical evidence bundle that
+also binds the manifest, artifact hashes, and covered obligation IDs.
+
+### SLSA
+
+Vouch should treat SLSA provenance as evidence about the runner/build chain, not
+as a substitute for product obligations. A high-quality SLSA provenance record
+can support the claim that evidence came from an expected builder. It does not
+say whether `auth.password_reset.security.reset_token_is_never_logged` was
+covered.
+
+### in-toto
+
+in-toto is the closest conceptual neighbor for supply-chain step integrity.
+Vouch should borrow the idea of authorized steps and signed metadata, while
+keeping its own obligation IR as the semantic layer for agent-change release
+decisions.
+
+### OPA/Rego
+
+OPA is the best near-term candidate for moving policy out of Go. Vouch should
+prepare a compact policy input that includes manifest data, spec risk, coverage,
+findings, invalid evidence, and signer/provenance status. The policy output
+should be the release decision and reasons.
+
+### Conftest
+
+Conftest is useful as a reference workflow and local policy runner. Vouch should
+not become only a wrapper around Conftest; the value is in generating the policy
+input from contracts, obligations, and evidence.
+
+## Boundary
+
+Vouch is not trying to prove that code is correct. It is trying to make release
+decisions auditable against explicit contracts. The strongest architecture is
+therefore compositional:
+
+- Sigstore/cosign proves who signed evidence.
+- SLSA/in-toto-style metadata proves where evidence came from and which steps ran.
+- OPA/Rego decides release posture from structured facts.
+- Vouch supplies the contract language, obligation IR, evidence linkage, and gate
+  result.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The mental model:
 | Contract | `.vouch/intents/*.yaml` and `.vouch/specs/*.json` | Human-owned intent for one part of the repo. |
 | Manifest | `.vouch/manifests/*.json` | What the agent changed in one run. |
 | Evidence | `.vouch/artifacts/*` | Test/probe/scanner output that covers compiled obligation IDs. |
-| Gate result | command output | Vouch's decision for that manifest. |
+| Gate result | command output or `.vouch/build/gate-result.json` | Vouch's decision for that manifest. |
 
 ### 1. Initialize Vouch In Your Repo
 
@@ -208,6 +208,38 @@ vouch --repo /path/to/your/repo manifest attach-artifact \
   --out .vouch/manifests/run-123.json
 ```
 
+Signature fields are optional in beta. To attach signed evidence, first sign the
+artifact with cosign, then include the bundle and expected identity when
+attaching it:
+
+```sh
+cosign sign-blob .vouch/artifacts/behavior.json \
+  --bundle .vouch/artifacts/behavior.sigstore.json
+
+vouch --repo /path/to/your/repo manifest attach-artifact \
+  --manifest .vouch/manifests/run-123.json \
+  --id behavior \
+  --kind behavior_trace \
+  --path .vouch/artifacts/behavior.json \
+  --signature-bundle .vouch/artifacts/behavior.sigstore.json \
+  --signer-identity "https://github.com/ORG/REPO/.github/workflows/vouch.yml@refs/heads/main" \
+  --signer-oidc-issuer "https://token.actions.githubusercontent.com" \
+  --exit-code 0 \
+  --out .vouch/manifests/run-123.json
+```
+
+Production-style gates should require signed evidence:
+
+```sh
+vouch --repo /path/to/your/repo \
+  --manifest .vouch/manifests/run-123.json \
+  gate --require-signed
+```
+
+`--require-signed` verifies each evidence artifact with `cosign verify-blob`
+using the artifact's `signature_bundle`, `signer_identity`, and
+`signer_oidc_issuer` fields.
+
 ### 7. Gate The Change
 
 ```sh
@@ -231,9 +263,18 @@ vouch --repo /path/to/your/repo \
   gate --json
 ```
 
+To preserve a compact gate result artifact for CI upload or required-status checks:
+
+```sh
+vouch --repo /path/to/your/repo \
+  --manifest .vouch/manifests/run-123.json \
+  gate --out .vouch/build/gate-result.json
+```
+
 ## Project Docs
 
 - [Roadmap](ROADMAP.md) explains where the project is going and what remains before this can be production infrastructure.
+- [Comparison](COMPARISON.md) explains how Vouch composes with Sigstore, SLSA, in-toto, OPA, and Conftest.
 - [Contributing](CONTRIBUTING.md) explains how to help and which areas need work.
 
 The problem it attempts to solve is:
@@ -266,19 +307,21 @@ Today, Vouch can check:
 - Artifact paths stay inside the repo and files exist.
 - Artifact exit codes are present and zero.
 - Optional artifact SHA-256 values match file contents.
+- Optional `gate --require-signed` mode verifies evidence artifacts with cosign bundles and expected signer identities.
 - JUnit evidence has no failure/error/skipped testcases and covers required test obligations.
 - Raw pytest/JUnit testcases can be mapped through `.vouch/test-map.json`.
 - Generic JSON/text artifacts contain exact obligation IDs and optional passing status.
+- Compact gate results can be written to a JSON artifact file.
 - Release decisions follow deterministic risk and evidence rules.
 
 Today, Vouch cannot check:
 
 - Whether arbitrary code semantically implements the declared behavior.
 - Whether a generic JSON/text artifact is truthful beyond its structure, IDs, status, path, exit code, and optional hash.
-- Whether tests were actually run unless the external runner preserves the artifact and manifest chain.
+- Whether tests were actually run unless the external runner preserves and signs the artifact chain.
 - Whether product intent was inferred correctly from code.
 - Whether release policy is team-defined; policy is still hard-coded Go logic.
-- Whether evidence is signed, provenance-bound, or tamper-evident.
+- Whether signed evidence is bound to a canonical bundle that includes manifest identity, artifact hashes, and covered obligation IDs.
 
 ## Validation Status
 
@@ -556,14 +599,14 @@ vouch artifacts build --spec FILE --out DIR
 vouch --repo DIR spec lint
 vouch --repo DIR --manifest FILE manifest check
 vouch --repo DIR manifest create --task-id ID --summary TEXT --agent NAME --run-id ID --out FILE
-vouch --repo DIR --manifest FILE manifest attach-artifact --id ID --kind KIND --path FILE --exit-code N --out FILE
+vouch --repo DIR --manifest FILE manifest attach-artifact --id ID --kind KIND --path FILE --exit-code N [--signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE
 vouch --repo DIR --manifest FILE junit map --junit FILE --test-map FILE --out FILE
 vouch --repo DIR --manifest FILE verify
-vouch --repo DIR --manifest FILE gate
+vouch --repo DIR --manifest FILE gate [--out FILE] [--require-signed]
 vouch --repo DIR --manifest FILE evidence
 ```
 
-`--json` emits machine-readable evidence for commands that collect evidence.
+`--json` emits machine-readable evidence for commands that collect evidence. For `gate`, `--json` emits the compact gate result to stdout and `--out FILE` writes the same gate-result shape as a JSON artifact.
 
 ## Test
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -33,6 +33,11 @@ CI can execute Vouch, but the product is the compiler-like control plane:
 
 If a feature only makes Vouch a nicer wrapper around existing test commands, it should not be a roadmap priority unless it also strengthens obligation coverage, evidence quality, policy semantics, or auditability.
 
+Vouch should also be explicit about how it composes with existing supply-chain
+and policy tools. Sigstore/cosign, SLSA, in-toto, OPA, and Conftest cover
+important parts of the system; Vouch's distinct surface is the contract language,
+obligation IR, evidence mapping, and release result built on top.
+
 ## Current Beta
 
 Implemented today:
@@ -46,6 +51,7 @@ Implemented today:
 - Verifier/test/release artifact generation.
 - Evidence artifact reference resolution from change manifests.
 - Artifact path/hash verification.
+- Optional cosign bundle verification for evidence artifacts under `gate --require-signed`.
 - JUnit XML importer for test evidence.
 - Deterministic verifier findings.
 - Touched-spec compilation for faster PR checks.
@@ -54,6 +60,7 @@ Implemented today:
 - Manifest creation from changed files and owned paths.
 - Artifact attachment with obligation inference.
 - JUnit test-map adapter for raw pytest-style JUnit evidence.
+- Machine-readable gate result artifact output for status checks.
 - Release decisions: `block`, `human_escalation`, `canary`, `auto_merge`.
 - Demo repo with blocked and passing manifests.
 - Unit tests for the current pipeline.
@@ -71,6 +78,21 @@ Recent validation runs used temp copies of real repos, so Vouch exercised the ge
 These runs show the current beta can initialize unfamiliar repos, create contracts, create manifests from changed files, map raw test output to required-test obligations, attach evidence, and produce deterministic release decisions.
 
 It does not yet prove that Vouch understands arbitrary product intent. The contract remains the source of truth, and the next product work should reduce the manual work needed to create and maintain those contracts.
+
+## Execution Order
+
+The trust and policy work should move earlier than the original phase order.
+Until evidence is provenance-bound and policy is inspectable, workflow polish and
+AI verifier layers are easy to bypass or hard to reason about.
+
+Near-term execution order:
+
+1. Tamper-evident evidence and runner identity.
+2. Policy files and policy simulation.
+3. Positioning and comparison artifacts.
+4. Contract-generation paths that reduce authoring cost.
+5. Reproducible case studies that show Vouch catching realistic regressions.
+6. AI evidence verifiers only after signed evidence and policy semantics exist.
 
 ## Roadmap Phases
 
@@ -94,7 +116,10 @@ Separate release policy from hard-coded Go logic.
 
 Planned work:
 
-- Policy-as-code files.
+- Policy-as-code files loaded from `.vouch/policy/`.
+- Rego policy adapter or a deliberately smaller custom evaluator.
+- Compact policy input containing spec, manifest, IR coverage, findings, invalid evidence, and provenance status.
+- Policy output containing decision and reasons.
 - Risk-specific policy profiles.
 - Team-specific override rules.
 - Exception handling with audit trails.
@@ -108,7 +133,6 @@ Make Vouch useful in real pull-request workflows while keeping CI as the runner,
 Planned work:
 
 - GitHub Checks integration.
-- Machine-readable gate result artifact.
 - SARIF or annotation output for diagnostics.
 - Artifact upload conventions.
 - Required status check examples.
@@ -118,9 +142,14 @@ Planned work:
 
 Turn generated verifier packets into first-class verifier inputs.
 
+This phase should wait until evidence provenance and policy semantics are in
+place. A verifier finding is useful only when the verifier output is tied to a
+runner identity and the release policy says how to use it.
+
 Planned work:
 
 - Verifier input packet schema.
+- Signed verifier output schema.
 - Structured verifier output schema.
 - Prompt and model version pinning.
 - Verifier confidence and disagreement handling.
@@ -144,7 +173,9 @@ Implemented base:
 Planned work:
 
 - Spec-to-file traceability beyond owned path globs.
+- OpenAPI-to-contract stub generation.
 - Test discovery and suggested test-map generation.
+- Typed API/signature obligation suggestions.
 - Coverage report import.
 - Static analysis import.
 - SARIF import.
@@ -172,6 +203,10 @@ Make the system usable by teams.
 
 Planned work:
 
+- Runner identity in manifests and evidence artifacts.
+- Allowed signer policy for contracts or repo policy.
+- Detached signatures over canonical evidence bundles.
+- Hardened `gate --require-signed` mode that binds manifest, artifact hashes, and obligation IDs.
 - Signed specs and manifests.
 - Agent identity and run provenance.
 - Tamper-evident evidence bundles.
@@ -184,15 +219,19 @@ Planned work:
 
 The next useful contributions are:
 
+- Signed or hashed evidence bundle format.
+- Runner identity and allowed signer fields.
+- Hardened `gate --require-signed` production mode.
+- Policy-as-code design and simulation command.
+- Rego policy adapter decision spike.
 - Reference workflow for `init -> manifest -> pytest -> junit map -> attach -> gate`.
-- Machine-readable gate result file for required status checks.
+- Real-world case study showing a plausible bad agent change blocked by an obligation.
 - Test-map discovery to reduce manual required-test mapping.
+- OpenAPI-to-contract stub generation.
 - Coverage XML importer for required-test and behavior evidence.
 - Static-analysis/SARIF importer for security and quality evidence.
 - JSON schemas plus compatibility tests for AST, spec, IR, plan, manifest, and evidence.
 - Golden diagnostics for parser and compiler failures.
-- Policy-as-code design and simulation command.
-- Signed or hashed evidence bundle format.
 - More demo scenarios beyond password reset, including ordinary library changes.
 
 ## Productionization Track

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -82,11 +82,11 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 			return junitMap(absRepo, rest[2:], common.json, stdout, stderr, manifest)
 		}
 	case "verify":
-		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "evidence")
+		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "evidence", rest[1:])
 	case "gate":
-		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "gate")
+		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "gate", rest[1:])
 	case "evidence":
-		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "evidence-no-exit")
+		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "evidence-no-exit", rest[1:])
 	}
 	usage(stderr)
 	return 2
@@ -269,6 +269,9 @@ func manifestAttachArtifact(repo string, args []string, jsonOut bool, stdout io.
 	producer := flags.String("producer", "", "artifact producer")
 	command := flags.String("command", "", "command that produced artifact")
 	sha256 := flags.String("sha256", "", "expected sha256")
+	signatureBundle := flags.String("signature-bundle", "", "cosign signature bundle path")
+	signerIdentity := flags.String("signer-identity", "", "expected cosign signer identity")
+	signerOIDCIssuer := flags.String("signer-oidc-issuer", "", "expected cosign signer OIDC issuer")
 	outPath := flags.String("out", "", "updated manifest output path")
 	exitCode := flags.Int("exit-code", -1, "artifact command exit code")
 	if err := flags.Parse(args); err != nil {
@@ -282,16 +285,19 @@ func manifestAttachArtifact(repo string, args []string, jsonOut bool, stdout io.
 		return 2
 	}
 	manifest, artifact, err := AttachArtifact(repo, AttachArtifactOptions{
-		ManifestPath: *manifestPath,
-		ID:           *id,
-		Kind:         EvidenceKind(*kind),
-		Path:         *path,
-		TestMapPath:  *testMap,
-		Producer:     *producer,
-		Command:      *command,
-		ExitCode:     *exitCode,
-		SHA256:       *sha256,
-		Out:          *outPath,
+		ManifestPath:     *manifestPath,
+		ID:               *id,
+		Kind:             EvidenceKind(*kind),
+		Path:             *path,
+		TestMapPath:      *testMap,
+		Producer:         *producer,
+		Command:          *command,
+		ExitCode:         *exitCode,
+		SHA256:           *sha256,
+		SignatureBundle:  *signatureBundle,
+		SignerIdentity:   *signerIdentity,
+		SignerOIDCIssuer: *signerOIDCIssuer,
+		Out:              *outPath,
 	})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
@@ -546,11 +552,32 @@ func manifestCheck(repo string, manifestPath string, stdout io.Writer, stderr io
 	return 0
 }
 
-func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.Writer, stderr io.Writer, mode string) int {
-	evidence, err := CollectEvidence(repo, manifestPath)
+func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.Writer, stderr io.Writer, mode string, args []string) int {
+	flags := flag.NewFlagSet(mode, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	gateOut := ""
+	requireSigned := false
+	if mode == "gate" {
+		flags.StringVar(&gateOut, "out", "", "path to write compact gate result JSON")
+		flags.BoolVar(&requireSigned, "require-signed", false, "require cosign-verified evidence artifacts")
+	}
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "%s: unexpected argument %q\n", mode, flags.Arg(0))
+		return 2
+	}
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: requireSigned})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
+	}
+	if gateOut != "" {
+		if err := writeJSONFile(resolveRepoOutput(repo, gateOut), GateResultFromEvidence(evidence)); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
 	}
 	if jsonOut {
 		var output string
@@ -597,9 +624,9 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  spec lint")
 	fmt.Fprintln(out, "  manifest check")
 	fmt.Fprintln(out, "  manifest create --task-id ID --summary TEXT --agent NAME --run-id ID --out FILE")
-	fmt.Fprintln(out, "  manifest attach-artifact --manifest FILE --id ID --kind KIND --path FILE --exit-code N --out FILE")
+	fmt.Fprintln(out, "  manifest attach-artifact --manifest FILE --id ID --kind KIND --path FILE --exit-code N [--signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE")
 	fmt.Fprintln(out, "  junit map --manifest FILE --junit FILE --test-map FILE --out FILE")
 	fmt.Fprintln(out, "  verify")
-	fmt.Fprintln(out, "  gate")
+	fmt.Fprintln(out, "  gate [--out FILE] [--require-signed]")
 	fmt.Fprintln(out, "  evidence")
 }

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -7,7 +7,15 @@ import (
 	"strings"
 )
 
+type CollectEvidenceOptions struct {
+	RequireSigned bool
+}
+
 func CollectEvidence(repo string, manifestPath string) (Evidence, error) {
+	return CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{})
+}
+
+func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEvidenceOptions) (Evidence, error) {
 	absRepo, err := filepath.Abs(repo)
 	if err != nil {
 		return Evidence{}, err
@@ -26,33 +34,34 @@ func CollectEvidence(repo string, manifestPath string) (Evidence, error) {
 	}
 	pipeline := CompileManifestPipeline(specs, manifest)
 	evidence := Evidence{
-		Version:             EvidenceSchemaVersion,
-		Repo:                absRepo,
-		ManifestPath:        absManifest,
-		Compilation:         pipeline.Compilation,
-		Manifest:            manifest,
-		Specs:               specs,
-		IRs:                 pipeline.IRs,
-		VerificationPlans:   pipeline.VerificationPlans,
-		Diagnostics:         pipeline.Diagnostics,
-		SpecErrors:          pipeline.SpecErrors,
-		ManifestErrors:      pipeline.ManifestErrors,
-		ArtifactResults:     []ArtifactResult{},
-		InvalidEvidence:     []InvalidEvidence{},
-		RequiredObligations: make(map[string][]Obligation),
-		CoveredObligations:  make(map[string][]Obligation),
-		MissingObligations:  make(map[string][]Obligation),
-		RequiredTests:       make(map[string][]string),
-		CoveredTests:        make(map[string][]string),
-		MissingTests:        make(map[string][]string),
-		RequiredSecurity:    make(map[string][]string),
-		CoveredSecurity:     make(map[string][]string),
-		MissingSecurity:     make(map[string][]string),
-		Findings:            []Finding{},
-		Reasons:             []string{},
+		Version:                EvidenceSchemaVersion,
+		Repo:                   absRepo,
+		ManifestPath:           absManifest,
+		Compilation:            pipeline.Compilation,
+		Manifest:               manifest,
+		Specs:                  specs,
+		IRs:                    pipeline.IRs,
+		VerificationPlans:      pipeline.VerificationPlans,
+		Diagnostics:            pipeline.Diagnostics,
+		SignedEvidenceRequired: opts.RequireSigned,
+		SpecErrors:             pipeline.SpecErrors,
+		ManifestErrors:         pipeline.ManifestErrors,
+		ArtifactResults:        []ArtifactResult{},
+		InvalidEvidence:        []InvalidEvidence{},
+		RequiredObligations:    make(map[string][]Obligation),
+		CoveredObligations:     make(map[string][]Obligation),
+		MissingObligations:     make(map[string][]Obligation),
+		RequiredTests:          make(map[string][]string),
+		CoveredTests:           make(map[string][]string),
+		MissingTests:           make(map[string][]string),
+		RequiredSecurity:       make(map[string][]string),
+		CoveredSecurity:        make(map[string][]string),
+		MissingSecurity:        make(map[string][]string),
+		Findings:               []Finding{},
+		Reasons:                []string{},
 	}
 	obligationIndex := NewObligationIndex(evidence.VerificationPlans)
-	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest.Verification.Artifacts, obligationIndex)
+	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{RequireSigned: opts.RequireSigned})
 	buildCoverage(&evidence)
 	runVerifiers(&evidence)
 	decide(&evidence)
@@ -161,6 +170,16 @@ func verifyCompilation(evidence *Evidence) {
 }
 
 func verifyArtifactEvidence(evidence *Evidence) {
+	if evidence.SignedEvidenceRequired && evidence.Compilation.ObligationsBuilt > 0 && len(evidence.Manifest.Verification.Artifacts) == 0 {
+		evidence.Findings = append(evidence.Findings, Finding{
+			Verifier:    "evidence_linker",
+			Severity:    "high",
+			Decision:    "block",
+			Claim:       "signed evidence artifacts are required",
+			Evidence:    "gate --require-signed was used and verification.artifacts is empty",
+			RequiredFix: "attach cosign-signed evidence artifacts for compiled obligations",
+		})
+	}
 	if evidence.Compilation.ObligationsBuilt > 0 && len(evidence.Manifest.Verification.Artifacts) == 0 && riskRank[evidence.Manifest.Change.Risk] >= riskRank[RiskMedium] {
 		evidence.Findings = append(evidence.Findings, Finding{
 			Verifier:    "evidence_linker",

--- a/internal/vouch/evidence_artifacts.go
+++ b/internal/vouch/evidence_artifacts.go
@@ -7,12 +7,17 @@ import (
 	"encoding/xml"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
 type ObligationIndex struct {
 	ByID map[string]Obligation
+}
+
+type ArtifactLinkOptions struct {
+	RequireSigned bool
 }
 
 func NewObligationIndex(plans map[string]VerificationPlan) ObligationIndex {
@@ -25,7 +30,7 @@ func NewObligationIndex(plans map[string]VerificationPlan) ObligationIndex {
 	return index
 }
 
-func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index ObligationIndex) ([]ArtifactResult, []InvalidEvidence) {
+func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index ObligationIndex, opts ArtifactLinkOptions) ([]ArtifactResult, []InvalidEvidence) {
 	results := make([]ArtifactResult, 0, len(artifacts))
 	var invalid []InvalidEvidence
 	for _, artifact := range artifacts {
@@ -79,6 +84,10 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 			result.addIssue("artifact_path_required", fmt.Sprintf("%s evidence requires an artifact path", artifact.Kind))
 		}
 
+		if opts.RequireSigned && len(data) > 0 {
+			verifyCosignBundle(repo, artifact, result.ResolvedPath, &result)
+		}
+
 		if artifact.Kind == EvidenceTestCoverage {
 			if len(data) > 0 {
 				covered, failed, issues := importJUnitEvidence(data, artifact.Obligations)
@@ -113,6 +122,52 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 		results = append(results, result)
 	}
 	return results, invalid
+}
+
+func verifyCosignBundle(repo string, artifact EvidenceArtifact, artifactPath string, result *ArtifactResult) {
+	if artifact.SignatureBundle == "" {
+		result.addIssue("missing_signature_bundle", "signature_bundle is required when signed evidence is enforced")
+		return
+	}
+	if artifact.SignerIdentity == "" {
+		result.addIssue("missing_signer_identity", "signer_identity is required when signed evidence is enforced")
+		return
+	}
+	if artifact.SignerOIDCIssuer == "" {
+		result.addIssue("missing_signer_oidc_issuer", "signer_oidc_issuer is required when signed evidence is enforced")
+		return
+	}
+	bundlePath, err := resolveArtifactPath(repo, artifact.SignatureBundle)
+	if err != nil {
+		result.addIssue("signature_bundle_path_escape", err.Error())
+		return
+	}
+	if _, err := os.Stat(bundlePath); err != nil {
+		result.addIssue("signature_bundle_missing", fmt.Sprintf("cannot read signature bundle %s: %v", artifact.SignatureBundle, err))
+		return
+	}
+	cosignPath, err := exec.LookPath("cosign")
+	if err != nil {
+		result.addIssue("cosign_missing", "cosign is required to verify signed evidence")
+		return
+	}
+	cmd := exec.Command(cosignPath,
+		"verify-blob",
+		artifactPath,
+		"--bundle", bundlePath,
+		"--certificate-identity="+artifact.SignerIdentity,
+		"--certificate-oidc-issuer="+artifact.SignerOIDCIssuer,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		message := strings.TrimSpace(string(output))
+		if message == "" {
+			message = err.Error()
+		}
+		result.addIssue("signature_verify", message)
+		return
+	}
+	result.SignatureVerified = true
 }
 
 func (r *ArtifactResult) addIssue(code string, message string) {

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -1338,6 +1339,194 @@ func TestGateResultJSONIsCompactAndDeterministic(t *testing.T) {
 	}
 }
 
+func TestGateCommandWritesGateResultFile(t *testing.T) {
+	repo, manifestPath := writeScenario(t, Spec{
+		Version:    SpecSchemaVersion,
+		ID:         "ui.copy",
+		Owner:      "product",
+		OwnedPaths: []string{"src/ui/**"},
+		Risk:       RiskLow,
+		Behavior:   []string{"button label changes to Save"},
+		Security:   []string{"no secrets introduced"},
+		Tests:      SpecTests{Required: []string{"button label renders"}},
+		Runtime:    SpecRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback:   SpecRollback{Strategy: "revert_commit"},
+	}, Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "issue-gate-out", Summary: "copy update"},
+		Change: Change{
+			Risk:            RiskLow,
+			SpecsTouched:    []string{"ui.copy"},
+			BehaviorChanged: true,
+			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Verification: Verification{
+			CoversBehavior: []string{"button label changes to Save"},
+			Commands:       []string{"go test ./..."},
+			CoversTests:    []string{"button label renders"},
+			CoversSecurity: []string{"no secrets introduced"},
+			TestResults:    TestResults{Passed: 1},
+		},
+		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback: ManifestRollback{Strategy: "revert_commit"},
+	})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Main([]string{"--repo", repo, "--manifest", manifestPath, "gate", "--out", ".vouch/build/gate-result.json"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gate failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Release decision: auto_merge") {
+		t.Fatalf("expected human gate output, got %s", stdout.String())
+	}
+	result, err := LoadJSON[GateResult](filepath.Join(repo, ".vouch", "build", "gate-result.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Version != "vouch.gate_result.v0" || result.Decision != "auto_merge" {
+		t.Fatalf("unexpected gate result: %#v", result)
+	}
+}
+
+func TestRequireSignedBlocksUnsignedArtifacts(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	evidence, err := CollectEvidenceWithOptions(demo, filepath.Join(demo, ".vouch", "manifests", "pass.json"), CollectEvidenceOptions{RequireSigned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected signed-evidence gate to block unsigned artifacts, got %s", evidence.Decision)
+	}
+	if !hasInvalidEvidence(evidence, "behavior-trace", "missing_signature_bundle") {
+		t.Fatalf("expected unsigned behavior artifact to be invalid: %#v", evidence.InvalidEvidence)
+	}
+}
+
+func TestRequireSignedRequiresArtifactBackedEvidence(t *testing.T) {
+	repo, manifestPath := writeScenario(t, Spec{
+		Version:    SpecSchemaVersion,
+		ID:         "ui.copy",
+		Owner:      "product",
+		OwnedPaths: []string{"src/ui/**"},
+		Risk:       RiskLow,
+		Behavior:   []string{"button label changes to Save"},
+		Security:   []string{"no secrets introduced"},
+		Tests:      SpecTests{Required: []string{"button label renders"}},
+		Runtime:    SpecRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback:   SpecRollback{Strategy: "revert_commit"},
+	}, Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "issue-signed-text", Summary: "text evidence"},
+		Change: Change{
+			Risk:            RiskLow,
+			SpecsTouched:    []string{"ui.copy"},
+			BehaviorChanged: true,
+			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Verification: Verification{
+			CoversBehavior: []string{"button label changes to Save"},
+			Commands:       []string{"go test ./..."},
+			CoversTests:    []string{"button label renders"},
+			CoversSecurity: []string{"no secrets introduced"},
+			TestResults:    TestResults{Passed: 1},
+		},
+		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback: ManifestRollback{Strategy: "revert_commit"},
+	})
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected require-signed to block text-only evidence, got %s", evidence.Decision)
+	}
+	if !hasFinding(evidence, "evidence_linker", "signed evidence artifacts are required") {
+		t.Fatalf("expected signed artifact finding: %#v", evidence.Findings)
+	}
+}
+
+func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
+	installFakeCosign(t, 0)
+	spec := Spec{
+		Version:    SpecSchemaVersion,
+		ID:         "ui.copy",
+		Owner:      "product",
+		OwnedPaths: []string{"src/ui/**"},
+		Risk:       RiskLow,
+		Behavior:   []string{"button label changes to Save"},
+		Security:   []string{"no secrets introduced"},
+		Tests:      SpecTests{Required: []string{"button label renders"}},
+		Runtime:    SpecRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback:   SpecRollback{Strategy: "revert_commit"},
+	}
+	behaviorID := obligationID(t, spec, ObligationBehavior, "button label changes to Save")
+	securityID := obligationID(t, spec, ObligationSecurity, "no secrets introduced")
+	testID := obligationID(t, spec, ObligationRequiredTest, "button label renders")
+	runtimeID := obligationID(t, spec, ObligationRuntimeSignal, "ui.rendered")
+	rollbackID := obligationID(t, spec, ObligationRollback, "revert_commit")
+	signed := func(id string, kind EvidenceKind, path string, obligations ...string) EvidenceArtifact {
+		return EvidenceArtifact{
+			ID:               id,
+			Kind:             kind,
+			Producer:         "ci",
+			Path:             path,
+			SignatureBundle:  "artifacts/" + id + ".sigstore.json",
+			SignerIdentity:   "https://github.com/example/repo/.github/workflows/vouch.yml@refs/heads/main",
+			SignerOIDCIssuer: "https://token.actions.githubusercontent.com",
+			ExitCode:         exitCode(0),
+			Obligations:      obligations,
+		}
+	}
+	repo, manifestPath := writeScenario(t, spec, Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "issue-signed", Summary: "signed evidence"},
+		Change: Change{
+			Risk:            RiskLow,
+			SpecsTouched:    []string{"ui.copy"},
+			BehaviorChanged: true,
+			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Verification: Verification{
+			Commands:    []string{"go test ./..."},
+			TestResults: TestResults{Passed: 1},
+			Artifacts: []EvidenceArtifact{
+				signed("behavior", EvidenceBehaviorTrace, "artifacts/behavior.json", behaviorID),
+				signed("security", EvidenceSecurityCheck, "artifacts/security.json", securityID),
+				signed("tests", EvidenceTestCoverage, "artifacts/junit.xml", testID),
+				signed("runtime", EvidenceRuntimeMetric, "artifacts/runtime.json", runtimeID),
+				signed("rollback", EvidenceRollbackPlan, "artifacts/rollback.json", rollbackID),
+			},
+		},
+		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback: ManifestRollback{Strategy: "revert_commit"},
+	})
+	writeArtifact(t, repo, "artifacts/behavior.json", `{"status":"pass","obligations":["`+behaviorID+`"]}`)
+	writeArtifact(t, repo, "artifacts/security.json", `{"status":"pass","obligations":["`+securityID+`"]}`)
+	writeArtifact(t, repo, "artifacts/runtime.json", `{"status":"pass","obligations":["`+runtimeID+`"]}`)
+	writeArtifact(t, repo, "artifacts/rollback.json", `{"status":"pass","obligations":["`+rollbackID+`"]}`)
+	writeArtifact(t, repo, "artifacts/junit.xml", `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="ui.copy" tests="1" failures="0" errors="0" skipped="0">
+  <testcase classname="`+testID+`" name="button label renders" />
+</testsuite>
+`)
+	for _, artifact := range []string{"behavior", "security", "tests", "runtime", "rollback"} {
+		writeArtifact(t, repo, "artifacts/"+artifact+".sigstore.json", `{"mediaType":"application/vnd.dev.sigstore.bundle+json"}`)
+	}
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "auto_merge" {
+		t.Fatalf("expected signed artifacts to pass, got %s: invalid=%#v findings=%#v", evidence.Decision, evidence.InvalidEvidence, evidence.Findings)
+	}
+	for _, result := range evidence.ArtifactResults {
+		if !result.SignatureVerified {
+			t.Fatalf("expected signature verification for artifact %s: %#v", result.ID, evidence.ArtifactResults)
+		}
+	}
+}
+
 func contains(values []string, want string) bool {
 	for _, value := range values {
 		if value == want {
@@ -1494,6 +1683,17 @@ func writeArtifact(t *testing.T, repo string, relPath string, data string) {
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func installFakeCosign(t *testing.T, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cosign")
+	script := "#!/bin/sh\nexit " + strconv.Itoa(exitCode) + "\n"
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func obligationID(t *testing.T, spec Spec, kind ObligationKind, text string) string {

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -360,16 +360,19 @@ func CreateManifest(repo string, opts ManifestCreateOptions) (Manifest, error) {
 }
 
 type AttachArtifactOptions struct {
-	ManifestPath string
-	ID           string
-	Kind         EvidenceKind
-	Path         string
-	TestMapPath  string
-	Producer     string
-	Command      string
-	ExitCode     int
-	SHA256       string
-	Out          string
+	ManifestPath     string
+	ID               string
+	Kind             EvidenceKind
+	Path             string
+	TestMapPath      string
+	Producer         string
+	Command          string
+	ExitCode         int
+	SHA256           string
+	SignatureBundle  string
+	SignerIdentity   string
+	SignerOIDCIssuer string
+	Out              string
 }
 
 func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, EvidenceArtifact, error) {
@@ -386,6 +389,9 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 	if opts.ExitCode != 0 {
 		return Manifest{}, EvidenceArtifact{}, fmt.Errorf("artifact exit code must be 0, got %d", opts.ExitCode)
 	}
+	if err := validateSignatureMetadata(opts.SignatureBundle, opts.SignerIdentity, opts.SignerOIDCIssuer); err != nil {
+		return Manifest{}, EvidenceArtifact{}, err
+	}
 	artifactPath := opts.Path
 	if opts.TestMapPath != "" {
 		if opts.Kind != EvidenceTestCoverage {
@@ -393,6 +399,9 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 		}
 		if opts.SHA256 != "" {
 			return Manifest{}, EvidenceArtifact{}, errors.New("--sha256 cannot be combined with --test-map because the mapped JUnit artifact is generated")
+		}
+		if opts.SignatureBundle != "" || opts.SignerIdentity != "" || opts.SignerOIDCIssuer != "" {
+			return Manifest{}, EvidenceArtifact{}, errors.New("signature metadata cannot be combined with --test-map because the mapped JUnit artifact is generated")
 		}
 		mappedPath := defaultMappedJUnitArtifactPath(opts.ID)
 		if _, err := MapJUnitEvidence(absRepo, JUnitMapOptions{
@@ -444,14 +453,17 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 		producer = "local"
 	}
 	artifact := EvidenceArtifact{
-		ID:          opts.ID,
-		Kind:        opts.Kind,
-		Producer:    producer,
-		Command:     opts.Command,
-		Path:        artifactPath,
-		SHA256:      opts.SHA256,
-		ExitCode:    &opts.ExitCode,
-		Obligations: covered,
+		ID:               opts.ID,
+		Kind:             opts.Kind,
+		Producer:         producer,
+		Command:          opts.Command,
+		Path:             artifactPath,
+		SHA256:           opts.SHA256,
+		SignatureBundle:  opts.SignatureBundle,
+		SignerIdentity:   opts.SignerIdentity,
+		SignerOIDCIssuer: opts.SignerOIDCIssuer,
+		ExitCode:         &opts.ExitCode,
+		Obligations:      covered,
 	}
 	manifest.Verification.Artifacts = append(manifest.Verification.Artifacts, artifact)
 	sort.Slice(manifest.Verification.Artifacts, func(i, j int) bool {
@@ -462,6 +474,16 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 		return Manifest{}, EvidenceArtifact{}, err
 	}
 	return manifest, artifact, nil
+}
+
+func validateSignatureMetadata(bundle string, identity string, issuer string) error {
+	if bundle == "" && identity == "" && issuer == "" {
+		return nil
+	}
+	if bundle == "" || identity == "" || issuer == "" {
+		return errors.New("signed artifacts require --signature-bundle, --signer-identity, and --signer-oidc-issuer together")
+	}
+	return nil
 }
 
 func defaultMappedJUnitArtifactPath(artifactID string) string {

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -222,14 +222,17 @@ type Verification struct {
 }
 
 type EvidenceArtifact struct {
-	ID          string       `json:"id"`
-	Kind        EvidenceKind `json:"kind"`
-	Producer    string       `json:"producer,omitempty"`
-	Command     string       `json:"command,omitempty"`
-	Path        string       `json:"path,omitempty"`
-	SHA256      string       `json:"sha256,omitempty"`
-	ExitCode    *int         `json:"exit_code"`
-	Obligations []string     `json:"obligations"`
+	ID               string       `json:"id"`
+	Kind             EvidenceKind `json:"kind"`
+	Producer         string       `json:"producer,omitempty"`
+	Command          string       `json:"command,omitempty"`
+	Path             string       `json:"path,omitempty"`
+	SHA256           string       `json:"sha256,omitempty"`
+	SignatureBundle  string       `json:"signature_bundle,omitempty"`
+	SignerIdentity   string       `json:"signer_identity,omitempty"`
+	SignerOIDCIssuer string       `json:"signer_oidc_issuer,omitempty"`
+	ExitCode         *int         `json:"exit_code"`
+	Obligations      []string     `json:"obligations"`
 }
 
 type TestResults struct {
@@ -267,31 +270,32 @@ func (f Finding) Blocks() bool {
 }
 
 type Evidence struct {
-	Version             string                      `json:"version"`
-	Repo                string                      `json:"repo"`
-	ManifestPath        string                      `json:"manifest_path"`
-	Compilation         CompilationStats            `json:"compilation"`
-	Manifest            Manifest                    `json:"manifest"`
-	Specs               map[string]Spec             `json:"specs"`
-	IRs                 map[string]IR               `json:"irs"`
-	VerificationPlans   map[string]VerificationPlan `json:"verification_plans"`
-	Diagnostics         []Diagnostic                `json:"diagnostics"`
-	SpecErrors          []string                    `json:"spec_errors"`
-	ManifestErrors      []string                    `json:"manifest_errors"`
-	ArtifactResults     []ArtifactResult            `json:"artifact_results"`
-	InvalidEvidence     []InvalidEvidence           `json:"invalid_evidence"`
-	RequiredObligations map[string][]Obligation     `json:"required_obligations"`
-	CoveredObligations  map[string][]Obligation     `json:"covered_obligations"`
-	MissingObligations  map[string][]Obligation     `json:"missing_obligations"`
-	RequiredTests       map[string][]string         `json:"required_tests"`
-	CoveredTests        map[string][]string         `json:"covered_tests"`
-	MissingTests        map[string][]string         `json:"missing_tests"`
-	RequiredSecurity    map[string][]string         `json:"required_security"`
-	CoveredSecurity     map[string][]string         `json:"covered_security"`
-	MissingSecurity     map[string][]string         `json:"missing_security"`
-	Findings            []Finding                   `json:"findings"`
-	Decision            string                      `json:"decision"`
-	Reasons             []string                    `json:"reasons"`
+	Version                string                      `json:"version"`
+	Repo                   string                      `json:"repo"`
+	ManifestPath           string                      `json:"manifest_path"`
+	Compilation            CompilationStats            `json:"compilation"`
+	Manifest               Manifest                    `json:"manifest"`
+	Specs                  map[string]Spec             `json:"specs"`
+	IRs                    map[string]IR               `json:"irs"`
+	VerificationPlans      map[string]VerificationPlan `json:"verification_plans"`
+	Diagnostics            []Diagnostic                `json:"diagnostics"`
+	SignedEvidenceRequired bool                        `json:"signed_evidence_required"`
+	SpecErrors             []string                    `json:"spec_errors"`
+	ManifestErrors         []string                    `json:"manifest_errors"`
+	ArtifactResults        []ArtifactResult            `json:"artifact_results"`
+	InvalidEvidence        []InvalidEvidence           `json:"invalid_evidence"`
+	RequiredObligations    map[string][]Obligation     `json:"required_obligations"`
+	CoveredObligations     map[string][]Obligation     `json:"covered_obligations"`
+	MissingObligations     map[string][]Obligation     `json:"missing_obligations"`
+	RequiredTests          map[string][]string         `json:"required_tests"`
+	CoveredTests           map[string][]string         `json:"covered_tests"`
+	MissingTests           map[string][]string         `json:"missing_tests"`
+	RequiredSecurity       map[string][]string         `json:"required_security"`
+	CoveredSecurity        map[string][]string         `json:"covered_security"`
+	MissingSecurity        map[string][]string         `json:"missing_security"`
+	Findings               []Finding                   `json:"findings"`
+	Decision               string                      `json:"decision"`
+	Reasons                []string                    `json:"reasons"`
 }
 
 type CompilationStats struct {
@@ -308,6 +312,7 @@ type ArtifactResult struct {
 	ResolvedPath       string       `json:"resolved_path,omitempty"`
 	Status             string       `json:"status"`
 	HashVerified       bool         `json:"hash_verified"`
+	SignatureVerified  bool         `json:"signature_verified"`
 	CoveredObligations []string     `json:"covered_obligations"`
 	FailedTests        []string     `json:"failed_tests,omitempty"`
 	Issues             []string     `json:"issues,omitempty"`


### PR DESCRIPTION
## Summary

  - Add optional signed-evidence enforcement with `gate --require-signed`
  - Allow evidence artifacts to carry cosign bundle and signer identity metadata
  - Add compact gate result artifact output with `gate --out`
  - Add `COMPARISON.md` for Sigstore/SLSA/in-toto/OPA/Conftest positioning

  ## Verification

  - `go test ./...`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json gate`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json gate --require-signed`