### PR TITLE
feat: add evidence verifier outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ If an artifact does not include the exact obligation ID, Vouch will not count it
 ### 6. Attach Evidence
 
 Attach behavior, security, test, runtime, and rollback evidence as needed. The artifact kind must match the obligation kind.
+`verifier_output` artifacts are the exception: they may reference any compiled obligation, import structured verifier findings, and do not satisfy required evidence coverage by themselves.
 
 | Obligation ID Contains | Attach With `--kind` |
 | --- | --- |
@@ -323,6 +324,9 @@ Today, Vouch can check:
 - Optional artifact SHA-256 values match file contents.
 - Optional `gate --require-signed` mode verifies evidence artifacts with cosign bundles and expected signer identities.
 - Release policy is loaded from `.vouch/policy/release-policy.json` or an explicit `--policy` file.
+- Generated verifier packets pin prompt and output schema versions.
+- Structured `verifier_output` artifacts parse as `vouch.verifier_output.v0` and import pass/block findings into release policy.
+- `verifier_output` artifacts do not count as required behavior, security, test, runtime, or rollback evidence.
 - JUnit evidence has no failure/error/skipped testcases and covers required test obligations.
 - Raw pytest/JUnit testcases can be mapped through `.vouch/test-map.json`.
 - Generic JSON/text artifacts contain exact obligation IDs and optional passing status.
@@ -332,6 +336,7 @@ Today, Vouch can check:
 Today, Vouch cannot check:
 
 - Whether arbitrary code semantically implements the declared behavior.
+- Whether an AI verifier's judgment is correct beyond its structured output, obligation references, model/prompt pins, and artifact provenance.
 - Whether a generic JSON/text artifact is truthful beyond its structure, IDs, status, path, exit code, and optional hash.
 - Whether tests were actually run unless the external runner preserves and signs the artifact chain.
 - Whether product intent was inferred correctly from code.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,6 +63,7 @@ Implemented today:
 - Machine-readable gate result artifact output for status checks.
 - Release policy files loaded from `.vouch/policy/release-policy.json`.
 - Policy simulation command with structured policy input/output.
+- Structured verifier output artifacts imported into findings and policy input.
 - Release decisions: `block`, `human_escalation`, `canary`, `auto_merge`.
 - Demo repo with blocked and passing manifests.
 - Unit tests for the current pipeline.
@@ -151,12 +152,17 @@ This phase should wait until evidence provenance and policy semantics are in
 place. A verifier finding is useful only when the verifier output is tied to a
 runner identity and the release policy says how to use it.
 
-Planned work:
+Implemented base:
 
-- Verifier input packet schema.
+- Verifier input packets include prompt-version and output-schema pins.
+- Structured `vouch.verifier_output.v0` artifacts can be linked from manifests.
+- Verifier output findings are imported into the normal policy path.
+- Malformed verifier outputs invalidate evidence.
+- Verifier output artifacts are excluded from required evidence coverage.
+
+Remaining work:
+
 - Signed verifier output schema.
-- Structured verifier output schema.
-- Prompt and model version pinning.
 - Verifier confidence and disagreement handling.
 - Verifier isolation rules.
 - Audit log for every verifier decision.

--- a/internal/vouch/artifacts.go
+++ b/internal/vouch/artifacts.go
@@ -51,10 +51,13 @@ func verifierPackets(ir IR) []VerifierPacket {
 	var packets []VerifierPacket
 	for _, role := range verifierRoles(ir) {
 		packets = append(packets, VerifierPacket{
-			Verifier:       role,
-			Focus:          verifierFocus(role),
-			Obligations:    obligationsForVerifier(ir, role),
-			RequiredOutput: "Return structured findings with verifier, decision, severity, claim, evidence, and required_fix.",
+			Verifier:      role,
+			Focus:         verifierFocus(role),
+			PromptVersion: VerifierPromptVersion,
+			OutputSchema:  VerifierOutputVersion,
+			Obligations:   obligationsForVerifier(ir, role),
+			RequiredOutput: "Return JSON matching " + VerifierOutputVersion + " with version, verifier, prompt_version, model, obligations, confidence, and findings. " +
+				"Each finding must include verifier, decision, severity, claim, evidence, required_fix when blocking, and obligation IDs.",
 		})
 	}
 	return packets

--- a/internal/vouch/compiler.go
+++ b/internal/vouch/compiler.go
@@ -164,7 +164,7 @@ func validateArtifactReferencesWithSymbols(manifest Manifest, symbols SymbolTabl
 				errors = append(errors, fmt.Sprintf("manifest: verification.artifacts[%s] references unknown obligation %q", artifact.ID, obligationID))
 				continue
 			}
-			if artifact.Kind != obligation.RequiredEvidence {
+			if artifact.Kind != EvidenceVerifierOutput && artifact.Kind != obligation.RequiredEvidence {
 				errors = append(errors, fmt.Sprintf("manifest: verification.artifacts[%s] kind %q does not satisfy obligation %s required evidence %q", artifact.ID, artifact.Kind, obligationID, obligation.RequiredEvidence))
 			}
 		}

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -49,6 +49,7 @@ func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEv
 		ManifestErrors:         pipeline.ManifestErrors,
 		ArtifactResults:        []ArtifactResult{},
 		InvalidEvidence:        []InvalidEvidence{},
+		VerifierOutputs:        []VerifierOutput{},
 		RequiredObligations:    make(map[string][]Obligation),
 		CoveredObligations:     make(map[string][]Obligation),
 		MissingObligations:     make(map[string][]Obligation),
@@ -65,6 +66,7 @@ func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEv
 	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{RequireSigned: opts.RequireSigned})
 	buildCoverage(&evidence)
 	runVerifiers(&evidence)
+	importVerifierFindings(&evidence)
 	policy, policyPath, err := LoadReleasePolicy(absRepo, opts.PolicyPath)
 	if err != nil {
 		return Evidence{}, err
@@ -141,6 +143,9 @@ func artifactCoverageByKind(artifacts []ArtifactResult) map[EvidenceKind]map[str
 		if artifact.Status != "valid" {
 			continue
 		}
+		if artifact.Kind == EvidenceVerifierOutput {
+			continue
+		}
 		if coverage[artifact.Kind] == nil {
 			coverage[artifact.Kind] = make(map[string]bool)
 		}
@@ -149,6 +154,16 @@ func artifactCoverageByKind(artifacts []ArtifactResult) map[EvidenceKind]map[str
 		}
 	}
 	return coverage
+}
+
+func importVerifierFindings(evidence *Evidence) {
+	for _, result := range evidence.ArtifactResults {
+		if result.VerifierOutput == nil {
+			continue
+		}
+		evidence.VerifierOutputs = append(evidence.VerifierOutputs, *result.VerifierOutput)
+		evidence.Findings = append(evidence.Findings, result.VerifierFindings...)
+	}
 }
 
 func runVerifiers(evidence *Evidence) {

--- a/internal/vouch/evidence_artifacts.go
+++ b/internal/vouch/evidence_artifacts.go
@@ -1,11 +1,13 @@
 package vouch
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -53,7 +55,7 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 				result.addIssue("unknown_obligation", fmt.Sprintf("unknown obligation %q", obligationID))
 				continue
 			}
-			if obligation.RequiredEvidence != artifact.Kind {
+			if artifact.Kind != EvidenceVerifierOutput && obligation.RequiredEvidence != artifact.Kind {
 				result.addIssue("kind_mismatch", fmt.Sprintf("kind %q does not satisfy obligation %s required evidence %q", artifact.Kind, obligationID, obligation.RequiredEvidence))
 			}
 		}
@@ -88,7 +90,19 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 			verifyCosignBundle(repo, artifact, result.ResolvedPath, &result)
 		}
 
-		if artifact.Kind == EvidenceTestCoverage {
+		if artifact.Kind == EvidenceVerifierOutput {
+			if len(data) > 0 {
+				output, issues := importVerifierOutput(data, artifact.Obligations, index)
+				if len(issues) == 0 {
+					result.VerifierOutput = &output
+					result.VerifierFindings = cloneFindings(output.Findings)
+					result.CoveredObligations = cloneStrings(output.Obligations)
+				}
+				for _, issue := range issues {
+					result.addIssue("verifier_output_import", issue)
+				}
+			}
+		} else if artifact.Kind == EvidenceTestCoverage {
 			if len(data) > 0 {
 				covered, failed, issues := importJUnitEvidence(data, artifact.Obligations)
 				result.CoveredObligations = covered
@@ -301,6 +315,148 @@ func importGenericEvidence(data []byte, obligationIDs []string) ([]string, []str
 		}
 	}
 	return covered, issues
+}
+
+func importVerifierOutput(data []byte, artifactObligations []string, index ObligationIndex) (VerifierOutput, []string) {
+	var output VerifierOutput
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&output); err != nil {
+		return output, []string{fmt.Sprintf("cannot parse verifier output JSON: %v", err)}
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return output, []string{"trailing JSON content after verifier output"}
+	}
+
+	var issues []string
+	if output.Version != VerifierOutputVersion {
+		issues = append(issues, fmt.Sprintf("version must be %s", VerifierOutputVersion))
+	}
+	if strings.TrimSpace(output.Verifier) == "" {
+		issues = append(issues, "verifier is required")
+	}
+	if output.PromptVersion != VerifierPromptVersion {
+		issues = append(issues, fmt.Sprintf("prompt_version must be %s", VerifierPromptVersion))
+	}
+	if strings.TrimSpace(output.Model) == "" {
+		issues = append(issues, "model is required")
+	}
+	if len(output.Obligations) == 0 {
+		issues = append(issues, "obligations must reference at least one obligation")
+	}
+	if output.Confidence < 0 || output.Confidence > 1 {
+		issues = append(issues, "confidence must be between 0 and 1")
+	}
+	if duplicates := duplicateStrings(output.Obligations); len(duplicates) > 0 {
+		issues = append(issues, "obligations contain duplicate values: "+strings.Join(duplicates, ", "))
+	}
+	if !sameStringSet(output.Obligations, artifactObligations) {
+		issues = append(issues, "output obligations must match manifest artifact obligations")
+	}
+	for _, obligationID := range output.Obligations {
+		if strings.TrimSpace(obligationID) == "" {
+			issues = append(issues, "obligations must be non-empty")
+			continue
+		}
+		if _, ok := index.ByID[obligationID]; !ok {
+			issues = append(issues, fmt.Sprintf("unknown obligation %q", obligationID))
+		}
+	}
+	outputObligations := stringSet(output.Obligations)
+	for i, finding := range output.Findings {
+		issues = append(issues, validateVerifierFinding(output, finding, i, outputObligations, index)...)
+	}
+	return output, issues
+}
+
+func validateVerifierFinding(output VerifierOutput, finding Finding, index int, outputObligations map[string]bool, obligations ObligationIndex) []string {
+	owner := fmt.Sprintf("findings[%d]", index)
+	var issues []string
+	if strings.TrimSpace(finding.Verifier) == "" {
+		issues = append(issues, owner+" verifier is required")
+	} else if finding.Verifier != output.Verifier {
+		issues = append(issues, fmt.Sprintf("%s verifier %q does not match output verifier %q", owner, finding.Verifier, output.Verifier))
+	}
+	if !validVerifierDecision(finding.Decision) {
+		issues = append(issues, fmt.Sprintf("%s decision must be pass or block", owner))
+	}
+	if !validFindingSeverity(finding.Severity) {
+		issues = append(issues, fmt.Sprintf("%s severity must be low, medium, high, or critical", owner))
+	}
+	if strings.TrimSpace(finding.Claim) == "" {
+		issues = append(issues, owner+" claim is required")
+	}
+	if strings.TrimSpace(finding.Evidence) == "" {
+		issues = append(issues, owner+" evidence is required")
+	}
+	if finding.Decision == "block" && strings.TrimSpace(finding.RequiredFix) == "" {
+		issues = append(issues, owner+" required_fix is required for block decisions")
+	}
+	if len(finding.Obligations) == 0 {
+		issues = append(issues, owner+" obligations must reference at least one obligation")
+	}
+	if duplicates := duplicateStrings(finding.Obligations); len(duplicates) > 0 {
+		issues = append(issues, owner+" obligations contain duplicate values: "+strings.Join(duplicates, ", "))
+	}
+	for _, obligationID := range finding.Obligations {
+		if strings.TrimSpace(obligationID) == "" {
+			issues = append(issues, owner+" obligations must be non-empty")
+			continue
+		}
+		if !outputObligations[obligationID] {
+			issues = append(issues, fmt.Sprintf("%s obligation %q is not listed in output obligations", owner, obligationID))
+		}
+		if _, ok := obligations.ByID[obligationID]; !ok {
+			issues = append(issues, fmt.Sprintf("%s references unknown obligation %q", owner, obligationID))
+		}
+	}
+	return issues
+}
+
+func validVerifierDecision(decision string) bool {
+	switch decision {
+	case "pass", "block":
+		return true
+	default:
+		return false
+	}
+}
+
+func validFindingSeverity(severity string) bool {
+	switch severity {
+	case "low", "medium", "high", "critical":
+		return true
+	default:
+		return false
+	}
+}
+
+func sameStringSet(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	set := stringSet(left)
+	if len(set) != len(left) {
+		return false
+	}
+	for _, value := range right {
+		if !set[value] {
+			return false
+		}
+	}
+	return true
+}
+
+func duplicateStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	duplicates := []string{}
+	for _, value := range values {
+		if seen[value] && !containsString(duplicates, value) {
+			duplicates = append(duplicates, value)
+		}
+		seen[value] = true
+	}
+	return duplicates
 }
 
 func artifactStatusIssue(data []byte) (string, bool) {

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -361,6 +361,21 @@ func TestArtifactsBuildDeterministically(t *testing.T) {
 	if !bytes.Equal(first, second) {
 		t.Fatal("artifact generation should be deterministic")
 	}
+	var packets []VerifierPacket
+	if err := json.Unmarshal(first, &packets); err != nil {
+		t.Fatal(err)
+	}
+	if len(packets) == 0 {
+		t.Fatal("expected verifier packets")
+	}
+	for _, packet := range packets {
+		if packet.PromptVersion != VerifierPromptVersion || packet.OutputSchema != VerifierOutputVersion {
+			t.Fatalf("expected verifier packet schema pins, got %#v", packet)
+		}
+		if !strings.Contains(packet.RequiredOutput, VerifierOutputVersion) {
+			t.Fatalf("expected required output to name verifier output schema, got %q", packet.RequiredOutput)
+		}
+	}
 	for _, name := range []string{"verification-plan.json", "verifier-packets.json", "test-obligations.json", "release-policy.json"} {
 		if _, err := os.Stat(filepath.Join(out, name)); err != nil {
 			t.Fatalf("missing artifact %s: %v", name, err)
@@ -1467,6 +1482,141 @@ func TestPolicyInputIncludesArtifactVerificationState(t *testing.T) {
 	}
 }
 
+func TestVerifierOutputFindingBlocksReleasePolicy(t *testing.T) {
+	var behaviorID string
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, func(ids map[ObligationKind]string) []EvidenceArtifact {
+		behaviorID = ids[ObligationBehavior]
+		return []EvidenceArtifact{
+			unsignedArtifact("ai-review", EvidenceVerifierOutput, "artifacts/verifier-block.json", behaviorID),
+		}
+	})
+	writeVerifierOutputArtifact(t, repo, "artifacts/verifier-block.json", VerifierOutput{
+		Version:       VerifierOutputVersion,
+		Verifier:      "spec_adherence",
+		PromptVersion: VerifierPromptVersion,
+		Model:         "gpt-5.2",
+		Obligations:   []string{behaviorID},
+		Confidence:    0.82,
+		Findings: []Finding{{
+			Verifier:    "spec_adherence",
+			Severity:    "high",
+			Decision:    "block",
+			Claim:       "behavior artifact does not prove the saved label state",
+			Evidence:    "artifact references the obligation ID but does not include a state trace",
+			RequiredFix: "attach a behavior trace that exercises the saved label state",
+			Obligations: []string{behaviorID},
+		}},
+	})
+	evidence, err := CollectEvidence(repo, manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected verifier output to block, got %s", evidence.Decision)
+	}
+	if !hasFinding(evidence, "spec_adherence", "behavior artifact does not prove") {
+		t.Fatalf("expected imported verifier finding: %#v", evidence.Findings)
+	}
+	if len(evidence.VerifierOutputs) != 1 {
+		t.Fatalf("expected verifier output to be imported: %#v", evidence.VerifierOutputs)
+	}
+	if !contains(evidence.PolicyResult.RulesFired, "block_verifier_findings") {
+		t.Fatalf("expected policy to block on verifier finding: %#v", evidence.PolicyResult)
+	}
+	input := PolicyInputFromEvidence(evidence)
+	if len(input.VerifierOutputs) != 1 || !input.HasBlockingFindings {
+		t.Fatalf("expected policy input to include verifier output and blocking finding: %#v", input)
+	}
+}
+
+func TestMalformedVerifierOutputInvalidatesEvidence(t *testing.T) {
+	var behaviorID string
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, func(ids map[ObligationKind]string) []EvidenceArtifact {
+		behaviorID = ids[ObligationBehavior]
+		return []EvidenceArtifact{
+			unsignedArtifact("ai-review", EvidenceVerifierOutput, "artifacts/verifier-bad.json", behaviorID),
+		}
+	})
+	writeArtifact(t, repo, "artifacts/verifier-bad.json", `{
+  "version": "vouch.verifier_output.old",
+  "verifier": "spec_adherence",
+  "prompt_version": "vouch.verifier_prompt.v0",
+  "obligations": ["`+behaviorID+`"],
+  "findings": []
+}`)
+	evidence, err := CollectEvidence(repo, manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected malformed verifier output to block, got %s", evidence.Decision)
+	}
+	if !hasInvalidEvidence(evidence, "ai-review", "verifier_output_import") {
+		t.Fatalf("expected verifier output import failure: %#v", evidence.InvalidEvidence)
+	}
+	if !hasFinding(evidence, "evidence_linker", "evidence artifact ai-review is invalid") {
+		t.Fatalf("expected invalid verifier output finding: %#v", evidence.Findings)
+	}
+}
+
+func TestVerifierOutputDoesNotSatisfyRequiredEvidenceCoverage(t *testing.T) {
+	spec := sampleUISpec()
+	behaviorID := obligationID(t, spec, ObligationBehavior, "button label changes to Save")
+	securityID := obligationID(t, spec, ObligationSecurity, "no secrets introduced")
+	testID := obligationID(t, spec, ObligationRequiredTest, "button label renders")
+	runtimeID := obligationID(t, spec, ObligationRuntimeSignal, "ui.rendered")
+	rollbackID := obligationID(t, spec, ObligationRollback, "revert_commit")
+	allIDs := []string{behaviorID, securityID, testID, runtimeID, rollbackID}
+	repo, manifestPath := writeScenario(t, spec, Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "issue-verifier-only", Summary: "verifier only"},
+		Change: Change{
+			Risk:            RiskLow,
+			SpecsTouched:    []string{"ui.copy"},
+			BehaviorChanged: true,
+			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Verification: Verification{
+			Commands:    []string{"ai verifier"},
+			TestResults: TestResults{Passed: 1},
+			Artifacts: []EvidenceArtifact{
+				unsignedArtifact("ai-review", EvidenceVerifierOutput, "artifacts/verifier-pass.json", allIDs...),
+			},
+		},
+		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback: ManifestRollback{Strategy: "revert_commit"},
+	})
+	writeVerifierOutputArtifact(t, repo, "artifacts/verifier-pass.json", VerifierOutput{
+		Version:       VerifierOutputVersion,
+		Verifier:      "spec_adherence",
+		PromptVersion: VerifierPromptVersion,
+		Model:         "gpt-5.2",
+		Obligations:   allIDs,
+		Confidence:    0.74,
+		Findings: []Finding{{
+			Verifier:    "spec_adherence",
+			Severity:    "low",
+			Decision:    "pass",
+			Claim:       "verifier found no contradiction in the submitted evidence",
+			Evidence:    "no non-verifier evidence was attached",
+			Obligations: allIDs,
+		}},
+	})
+	evidence, err := CollectEvidence(repo, manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected verifier-only evidence to block, got %s", evidence.Decision)
+	}
+	if !missingObligation(evidence, "ui.copy", ObligationBehavior, "button label changes to Save") {
+		t.Fatalf("verifier output should not satisfy behavior coverage: %#v", evidence.CoveredObligations["ui.copy"])
+	}
+	if len(evidence.CoveredObligations["ui.copy"]) != 0 {
+		t.Fatalf("verifier output should not count as required evidence coverage: %#v", evidence.CoveredObligations["ui.copy"])
+	}
+}
+
 func TestMissingDefaultPolicyFailsClosed(t *testing.T) {
 	repo := t.TempDir()
 	specDir := filepath.Join(repo, ".vouch", "specs")
@@ -1843,6 +1993,81 @@ func exitCode(code int) *int {
 	return &code
 }
 
+func sampleUISpec() Spec {
+	return Spec{
+		Version:    SpecSchemaVersion,
+		ID:         "ui.copy",
+		Owner:      "product",
+		OwnedPaths: []string{"src/ui/**"},
+		Risk:       RiskLow,
+		Behavior:   []string{"button label changes to Save"},
+		Security:   []string{"no secrets introduced"},
+		Tests:      SpecTests{Required: []string{"button label renders"}},
+		Runtime:    SpecRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback:   SpecRollback{Strategy: "revert_commit"},
+	}
+}
+
+func unsignedArtifact(id string, kind EvidenceKind, path string, obligations ...string) EvidenceArtifact {
+	return EvidenceArtifact{
+		ID:          id,
+		Kind:        kind,
+		Producer:    "ci",
+		Path:        path,
+		ExitCode:    exitCode(0),
+		Obligations: obligations,
+	}
+}
+
+func writeFullyCoveredUIScenario(t *testing.T, extra func(map[ObligationKind]string) []EvidenceArtifact) (string, string, map[ObligationKind]string) {
+	t.Helper()
+	spec := sampleUISpec()
+	ids := map[ObligationKind]string{
+		ObligationBehavior:      obligationID(t, spec, ObligationBehavior, "button label changes to Save"),
+		ObligationSecurity:      obligationID(t, spec, ObligationSecurity, "no secrets introduced"),
+		ObligationRequiredTest:  obligationID(t, spec, ObligationRequiredTest, "button label renders"),
+		ObligationRuntimeSignal: obligationID(t, spec, ObligationRuntimeSignal, "ui.rendered"),
+		ObligationRollback:      obligationID(t, spec, ObligationRollback, "revert_commit"),
+	}
+	artifacts := []EvidenceArtifact{
+		unsignedArtifact("behavior", EvidenceBehaviorTrace, "artifacts/behavior.json", ids[ObligationBehavior]),
+		unsignedArtifact("security", EvidenceSecurityCheck, "artifacts/security.json", ids[ObligationSecurity]),
+		unsignedArtifact("tests", EvidenceTestCoverage, "artifacts/junit.xml", ids[ObligationRequiredTest]),
+		unsignedArtifact("runtime", EvidenceRuntimeMetric, "artifacts/runtime.json", ids[ObligationRuntimeSignal]),
+		unsignedArtifact("rollback", EvidenceRollbackPlan, "artifacts/rollback.json", ids[ObligationRollback]),
+	}
+	if extra != nil {
+		artifacts = append(artifacts, extra(ids)...)
+	}
+	repo, manifestPath := writeScenario(t, spec, Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "issue-covered-ui", Summary: "copy update"},
+		Change: Change{
+			Risk:            RiskLow,
+			SpecsTouched:    []string{"ui.copy"},
+			BehaviorChanged: true,
+			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Verification: Verification{
+			Commands:    []string{"go test ./..."},
+			TestResults: TestResults{Passed: 1},
+			Artifacts:   artifacts,
+		},
+		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
+		Rollback: ManifestRollback{Strategy: "revert_commit"},
+	})
+	writeArtifact(t, repo, "artifacts/behavior.json", `{"status":"pass","obligations":["`+ids[ObligationBehavior]+`"]}`)
+	writeArtifact(t, repo, "artifacts/security.json", `{"status":"pass","obligations":["`+ids[ObligationSecurity]+`"]}`)
+	writeArtifact(t, repo, "artifacts/runtime.json", `{"status":"pass","obligations":["`+ids[ObligationRuntimeSignal]+`"]}`)
+	writeArtifact(t, repo, "artifacts/rollback.json", `{"status":"pass","obligations":["`+ids[ObligationRollback]+`"]}`)
+	writeArtifact(t, repo, "artifacts/junit.xml", `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="ui.copy" tests="1" failures="0" errors="0" skipped="0">
+  <testcase classname="`+ids[ObligationRequiredTest]+`" name="button label renders" />
+</testsuite>
+`)
+	return repo, manifestPath, ids
+}
+
 func writeScenario(t *testing.T, spec Spec, manifest Manifest) (string, string) {
 	t.Helper()
 	repo := t.TempDir()
@@ -1876,6 +2101,15 @@ func writeArtifact(t *testing.T, repo string, relPath string, data string) {
 	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func writeVerifierOutputArtifact(t *testing.T, repo string, relPath string, output VerifierOutput) {
+	t.Helper()
+	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeArtifact(t, repo, relPath, string(append(data, '\n')))
 }
 
 func installFakeCosign(t *testing.T, exitCode int) {

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -954,7 +954,7 @@ func resolveRepoOutput(repo string, path string) string {
 func obligationsForEvidenceKind(symbols SymbolTable, kind EvidenceKind) []string {
 	var ids []string
 	for id, obligation := range symbols.Obligations {
-		if obligation.RequiredEvidence == kind {
+		if kind == EvidenceVerifierOutput || obligation.RequiredEvidence == kind {
 			ids = append(ids, id)
 		}
 	}

--- a/internal/vouch/policy.go
+++ b/internal/vouch/policy.go
@@ -228,6 +228,7 @@ func PolicyInputFromEvidence(evidence Evidence) PolicyInput {
 		ManifestErrors:           cloneStrings(evidence.ManifestErrors),
 		ArtifactResults:          cloneArtifactResults(evidence.ArtifactResults),
 		InvalidEvidence:          cloneInvalidEvidence(evidence.InvalidEvidence),
+		VerifierOutputs:          cloneVerifierOutputs(evidence.VerifierOutputs),
 		MissingObligations:       obligationTextMap(evidence.MissingObligations),
 		CoveredObligations:       obligationTextMap(evidence.CoveredObligations),
 		Findings:                 cloneFindings(evidence.Findings),
@@ -246,6 +247,11 @@ func WriteDefaultReleasePolicy(path string) error {
 
 func cloneFindings(values []Finding) []Finding {
 	out := make([]Finding, 0, len(values))
+	return append(out, values...)
+}
+
+func cloneVerifierOutputs(values []VerifierOutput) []VerifierOutput {
+	out := make([]VerifierOutput, 0, len(values))
 	return append(out, values...)
 }
 

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -15,6 +15,8 @@ const (
 	PolicyInputVersion      = "vouch.policy_input.v0"
 	PolicyResultVersion     = "vouch.policy_result.v0"
 	PolicySimulationVersion = "vouch.policy_simulation.v0"
+	VerifierPromptVersion   = "vouch.verifier_prompt.v0"
+	VerifierOutputVersion   = "vouch.verifier_output.v0"
 )
 
 const (
@@ -71,11 +73,12 @@ const (
 type EvidenceKind string
 
 const (
-	EvidenceBehaviorTrace EvidenceKind = "behavior_trace"
-	EvidenceSecurityCheck EvidenceKind = "security_check"
-	EvidenceTestCoverage  EvidenceKind = "test_coverage"
-	EvidenceRuntimeMetric EvidenceKind = "runtime_metric"
-	EvidenceRollbackPlan  EvidenceKind = "rollback_plan"
+	EvidenceBehaviorTrace  EvidenceKind = "behavior_trace"
+	EvidenceSecurityCheck  EvidenceKind = "security_check"
+	EvidenceTestCoverage   EvidenceKind = "test_coverage"
+	EvidenceRuntimeMetric  EvidenceKind = "runtime_metric"
+	EvidenceRollbackPlan   EvidenceKind = "rollback_plan"
+	EvidenceVerifierOutput EvidenceKind = "verifier_output"
 )
 
 type Intent struct {
@@ -156,6 +159,8 @@ type VerificationPlan struct {
 type VerifierPacket struct {
 	Verifier       string       `json:"verifier"`
 	Focus          string       `json:"focus"`
+	PromptVersion  string       `json:"prompt_version"`
+	OutputSchema   string       `json:"output_schema"`
 	Obligations    []Obligation `json:"obligations"`
 	RequiredOutput string       `json:"required_output"`
 }
@@ -261,16 +266,28 @@ type ManifestRollback struct {
 }
 
 type Finding struct {
-	Verifier    string `json:"verifier"`
-	Severity    string `json:"severity"`
-	Decision    string `json:"decision"`
-	Claim       string `json:"claim"`
-	Evidence    string `json:"evidence"`
-	RequiredFix string `json:"required_fix"`
+	Verifier    string   `json:"verifier"`
+	Severity    string   `json:"severity"`
+	Decision    string   `json:"decision"`
+	Claim       string   `json:"claim"`
+	Evidence    string   `json:"evidence"`
+	RequiredFix string   `json:"required_fix"`
+	Obligations []string `json:"obligations,omitempty"`
 }
 
 func (f Finding) Blocks() bool {
 	return f.Decision == "block"
+}
+
+type VerifierOutput struct {
+	Version       string    `json:"version"`
+	Verifier      string    `json:"verifier"`
+	PromptVersion string    `json:"prompt_version"`
+	Model         string    `json:"model"`
+	Obligations   []string  `json:"obligations"`
+	Confidence    float64   `json:"confidence,omitempty"`
+	Findings      []Finding `json:"findings"`
+	Disagreements []string  `json:"disagreements,omitempty"`
 }
 
 type ReleasePolicy struct {
@@ -309,6 +326,7 @@ type PolicyInput struct {
 	ManifestErrors           []string            `json:"manifest_errors"`
 	ArtifactResults          []ArtifactResult    `json:"artifact_results"`
 	InvalidEvidence          []InvalidEvidence   `json:"invalid_evidence"`
+	VerifierOutputs          []VerifierOutput    `json:"verifier_outputs"`
 	MissingObligations       map[string][]string `json:"missing_obligations"`
 	CoveredObligations       map[string][]string `json:"covered_obligations"`
 	Findings                 []Finding           `json:"findings"`
@@ -353,6 +371,7 @@ type Evidence struct {
 	ManifestErrors         []string                    `json:"manifest_errors"`
 	ArtifactResults        []ArtifactResult            `json:"artifact_results"`
 	InvalidEvidence        []InvalidEvidence           `json:"invalid_evidence"`
+	VerifierOutputs        []VerifierOutput            `json:"verifier_outputs"`
 	RequiredObligations    map[string][]Obligation     `json:"required_obligations"`
 	CoveredObligations     map[string][]Obligation     `json:"covered_obligations"`
 	MissingObligations     map[string][]Obligation     `json:"missing_obligations"`
@@ -375,16 +394,18 @@ type CompilationStats struct {
 }
 
 type ArtifactResult struct {
-	ID                 string       `json:"id"`
-	Kind               EvidenceKind `json:"kind"`
-	Path               string       `json:"path,omitempty"`
-	ResolvedPath       string       `json:"resolved_path,omitempty"`
-	Status             string       `json:"status"`
-	HashVerified       bool         `json:"hash_verified"`
-	SignatureVerified  bool         `json:"signature_verified"`
-	CoveredObligations []string     `json:"covered_obligations"`
-	FailedTests        []string     `json:"failed_tests,omitempty"`
-	Issues             []string     `json:"issues,omitempty"`
+	ID                 string          `json:"id"`
+	Kind               EvidenceKind    `json:"kind"`
+	Path               string          `json:"path,omitempty"`
+	ResolvedPath       string          `json:"resolved_path,omitempty"`
+	Status             string          `json:"status"`
+	HashVerified       bool            `json:"hash_verified"`
+	SignatureVerified  bool            `json:"signature_verified"`
+	CoveredObligations []string        `json:"covered_obligations"`
+	VerifierOutput     *VerifierOutput `json:"-"`
+	VerifierFindings   []Finding       `json:"verifier_findings,omitempty"`
+	FailedTests        []string        `json:"failed_tests,omitempty"`
+	Issues             []string        `json:"issues,omitempty"`
 }
 
 type InvalidEvidence struct {

--- a/internal/vouch/validate.go
+++ b/internal/vouch/validate.go
@@ -97,7 +97,7 @@ func validRisk(risk Risk) bool {
 
 func validEvidenceKind(kind EvidenceKind) bool {
 	switch kind {
-	case EvidenceBehaviorTrace, EvidenceSecurityCheck, EvidenceTestCoverage, EvidenceRuntimeMetric, EvidenceRollbackPlan:
+	case EvidenceBehaviorTrace, EvidenceSecurityCheck, EvidenceTestCoverage, EvidenceRuntimeMetric, EvidenceRollbackPlan, EvidenceVerifierOutput:
 		return true
 	default:
 		return false


### PR DESCRIPTION
## Summary
  - Add structured `verifier_output` evidence artifacts
  - Import verifier findings into the release policy path
  - Reject malformed verifier outputs as invalid evidence
  - Keep verifier outputs from satisfying required evidence coverage
  - Pin verifier packet prompt/output schema versions

## Tests
  - `go test -count=1 ./...`
  - `git diff --check`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json gate`
