### PR TITLE
feat: add release policy engine

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -77,7 +77,9 @@ decisions.
 OPA is the best near-term candidate for moving policy out of Go. Vouch should
 prepare a compact policy input that includes manifest data, spec risk, coverage,
 findings, invalid evidence, and signer/provenance status. The policy output
-should be the release decision and reasons.
+should be the release decision and reasons. The current implementation uses a
+small Vouch JSON rule engine for that policy boundary; Rego remains the likely
+next step if the policy input shape proves stable.
 
 ### Conftest
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ This creates:
 - `.vouch/config.json`
 - `.vouch/intents/`
 - `.vouch/specs/`
+- `.vouch/policy/release-policy.json`
 - `.vouch/manifests/`
 - `.vouch/artifacts/`
 - `.vouch/build/`
@@ -248,6 +249,19 @@ vouch --repo /path/to/your/repo \
   gate
 ```
 
+Vouch loads release policy from `.vouch/policy/release-policy.json` by default.
+Pass `--policy` to simulate or gate with a different policy file:
+
+```sh
+vouch --repo /path/to/your/repo \
+  --manifest .vouch/manifests/run-123.json \
+  policy simulate --policy .vouch/policy/release-policy.json
+
+vouch --repo /path/to/your/repo \
+  --manifest .vouch/manifests/run-123.json \
+  gate --policy .vouch/policy/release-policy.json
+```
+
 Possible decisions:
 
 - `block`: required evidence is missing or invalid.
@@ -308,11 +322,12 @@ Today, Vouch can check:
 - Artifact exit codes are present and zero.
 - Optional artifact SHA-256 values match file contents.
 - Optional `gate --require-signed` mode verifies evidence artifacts with cosign bundles and expected signer identities.
+- Release policy is loaded from `.vouch/policy/release-policy.json` or an explicit `--policy` file.
 - JUnit evidence has no failure/error/skipped testcases and covers required test obligations.
 - Raw pytest/JUnit testcases can be mapped through `.vouch/test-map.json`.
 - Generic JSON/text artifacts contain exact obligation IDs and optional passing status.
 - Compact gate results can be written to a JSON artifact file.
-- Release decisions follow deterministic risk and evidence rules.
+- Release decisions follow deterministic policy rules.
 
 Today, Vouch cannot check:
 
@@ -320,7 +335,7 @@ Today, Vouch cannot check:
 - Whether a generic JSON/text artifact is truthful beyond its structure, IDs, status, path, exit code, and optional hash.
 - Whether tests were actually run unless the external runner preserves and signs the artifact chain.
 - Whether product intent was inferred correctly from code.
-- Whether release policy is team-defined; policy is still hard-coded Go logic.
+- Whether release policy uses a general-purpose policy language such as Rego; the current policy evaluator is a small Vouch JSON rule engine.
 - Whether signed evidence is bound to a canonical bundle that includes manifest identity, artifact hashes, and covered obligation IDs.
 
 ## Validation Status
@@ -406,6 +421,7 @@ The current implementation is early. Policy is still hard-coded, generic non-JUn
 | `plan build` | IR plus change manifest | `vouch.plan.v0` verification plan |
 | `artifacts build` | Spec JSON | runner/verifier/release artifacts |
 | `junit map` | raw pytest/JUnit and `.vouch/test-map.json` | Vouch-compatible JUnit evidence |
+| `policy simulate` | manifest, evidence, and release policy | policy input and release decision |
 | `evidence`, `verify`, `gate` | manifest and linked artifacts | findings and release decision |
 | Generic onboarding | repo shape and changed files | `.vouch` layout, contract suggestions, manifests, attached artifacts |
 
@@ -601,9 +617,10 @@ vouch --repo DIR --manifest FILE manifest check
 vouch --repo DIR manifest create --task-id ID --summary TEXT --agent NAME --run-id ID --out FILE
 vouch --repo DIR --manifest FILE manifest attach-artifact --id ID --kind KIND --path FILE --exit-code N [--signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE
 vouch --repo DIR --manifest FILE junit map --junit FILE --test-map FILE --out FILE
-vouch --repo DIR --manifest FILE verify
-vouch --repo DIR --manifest FILE gate [--out FILE] [--require-signed]
-vouch --repo DIR --manifest FILE evidence
+vouch --repo DIR --manifest FILE policy simulate [--policy FILE] [--require-signed]
+vouch --repo DIR --manifest FILE verify [--policy FILE]
+vouch --repo DIR --manifest FILE gate [--policy FILE] [--out FILE] [--require-signed]
+vouch --repo DIR --manifest FILE evidence [--policy FILE]
 ```
 
 `--json` emits machine-readable evidence for commands that collect evidence. For `gate`, `--json` emits the compact gate result to stdout and `--out FILE` writes the same gate-result shape as a JSON artifact.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -61,6 +61,8 @@ Implemented today:
 - Artifact attachment with obligation inference.
 - JUnit test-map adapter for raw pytest-style JUnit evidence.
 - Machine-readable gate result artifact output for status checks.
+- Release policy files loaded from `.vouch/policy/release-policy.json`.
+- Policy simulation command with structured policy input/output.
 - Release decisions: `block`, `human_escalation`, `canary`, `auto_merge`.
 - Demo repo with blocked and passing manifests.
 - Unit tests for the current pipeline.
@@ -116,15 +118,18 @@ Separate release policy from hard-coded Go logic.
 
 Planned work:
 
-- Policy-as-code files loaded from `.vouch/policy/`.
-- Rego policy adapter or a deliberately smaller custom evaluator.
-- Compact policy input containing spec, manifest, IR coverage, findings, invalid evidence, and provenance status.
-- Policy output containing decision and reasons.
+- Rego policy adapter or a richer custom evaluator.
 - Risk-specific policy profiles.
 - Team-specific override rules.
 - Exception handling with audit trails.
-- Policy simulation command.
 - Policy regression tests.
+
+Implemented base:
+
+- Policy-as-code JSON files loaded from `.vouch/policy/`.
+- Compact policy input containing spec, manifest, IR coverage, findings, invalid evidence, and provenance status.
+- Policy output containing decision, reasons, and fired rule IDs.
+- Policy simulation command.
 
 ### Phase 3: Workflow Integration
 
@@ -222,7 +227,6 @@ The next useful contributions are:
 - Signed or hashed evidence bundle format.
 - Runner identity and allowed signer fields.
 - Hardened `gate --require-signed` production mode.
-- Policy-as-code design and simulation command.
 - Rego policy adapter decision spike.
 - Reference workflow for `init -> manifest -> pytest -> junit map -> attach -> gate`.
 - Real-world case study showing a plausible bad agent change blocked by an obligation.
@@ -242,7 +246,7 @@ Before calling this production-ready, Vouch needs:
 - Sample runner workflow with artifact upload conventions.
 - Documented evidence kinds and required fields.
 - Schema version compatibility tests.
-- Policy files instead of hard-coded release decisions.
+- Policy profile and exception semantics beyond the base JSON evaluator.
 - Auditable gate result output for GitHub Checks or similar systems.
 - Tamper-evident evidence bundles with agent/run provenance.
 - Fixture repos that cover Python flat layout, Python `src/` layout, Node, Go, Rust, and generic fallback.

--- a/demo_repo/.vouch/policy/release-policy.json
+++ b/demo_repo/.vouch/policy/release-policy.json
@@ -1,0 +1,92 @@
+{
+  "version": "vouch.policy.v0",
+  "rules": [
+    {
+      "id": "block_invalid_spec_or_manifest",
+      "description": "Block when specs or the manifest are invalid.",
+      "when": {
+        "fact": "has_invalid_spec_or_manifest"
+      },
+      "decision": "block",
+      "reasons": [
+        "invalid specs or manifest"
+      ],
+      "stop": true
+    },
+    {
+      "id": "block_verifier_findings",
+      "description": "Block on verifier findings that request a block decision.",
+      "when": {
+        "fact": "has_blocking_findings"
+      },
+      "decision": "block",
+      "reason_source": "blocking_finding_claims",
+      "stop": true
+    },
+    {
+      "id": "high_risk_canary",
+      "description": "Allow high and critical risk changes only as canaries when evidence passes.",
+      "when": {
+        "all": [
+          {
+            "fact": "no_policy_blockers"
+          },
+          {
+            "risk_at_least": "high"
+          },
+          {
+            "fact": "canary_enabled"
+          }
+        ]
+      },
+      "decision": "canary",
+      "reasons": [
+        "high-risk change has passing evidence and canary enabled"
+      ],
+      "stop": true
+    },
+    {
+      "id": "high_risk_without_canary",
+      "description": "Escalate high and critical risk changes when evidence passes but canary is absent.",
+      "when": {
+        "all": [
+          {
+            "fact": "no_policy_blockers"
+          },
+          {
+            "risk_at_least": "high"
+          },
+          {
+            "not": {
+              "fact": "canary_enabled"
+            }
+          }
+        ]
+      },
+      "decision": "human_escalation",
+      "reasons": [
+        "high-risk change passed checks but has no canary"
+      ],
+      "stop": true
+    },
+    {
+      "id": "low_medium_auto_merge",
+      "description": "Allow low and medium risk changes when required evidence passes.",
+      "when": {
+        "all": [
+          {
+            "fact": "no_policy_blockers"
+          },
+          {
+            "risk_below": "high"
+          }
+        ]
+      },
+      "decision": "auto_merge",
+      "reasons": [
+        "low/medium risk change passed required evidence"
+      ],
+      "stop": true
+    }
+  ]
+}

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -81,6 +81,10 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 		if len(rest) >= 2 && rest[1] == "map" {
 			return junitMap(absRepo, rest[2:], common.json, stdout, stderr, manifest)
 		}
+	case "policy":
+		if len(rest) >= 2 && rest[1] == "simulate" {
+			return policySimulate(absRepo, rest[2:], common.json, stdout, stderr, manifest)
+		}
 	case "verify":
 		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "evidence", rest[1:])
 	case "gate":
@@ -277,6 +281,10 @@ func manifestAttachArtifact(repo string, args []string, jsonOut bool, stdout io.
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "manifest attach-artifact: unexpected argument %q\n", flags.Arg(0))
+		return 2
+	}
 	if *manifestPath == "" {
 		*manifestPath = defaultManifest
 	}
@@ -322,6 +330,10 @@ func junitMap(repo string, args []string, jsonOut bool, stdout io.Writer, stderr
 	testMapPath := flags.String("test-map", "", "test map path")
 	outPath := flags.String("out", "", "mapped JUnit XML output path")
 	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "junit map: unexpected argument %q\n", flags.Arg(0))
 		return 2
 	}
 	if *manifestPath == "" {
@@ -552,11 +564,56 @@ func manifestCheck(repo string, manifestPath string, stdout io.Writer, stderr io
 	return 0
 }
 
+func policySimulate(repo string, args []string, jsonOut bool, stdout io.Writer, stderr io.Writer, defaultManifest string) int {
+	flags := flag.NewFlagSet("policy simulate", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	manifestPath := flags.String("manifest", "", "manifest path")
+	policyPath := flags.String("policy", "", "release policy path")
+	requireSigned := flags.Bool("require-signed", false, "require cosign-verified evidence artifacts")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "policy simulate: unexpected argument %q\n", flags.Arg(0))
+		return 2
+	}
+	if *manifestPath == "" {
+		*manifestPath = defaultManifest
+	}
+	evidence, err := CollectEvidenceWithOptions(repo, *manifestPath, CollectEvidenceOptions{
+		RequireSigned: *requireSigned,
+		PolicyPath:    *policyPath,
+	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	simulation := PolicySimulation{
+		Version:    PolicySimulationVersion,
+		PolicyPath: evidence.PolicyPath,
+		Input:      PolicyInputFromEvidence(evidence),
+		Result:     evidence.PolicyResult,
+	}
+	if jsonOut {
+		return renderCommandJSON(simulation, stdout, stderr)
+	}
+	fmt.Fprintf(stdout, "Policy: %s\n", simulation.PolicyPath)
+	fmt.Fprintf(stdout, "Decision: %s\n", simulation.Result.Decision)
+	if len(simulation.Result.RulesFired) > 0 {
+		fmt.Fprintf(stdout, "Rules fired: %s\n", strings.Join(simulation.Result.RulesFired, ", "))
+	}
+	for _, reason := range simulation.Result.Reasons {
+		fmt.Fprintf(stdout, "- %s\n", reason)
+	}
+	return 0
+}
+
 func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.Writer, stderr io.Writer, mode string, args []string) int {
 	flags := flag.NewFlagSet(mode, flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	gateOut := ""
 	requireSigned := false
+	policyPath := flags.String("policy", "", "release policy path")
 	if mode == "gate" {
 		flags.StringVar(&gateOut, "out", "", "path to write compact gate result JSON")
 		flags.BoolVar(&requireSigned, "require-signed", false, "require cosign-verified evidence artifacts")
@@ -568,7 +625,7 @@ func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.
 		fmt.Fprintf(stderr, "%s: unexpected argument %q\n", mode, flags.Arg(0))
 		return 2
 	}
-	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: requireSigned})
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: requireSigned, PolicyPath: *policyPath})
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -626,7 +683,8 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  manifest create --task-id ID --summary TEXT --agent NAME --run-id ID --out FILE")
 	fmt.Fprintln(out, "  manifest attach-artifact --manifest FILE --id ID --kind KIND --path FILE --exit-code N [--signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE")
 	fmt.Fprintln(out, "  junit map --manifest FILE --junit FILE --test-map FILE --out FILE")
-	fmt.Fprintln(out, "  verify")
-	fmt.Fprintln(out, "  gate [--out FILE] [--require-signed]")
-	fmt.Fprintln(out, "  evidence")
+	fmt.Fprintln(out, "  policy simulate [--manifest FILE] [--policy FILE] [--require-signed]")
+	fmt.Fprintln(out, "  verify [--policy FILE]")
+	fmt.Fprintln(out, "  gate [--policy FILE] [--out FILE] [--require-signed]")
+	fmt.Fprintln(out, "  evidence [--policy FILE]")
 }

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -9,6 +9,7 @@ import (
 
 type CollectEvidenceOptions struct {
 	RequireSigned bool
+	PolicyPath    string
 }
 
 func CollectEvidence(repo string, manifestPath string) (Evidence, error) {
@@ -64,7 +65,11 @@ func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEv
 	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{RequireSigned: opts.RequireSigned})
 	buildCoverage(&evidence)
 	runVerifiers(&evidence)
-	decide(&evidence)
+	policy, policyPath, err := LoadReleasePolicy(absRepo, opts.PolicyPath)
+	if err != nil {
+		return Evidence{}, err
+	}
+	ApplyReleasePolicy(&evidence, policy, policyPath)
 	return evidence, nil
 }
 
@@ -317,33 +322,6 @@ func verifyReleaseReadiness(evidence *Evidence) {
 			RequiredFix: "add rollback.strategy or rollback.compensation",
 		})
 	}
-}
-
-func decide(evidence *Evidence) {
-	evidence.Decision = "block"
-	if len(evidence.SpecErrors) > 0 || len(evidence.ManifestErrors) > 0 {
-		evidence.Reasons = append(evidence.Reasons, "invalid specs or manifest")
-	}
-	for _, finding := range evidence.Findings {
-		if finding.Blocks() {
-			evidence.Reasons = append(evidence.Reasons, finding.Claim)
-		}
-	}
-	if len(evidence.Reasons) > 0 {
-		return
-	}
-	if riskRank[evidence.Manifest.Change.Risk] >= riskRank[RiskHigh] {
-		if evidence.Manifest.Runtime.Canary.Enabled {
-			evidence.Decision = "canary"
-			evidence.Reasons = append(evidence.Reasons, "high-risk change has passing evidence and canary enabled")
-		} else {
-			evidence.Decision = "human_escalation"
-			evidence.Reasons = append(evidence.Reasons, "high-risk change passed checks but has no canary")
-		}
-		return
-	}
-	evidence.Decision = "auto_merge"
-	evidence.Reasons = append(evidence.Reasons, "low/medium risk change passed required evidence")
 }
 
 func stringSet(values []string) map[string]bool {

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -1388,6 +1388,192 @@ func TestGateCommandWritesGateResultFile(t *testing.T) {
 	}
 }
 
+func TestCustomPolicyOverridesReleaseDecision(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	tmp := t.TempDir()
+	policyPath := filepath.Join(tmp, "freeze-policy.json")
+	writeJSON(t, policyPath, ReleasePolicy{
+		Version: PolicySchemaVersion,
+		Rules: []PolicyRule{{
+			ID:       "release_freeze",
+			When:     PolicyCondition{Fact: "always"},
+			Decision: "human_escalation",
+			Reasons:  []string{"release freeze requires human approval"},
+			Stop:     true,
+		}},
+	})
+	evidence, err := CollectEvidenceWithOptions(demo, filepath.Join(demo, ".vouch", "manifests", "pass.json"), CollectEvidenceOptions{PolicyPath: policyPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "human_escalation" {
+		t.Fatalf("expected custom policy decision, got %s", evidence.Decision)
+	}
+	if evidence.PolicyResult.FiredPolicyRule != "release_freeze" {
+		t.Fatalf("expected custom policy rule, got %#v", evidence.PolicyResult)
+	}
+	if !contains(evidence.Reasons, "release freeze requires human approval") {
+		t.Fatalf("expected custom policy reason, got %#v", evidence.Reasons)
+	}
+}
+
+func TestCustomPolicyCannotBypassSignedEvidenceFailures(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	tmp := t.TempDir()
+	policyPath := filepath.Join(tmp, "unsafe-policy.json")
+	writeJSON(t, policyPath, ReleasePolicy{
+		Version: PolicySchemaVersion,
+		Rules: []PolicyRule{{
+			ID:       "unsafe_auto_merge",
+			When:     PolicyCondition{Fact: "always"},
+			Decision: "auto_merge",
+			Reasons:  []string{"unsafe policy tried to auto merge"},
+			Stop:     true,
+		}},
+	})
+	evidence, err := CollectEvidenceWithOptions(demo, filepath.Join(demo, ".vouch", "manifests", "pass.json"), CollectEvidenceOptions{
+		RequireSigned: true,
+		PolicyPath:    policyPath,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected policy floor to block signed evidence failures, got %s", evidence.Decision)
+	}
+	if !contains(evidence.PolicyResult.RulesFired, "policy_floor_block") {
+		t.Fatalf("expected policy floor rule to fire: %#v", evidence.PolicyResult)
+	}
+	if !containsSubstring(evidence.Reasons, "evidence artifact behavior-trace is invalid") {
+		t.Fatalf("expected signed evidence failure reason, got %#v", evidence.Reasons)
+	}
+}
+
+func TestPolicyInputIncludesArtifactVerificationState(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	evidence, err := CollectEvidence(demo, filepath.Join(demo, ".vouch", "manifests", "pass.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	input := PolicyInputFromEvidence(evidence)
+	if len(input.ArtifactResults) == 0 {
+		t.Fatal("expected policy input to include artifact results")
+	}
+	if input.HasInvalidEvidence {
+		t.Fatalf("expected passing demo to have no invalid evidence: %#v", input.InvalidEvidence)
+	}
+}
+
+func TestMissingDefaultPolicyFailsClosed(t *testing.T) {
+	repo := t.TempDir()
+	specDir := filepath.Join(repo, ".vouch", "specs")
+	manifestDir := filepath.Join(repo, ".vouch", "manifests")
+	if err := os.MkdirAll(specDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, filepath.Join(specDir, "ui.copy.json"), Spec{
+		Version:    SpecSchemaVersion,
+		ID:         "ui.copy",
+		Owner:      "product",
+		OwnedPaths: []string{"src/ui/**"},
+		Risk:       RiskLow,
+		Behavior:   []string{"button label changes to Save"},
+		Security:   []string{"no secrets introduced"},
+		Tests:      SpecTests{Required: []string{"button label renders"}},
+		Runtime:    SpecRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback:   SpecRollback{Strategy: "revert_commit"},
+	})
+	manifestPath := filepath.Join(manifestDir, "change.json")
+	writeJSON(t, manifestPath, Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "issue-missing-policy", Summary: "copy update"},
+		Change: Change{
+			Risk:            RiskLow,
+			SpecsTouched:    []string{"ui.copy"},
+			BehaviorChanged: true,
+			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Verification: Verification{
+			CoversBehavior: []string{"button label changes to Save"},
+			Commands:       []string{"go test ./..."},
+			CoversTests:    []string{"button label renders"},
+			CoversSecurity: []string{"no secrets introduced"},
+			TestResults:    TestResults{Passed: 1},
+		},
+		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback: ManifestRollback{Strategy: "revert_commit"},
+	})
+	_, err := CollectEvidence(repo, manifestPath)
+	if err == nil || !strings.Contains(err.Error(), "release policy not found") {
+		t.Fatalf("expected missing policy error, got %v", err)
+	}
+}
+
+func TestPolicySimulateCommandRendersResult(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Main([]string{
+		"--repo", demo,
+		"--manifest", filepath.Join(demo, ".vouch", "manifests", "pass.json"),
+		"policy", "simulate",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("policy simulate failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Decision: canary") || !strings.Contains(stdout.String(), "Rules fired: high_risk_canary") {
+		t.Fatalf("unexpected policy simulate output: %s", stdout.String())
+	}
+}
+
+func TestPolicySimulateRejectsUnexpectedArgs(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Main([]string{
+		"--repo", demo,
+		"--manifest", filepath.Join(demo, ".vouch", "manifests", "pass.json"),
+		"policy", "simulate", "unexpected",
+	}, &stdout, &stderr)
+	if code != 2 {
+		t.Fatalf("expected usage error, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "unexpected argument") {
+		t.Fatalf("expected unexpected arg error, got %s", stderr.String())
+	}
+}
+
+func TestPolicySimulateJSONIncludesInputAndResult(t *testing.T) {
+	root := repoRoot(t)
+	demo := filepath.Join(root, "demo_repo")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := Main([]string{
+		"--json",
+		"--repo", demo,
+		"--manifest", filepath.Join(demo, ".vouch", "manifests", "pass.json"),
+		"policy", "simulate",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("policy simulate json failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	var simulation PolicySimulation
+	if err := json.Unmarshal(stdout.Bytes(), &simulation); err != nil {
+		t.Fatal(err)
+	}
+	if simulation.Result.Decision != "canary" || simulation.Input.Risk != RiskHigh {
+		t.Fatalf("unexpected simulation: %#v", simulation)
+	}
+}
+
 func TestRequireSignedBlocksUnsignedArtifacts(t *testing.T) {
 	root := repoRoot(t)
 	demo := filepath.Join(root, "demo_repo")
@@ -1661,11 +1847,18 @@ func writeScenario(t *testing.T, spec Spec, manifest Manifest) (string, string) 
 	t.Helper()
 	repo := t.TempDir()
 	specDir := filepath.Join(repo, ".vouch", "specs")
+	policyDir := filepath.Join(repo, ".vouch", "policy")
 	manifestDir := filepath.Join(repo, ".vouch", "manifests")
 	if err := os.MkdirAll(specDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
+	if err := os.MkdirAll(policyDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.MkdirAll(manifestDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteDefaultReleasePolicy(filepath.Join(policyDir, "release-policy.json")); err != nil {
 		t.Fatal(err)
 	}
 	writeJSON(t, filepath.Join(specDir, spec.ID+".json"), spec)

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -72,6 +72,7 @@ func InitRepo(repo string, profileOverride string, force bool) (InitResult, erro
 		".vouch",
 		".vouch/intents",
 		".vouch/specs",
+		".vouch/policy",
 		config.ManifestDir,
 		config.ArtifactDir,
 		config.BuildDir,
@@ -93,6 +94,14 @@ func InitRepo(repo string, profileOverride string, force bool) (InitResult, erro
 			return InitResult{}, err
 		}
 		created = true
+	} else if err != nil {
+		return InitResult{}, err
+	}
+	policyPath := DefaultPolicyPath(absRepo)
+	if _, err := os.Stat(policyPath); errors.Is(err, os.ErrNotExist) || force {
+		if err := WriteDefaultReleasePolicy(policyPath); err != nil {
+			return InitResult{}, err
+		}
 	} else if err != nil {
 		return InitResult{}, err
 	}

--- a/internal/vouch/onboarding_test.go
+++ b/internal/vouch/onboarding_test.go
@@ -27,10 +27,14 @@ test = { cmd = "pytest" }
 	if !contains(result.Profiles, "python") {
 		t.Fatalf("expected python profile, got %#v", result.Profiles)
 	}
-	for _, rel := range []string{".vouch/intents", ".vouch/specs", ".vouch/manifests", ".vouch/artifacts", ".vouch/build"} {
+	for _, rel := range []string{".vouch/intents", ".vouch/specs", ".vouch/policy", ".vouch/manifests", ".vouch/artifacts", ".vouch/build"} {
 		if !dirExists(filepath.Join(repo, rel)) {
 			t.Fatalf("expected directory %s", rel)
 		}
+	}
+	policy := mustLoadPolicy(t, filepath.Join(repo, ".vouch", "policy", "release-policy.json"))
+	if policy.Version != PolicySchemaVersion || len(policy.Rules) == 0 {
+		t.Fatalf("expected default release policy, got %#v", policy)
 	}
 	config := mustLoadConfig(t, filepath.Join(repo, ".vouch", "config.json"))
 	if config.Version != ConfigSchemaVersion {
@@ -353,6 +357,15 @@ func mustLoadConfig(t *testing.T, path string) Config {
 		t.Fatal(err)
 	}
 	return config
+}
+
+func mustLoadPolicy(t *testing.T, path string) ReleasePolicy {
+	t.Helper()
+	policy, err := LoadJSON[ReleasePolicy](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return policy
 }
 
 func mustLoadSpecs(t *testing.T, repo string) map[string]Spec {

--- a/internal/vouch/policy.go
+++ b/internal/vouch/policy.go
@@ -1,0 +1,375 @@
+package vouch
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const builtinPolicyPath = "builtin:default-release-policy"
+
+func DefaultPolicyPath(repo string) string {
+	return filepath.Join(repo, ".vouch", "policy", "release-policy.json")
+}
+
+func DefaultReleasePolicy() ReleasePolicy {
+	return ReleasePolicy{
+		Version: PolicySchemaVersion,
+		Rules: []PolicyRule{
+			{
+				ID:          "block_invalid_spec_or_manifest",
+				Description: "Block when specs or the manifest are invalid.",
+				When: PolicyCondition{
+					Fact: "has_invalid_spec_or_manifest",
+				},
+				Decision: "block",
+				Reasons:  []string{"invalid specs or manifest"},
+				Stop:     true,
+			},
+			{
+				ID:          "block_verifier_findings",
+				Description: "Block on verifier findings that request a block decision.",
+				When: PolicyCondition{
+					Fact: "has_blocking_findings",
+				},
+				Decision:     "block",
+				ReasonSource: "blocking_finding_claims",
+				Stop:         true,
+			},
+			{
+				ID:          "high_risk_canary",
+				Description: "Allow high and critical risk changes only as canaries when evidence passes.",
+				When: PolicyCondition{
+					All: []PolicyCondition{
+						{Fact: "no_policy_blockers"},
+						{RiskAtLeast: RiskHigh},
+						{Fact: "canary_enabled"},
+					},
+				},
+				Decision: "canary",
+				Reasons:  []string{"high-risk change has passing evidence and canary enabled"},
+				Stop:     true,
+			},
+			{
+				ID:          "high_risk_without_canary",
+				Description: "Escalate high and critical risk changes when evidence passes but canary is absent.",
+				When: PolicyCondition{
+					All: []PolicyCondition{
+						{Fact: "no_policy_blockers"},
+						{RiskAtLeast: RiskHigh},
+						{Not: &PolicyCondition{Fact: "canary_enabled"}},
+					},
+				},
+				Decision: "human_escalation",
+				Reasons:  []string{"high-risk change passed checks but has no canary"},
+				Stop:     true,
+			},
+			{
+				ID:          "low_medium_auto_merge",
+				Description: "Allow low and medium risk changes when required evidence passes.",
+				When: PolicyCondition{
+					All: []PolicyCondition{
+						{Fact: "no_policy_blockers"},
+						{RiskBelow: RiskHigh},
+					},
+				},
+				Decision: "auto_merge",
+				Reasons:  []string{"low/medium risk change passed required evidence"},
+				Stop:     true,
+			},
+		},
+	}
+}
+
+func LoadReleasePolicy(repo string, policyPath string) (ReleasePolicy, string, error) {
+	path := policyPath
+	if path == "" {
+		path = DefaultPolicyPath(repo)
+	}
+	resolved := path
+	if path != "" && path != builtinPolicyPath && !filepath.IsAbs(path) {
+		resolved = filepath.Join(repo, path)
+	}
+	if path == builtinPolicyPath {
+		policy := DefaultReleasePolicy()
+		return policy, builtinPolicyPath, ValidateReleasePolicy(policy)
+	}
+	policy, err := LoadJSON[ReleasePolicy](resolved)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) && policyPath == "" {
+			return ReleasePolicy{}, "", fmt.Errorf("release policy not found at %s; run vouch init or pass --policy", resolved)
+		}
+		return ReleasePolicy{}, "", err
+	}
+	if err := ValidateReleasePolicy(policy); err != nil {
+		return ReleasePolicy{}, "", err
+	}
+	return policy, resolved, nil
+}
+
+func ValidateReleasePolicy(policy ReleasePolicy) error {
+	if policy.Version != PolicySchemaVersion {
+		return fmt.Errorf("policy version must be %s", PolicySchemaVersion)
+	}
+	if len(policy.Rules) == 0 {
+		return errors.New("policy requires at least one rule")
+	}
+	seen := make(map[string]bool)
+	for _, rule := range policy.Rules {
+		if strings.TrimSpace(rule.ID) == "" {
+			return errors.New("policy rule id is required")
+		}
+		if seen[rule.ID] {
+			return fmt.Errorf("duplicate policy rule id %q", rule.ID)
+		}
+		seen[rule.ID] = true
+		if !validPolicyDecision(rule.Decision) {
+			return fmt.Errorf("policy rule %s has invalid decision %q", rule.ID, rule.Decision)
+		}
+		if rule.ReasonSource != "" && !validReasonSource(rule.ReasonSource) {
+			return fmt.Errorf("policy rule %s has invalid reason_source %q", rule.ID, rule.ReasonSource)
+		}
+		if err := validatePolicyCondition(rule.When); err != nil {
+			return fmt.Errorf("policy rule %s: %w", rule.ID, err)
+		}
+	}
+	return nil
+}
+
+func ApplyReleasePolicy(evidence *Evidence, policy ReleasePolicy, policyPath string) {
+	input := PolicyInputFromEvidence(*evidence)
+	result := EvaluateReleasePolicy(policy, policyPath, input)
+	enforcePolicyFloor(input, &result)
+	evidence.Decision = result.Decision
+	evidence.Reasons = cloneStrings(result.Reasons)
+	evidence.PolicyPath = result.PolicyPath
+	evidence.PolicyResult = result
+}
+
+func EvaluateReleasePolicy(policy ReleasePolicy, policyPath string, input PolicyInput) PolicyResult {
+	result := PolicyResult{
+		Version:    PolicyResultVersion,
+		PolicyPath: policyPath,
+		Reasons:    []string{},
+		RulesFired: []string{},
+	}
+	for _, rule := range policy.Rules {
+		if !policyConditionMatches(rule.When, input) {
+			continue
+		}
+		if result.Decision == "block" && rule.Decision != "block" {
+			continue
+		}
+		result.Decision = rule.Decision
+		result.RulesFired = append(result.RulesFired, rule.ID)
+		result.Reasons = append(result.Reasons, policyRuleReasons(rule, input)...)
+		if rule.Stop {
+			break
+		}
+	}
+	if result.Decision == "" {
+		result.Decision = "block"
+		result.RulesFired = append(result.RulesFired, "policy_no_match")
+		result.Reasons = append(result.Reasons, "release policy produced no decision")
+	}
+	if len(result.Reasons) == 0 {
+		result.Reasons = append(result.Reasons, fmt.Sprintf("policy rule %s selected %s", result.RulesFired[len(result.RulesFired)-1], result.Decision))
+	}
+	result.FiredPolicyRule = result.RulesFired[0]
+	return result
+}
+
+func enforcePolicyFloor(input PolicyInput, result *PolicyResult) {
+	if !input.HasInvalidSpecOrManifest && !input.HasBlockingFindings {
+		return
+	}
+	if result.Decision == "block" {
+		return
+	}
+	result.Decision = "block"
+	result.RulesFired = append(result.RulesFired, "policy_floor_block")
+	result.FiredPolicyRule = "policy_floor_block"
+	result.Reasons = append(result.Reasons, policyFloorReasons(input)...)
+	result.Reasons = uniqueStrings(result.Reasons)
+}
+
+func policyFloorReasons(input PolicyInput) []string {
+	var reasons []string
+	if input.HasInvalidSpecOrManifest {
+		reasons = append(reasons, "invalid specs or manifest")
+	}
+	reasons = append(reasons, input.BlockingFindingClaims...)
+	if len(reasons) == 0 {
+		reasons = append(reasons, "policy floor blocked release")
+	}
+	return reasons
+}
+
+func PolicyInputFromEvidence(evidence Evidence) PolicyInput {
+	blocking := []Finding{}
+	claims := []string{}
+	for _, finding := range evidence.Findings {
+		if finding.Blocks() {
+			blocking = append(blocking, finding)
+			claims = append(claims, finding.Claim)
+		}
+	}
+	return PolicyInput{
+		Version:                  PolicyInputVersion,
+		Manifest:                 evidence.Manifest,
+		Compilation:              evidence.Compilation,
+		Risk:                     evidence.Manifest.Change.Risk,
+		RiskRank:                 riskRank[evidence.Manifest.Change.Risk],
+		CanaryEnabled:            evidence.Manifest.Runtime.Canary.Enabled,
+		SignedEvidenceRequired:   evidence.SignedEvidenceRequired,
+		SpecErrors:               cloneStrings(evidence.SpecErrors),
+		ManifestErrors:           cloneStrings(evidence.ManifestErrors),
+		ArtifactResults:          cloneArtifactResults(evidence.ArtifactResults),
+		InvalidEvidence:          cloneInvalidEvidence(evidence.InvalidEvidence),
+		MissingObligations:       obligationTextMap(evidence.MissingObligations),
+		CoveredObligations:       obligationTextMap(evidence.CoveredObligations),
+		Findings:                 cloneFindings(evidence.Findings),
+		BlockingFindings:         blocking,
+		BlockingFindingClaims:    claims,
+		HasInvalidSpecOrManifest: len(evidence.SpecErrors) > 0 || len(evidence.ManifestErrors) > 0,
+		HasInvalidEvidence:       len(evidence.InvalidEvidence) > 0,
+		HasMissingObligations:    len(evidence.MissingObligations) > 0,
+		HasBlockingFindings:      len(blocking) > 0,
+	}
+}
+
+func WriteDefaultReleasePolicy(path string) error {
+	return writeJSONFile(path, DefaultReleasePolicy())
+}
+
+func cloneFindings(values []Finding) []Finding {
+	out := make([]Finding, 0, len(values))
+	return append(out, values...)
+}
+
+func policyRuleReasons(rule PolicyRule, input PolicyInput) []string {
+	reasons := cloneStrings(rule.Reasons)
+	switch rule.ReasonSource {
+	case "":
+	case "blocking_finding_claims":
+		reasons = append(reasons, input.BlockingFindingClaims...)
+	case "spec_errors":
+		reasons = append(reasons, input.SpecErrors...)
+	case "manifest_errors":
+		reasons = append(reasons, input.ManifestErrors...)
+	default:
+		reasons = append(reasons, "unsupported reason source: "+rule.ReasonSource)
+	}
+	return uniqueStrings(reasons)
+}
+
+func policyConditionMatches(condition PolicyCondition, input PolicyInput) bool {
+	if condition.Fact != "" && !policyFact(condition.Fact, input) {
+		return false
+	}
+	if condition.RiskAtLeast != "" && riskRank[input.Risk] < riskRank[condition.RiskAtLeast] {
+		return false
+	}
+	if condition.RiskBelow != "" && riskRank[input.Risk] >= riskRank[condition.RiskBelow] {
+		return false
+	}
+	for _, child := range condition.All {
+		if !policyConditionMatches(child, input) {
+			return false
+		}
+	}
+	if len(condition.Any) > 0 {
+		matched := false
+		for _, child := range condition.Any {
+			if policyConditionMatches(child, input) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			return false
+		}
+	}
+	if condition.Not != nil && policyConditionMatches(*condition.Not, input) {
+		return false
+	}
+	return true
+}
+
+func policyFact(name string, input PolicyInput) bool {
+	switch name {
+	case "always":
+		return true
+	case "has_invalid_spec_or_manifest":
+		return input.HasInvalidSpecOrManifest
+	case "has_blocking_findings":
+		return input.HasBlockingFindings
+	case "no_policy_blockers":
+		return !input.HasInvalidSpecOrManifest && !input.HasBlockingFindings
+	case "canary_enabled":
+		return input.CanaryEnabled
+	case "signed_evidence_required":
+		return input.SignedEvidenceRequired
+	case "has_invalid_evidence":
+		return len(input.InvalidEvidence) > 0
+	case "has_missing_obligations":
+		return len(input.MissingObligations) > 0
+	default:
+		return false
+	}
+}
+
+func validatePolicyCondition(condition PolicyCondition) error {
+	if condition.Fact != "" && !validPolicyFact(condition.Fact) {
+		return fmt.Errorf("invalid fact %q", condition.Fact)
+	}
+	if condition.RiskAtLeast != "" && !validRisk(condition.RiskAtLeast) {
+		return fmt.Errorf("invalid risk_at_least %q", condition.RiskAtLeast)
+	}
+	if condition.RiskBelow != "" && !validRisk(condition.RiskBelow) {
+		return fmt.Errorf("invalid risk_below %q", condition.RiskBelow)
+	}
+	for _, child := range condition.All {
+		if err := validatePolicyCondition(child); err != nil {
+			return err
+		}
+	}
+	for _, child := range condition.Any {
+		if err := validatePolicyCondition(child); err != nil {
+			return err
+		}
+	}
+	if condition.Not != nil {
+		return validatePolicyCondition(*condition.Not)
+	}
+	return nil
+}
+
+func validPolicyDecision(decision string) bool {
+	switch decision {
+	case "block", "human_escalation", "canary", "auto_merge":
+		return true
+	default:
+		return false
+	}
+}
+
+func validReasonSource(source string) bool {
+	switch source {
+	case "blocking_finding_claims", "spec_errors", "manifest_errors":
+		return true
+	default:
+		return false
+	}
+}
+
+func validPolicyFact(fact string) bool {
+	switch fact {
+	case "always", "has_invalid_spec_or_manifest", "has_blocking_findings", "no_policy_blockers", "canary_enabled", "signed_evidence_required", "has_invalid_evidence", "has_missing_obligations":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/vouch/render.go
+++ b/internal/vouch/render.go
@@ -37,6 +37,7 @@ func GateResultFromEvidence(evidence Evidence) GateResult {
 		Version:            "vouch.gate_result.v0",
 		Decision:           evidence.Decision,
 		Reasons:            cloneStrings(evidence.Reasons),
+		PolicyPath:         evidence.PolicyPath,
 		Compilation:        evidence.Compilation,
 		SpecErrors:         cloneStrings(evidence.SpecErrors),
 		ManifestErrors:     cloneStrings(evidence.ManifestErrors),
@@ -44,8 +45,8 @@ func GateResultFromEvidence(evidence Evidence) GateResult {
 		InvalidEvidence:    cloneInvalidEvidence(evidence.InvalidEvidence),
 		MissingObligations: obligationTextMap(evidence.MissingObligations),
 		CoveredObligations: obligationTextMap(evidence.CoveredObligations),
-		PolicyRulesFired:   firedPolicyRules(evidence),
-		FiredPolicyRule:    firedPolicyRule(evidence),
+		PolicyRulesFired:   cloneStrings(evidence.PolicyResult.RulesFired),
+		FiredPolicyRule:    evidence.PolicyResult.FiredPolicyRule,
 	}
 }
 
@@ -206,38 +207,4 @@ func obligationTextMap(items map[string][]Obligation) map[string][]string {
 		}
 	}
 	return out
-}
-
-func firedPolicyRule(evidence Evidence) string {
-	rules := firedPolicyRules(evidence)
-	if len(rules) == 0 {
-		return "unknown"
-	}
-	return rules[0]
-}
-
-func firedPolicyRules(evidence Evidence) []string {
-	if evidence.Decision == "block" {
-		var rules []string
-		if len(evidence.SpecErrors) > 0 || len(evidence.ManifestErrors) > 0 {
-			rules = append(rules, "block_invalid_spec_or_manifest")
-		}
-		if len(evidence.InvalidEvidence) > 0 {
-			rules = append(rules, "block_invalid_evidence")
-		}
-		if len(evidence.MissingObligations) > 0 || len(rules) == 0 {
-			rules = append(rules, "block_missing_required_evidence")
-		}
-		return rules
-	}
-	if evidence.Decision == "human_escalation" {
-		return []string{"high_risk_without_canary"}
-	}
-	if evidence.Decision == "canary" {
-		return []string{"high_risk_canary"}
-	}
-	if evidence.Decision == "auto_merge" {
-		return []string{"low_medium_auto_merge"}
-	}
-	return []string{"unknown"}
 }

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -3,14 +3,18 @@ package vouch
 type Risk string
 
 const (
-	SpecSchemaVersion     = "vouch.spec.v0"
-	ManifestSchemaVersion = "vouch.manifest.v0"
-	EvidenceSchemaVersion = "vouch.evidence.v0"
-	ASTSchemaVersion      = "vouch.ast.v0"
-	IRSchemaVersion       = "vouch.ir.v0"
-	PlanSchemaVersion     = "vouch.plan.v0"
-	ConfigSchemaVersion   = "vouch.config.v0"
-	TestMapSchemaVersion  = "vouch.test_map.v0"
+	SpecSchemaVersion       = "vouch.spec.v0"
+	ManifestSchemaVersion   = "vouch.manifest.v0"
+	EvidenceSchemaVersion   = "vouch.evidence.v0"
+	ASTSchemaVersion        = "vouch.ast.v0"
+	IRSchemaVersion         = "vouch.ir.v0"
+	PlanSchemaVersion       = "vouch.plan.v0"
+	ConfigSchemaVersion     = "vouch.config.v0"
+	TestMapSchemaVersion    = "vouch.test_map.v0"
+	PolicySchemaVersion     = "vouch.policy.v0"
+	PolicyInputVersion      = "vouch.policy_input.v0"
+	PolicyResultVersion     = "vouch.policy_result.v0"
+	PolicySimulationVersion = "vouch.policy_simulation.v0"
 )
 
 const (
@@ -269,6 +273,69 @@ func (f Finding) Blocks() bool {
 	return f.Decision == "block"
 }
 
+type ReleasePolicy struct {
+	Version string       `json:"version"`
+	Rules   []PolicyRule `json:"rules"`
+}
+
+type PolicyRule struct {
+	ID           string          `json:"id"`
+	Description  string          `json:"description,omitempty"`
+	When         PolicyCondition `json:"when"`
+	Decision     string          `json:"decision"`
+	Reasons      []string        `json:"reasons,omitempty"`
+	ReasonSource string          `json:"reason_source,omitempty"`
+	Stop         bool            `json:"stop,omitempty"`
+}
+
+type PolicyCondition struct {
+	Fact        string            `json:"fact,omitempty"`
+	RiskAtLeast Risk              `json:"risk_at_least,omitempty"`
+	RiskBelow   Risk              `json:"risk_below,omitempty"`
+	All         []PolicyCondition `json:"all,omitempty"`
+	Any         []PolicyCondition `json:"any,omitempty"`
+	Not         *PolicyCondition  `json:"not,omitempty"`
+}
+
+type PolicyInput struct {
+	Version                  string              `json:"version"`
+	Manifest                 Manifest            `json:"manifest"`
+	Compilation              CompilationStats    `json:"compilation"`
+	Risk                     Risk                `json:"risk"`
+	RiskRank                 int                 `json:"risk_rank"`
+	CanaryEnabled            bool                `json:"canary_enabled"`
+	SignedEvidenceRequired   bool                `json:"signed_evidence_required"`
+	SpecErrors               []string            `json:"spec_errors"`
+	ManifestErrors           []string            `json:"manifest_errors"`
+	ArtifactResults          []ArtifactResult    `json:"artifact_results"`
+	InvalidEvidence          []InvalidEvidence   `json:"invalid_evidence"`
+	MissingObligations       map[string][]string `json:"missing_obligations"`
+	CoveredObligations       map[string][]string `json:"covered_obligations"`
+	Findings                 []Finding           `json:"findings"`
+	BlockingFindings         []Finding           `json:"blocking_findings"`
+	BlockingFindingClaims    []string            `json:"blocking_finding_claims"`
+	HasInvalidSpecOrManifest bool                `json:"has_invalid_spec_or_manifest"`
+	HasInvalidEvidence       bool                `json:"has_invalid_evidence"`
+	HasMissingObligations    bool                `json:"has_missing_obligations"`
+	HasBlockingFindings      bool                `json:"has_blocking_findings"`
+}
+
+type PolicyResult struct {
+	Version         string   `json:"version"`
+	PolicyPath      string   `json:"policy_path"`
+	Decision        string   `json:"decision"`
+	Reasons         []string `json:"reasons"`
+	RulesFired      []string `json:"rules_fired"`
+	FiredPolicyRule string   `json:"fired_policy_rule"`
+}
+
+type PolicySimulation struct {
+	Version    string       `json:"version"`
+	PolicyPath string       `json:"policy_path"`
+	Input      PolicyInput  `json:"input"`
+	Result     PolicyResult `json:"result"`
+}
+
 type Evidence struct {
 	Version                string                      `json:"version"`
 	Repo                   string                      `json:"repo"`
@@ -280,6 +347,8 @@ type Evidence struct {
 	VerificationPlans      map[string]VerificationPlan `json:"verification_plans"`
 	Diagnostics            []Diagnostic                `json:"diagnostics"`
 	SignedEvidenceRequired bool                        `json:"signed_evidence_required"`
+	PolicyPath             string                      `json:"policy_path"`
+	PolicyResult           PolicyResult                `json:"policy_result"`
 	SpecErrors             []string                    `json:"spec_errors"`
 	ManifestErrors         []string                    `json:"manifest_errors"`
 	ArtifactResults        []ArtifactResult            `json:"artifact_results"`
@@ -328,6 +397,7 @@ type GateResult struct {
 	Version            string              `json:"version"`
 	Decision           string              `json:"decision"`
 	Reasons            []string            `json:"reasons"`
+	PolicyPath         string              `json:"policy_path"`
 	Compilation        CompilationStats    `json:"compilation"`
 	SpecErrors         []string            `json:"spec_errors"`
 	ManifestErrors     []string            `json:"manifest_errors"`


### PR DESCRIPTION
## Summary

  - Add `.vouch/policy/release-policy.json` as the default release policy file
  - Move release decisions out of hard-coded Go gate logic into a Vouch JSON policy evaluator
  - Add `vouch policy simulate` with text and JSON output
  - Add `--policy FILE` support for `gate`, `verify`, and `evidence`
  - Fail closed when the default policy file is missing
  - Add a non-bypassable policy floor so custom policy cannot override invalid specs, invalid evidence, missing obligations, or signed-evidence failures
  - Include policy rule IDs in gate results

## Verification

  - `go test ./...`
  - `go test ./internal/vouch -run 'Test(CustomPolicyOverridesReleaseDecision|
  CustomPolicyCannotBypassSignedEvidenceFailures|PolicyInputIncludesArtifactVerificationState|
  MissingDefaultPolicyFailsClosed|PolicySimulateCommandRendersResult|
  PolicySimulateRejectsUnexpectedArgs|PolicySimulateJSONIncludesInputAndResult|
  InitRepoDetectsPythonProfileAndWritesLayout)' -v`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json policy
  simulate`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json gate`
