### PR TITLE
feat: add evidence bundle enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,14 @@ vouch --repo /path/to/your/repo manifest attach-artifact \
   --out .vouch/manifests/run-123.json
 ```
 
-Signature fields are optional in beta. To attach signed evidence, first sign the
-artifact with cosign, then include the bundle and expected identity when
-attaching it:
+Signature fields are optional in beta. To attach signed evidence, first write a
+`vouch.evidence_bundle.v0` JSON file for the artifact. The bundle binds the
+manifest task, touched specs, artifact ID/kind/path/hash, covered obligation
+IDs, runner identity, and timestamp. Sign that evidence bundle with cosign, then
+include the bundle paths and expected identity when attaching the artifact:
 
 ```sh
-cosign sign-blob .vouch/artifacts/behavior.json \
+cosign sign-blob .vouch/artifacts/behavior.vouch-bundle.json \
   --bundle .vouch/artifacts/behavior.sigstore.json
 
 vouch --repo /path/to/your/repo manifest attach-artifact \
@@ -223,6 +225,7 @@ vouch --repo /path/to/your/repo manifest attach-artifact \
   --id behavior \
   --kind behavior_trace \
   --path .vouch/artifacts/behavior.json \
+  --evidence-bundle .vouch/artifacts/behavior.vouch-bundle.json \
   --signature-bundle .vouch/artifacts/behavior.sigstore.json \
   --signer-identity "https://github.com/ORG/REPO/.github/workflows/vouch.yml@refs/heads/main" \
   --signer-oidc-issuer "https://token.actions.githubusercontent.com" \
@@ -238,9 +241,11 @@ vouch --repo /path/to/your/repo \
   gate --require-signed
 ```
 
-`--require-signed` verifies each evidence artifact with `cosign verify-blob`
+`--require-signed` verifies each `evidence_bundle` with `cosign verify-blob`
 using the artifact's `signature_bundle`, `signer_identity`, and
-`signer_oidc_issuer` fields.
+`signer_oidc_issuer` fields. It also rejects bundles whose manifest identity,
+artifact hash, obligation IDs, runner identity, or runner OIDC issuer do not
+match the manifest and artifact being gated.
 
 ### 7. Gate The Change
 
@@ -322,7 +327,7 @@ Today, Vouch can check:
 - Artifact paths stay inside the repo and files exist.
 - Artifact exit codes are present and zero.
 - Optional artifact SHA-256 values match file contents.
-- Optional `gate --require-signed` mode verifies evidence artifacts with cosign bundles and expected signer identities.
+- Optional `gate --require-signed` mode verifies signed `vouch.evidence_bundle.v0` files and binds manifest identity, artifact hashes, obligation IDs, runner identity, and expected signer metadata.
 - Release policy is loaded from `.vouch/policy/release-policy.json` or an explicit `--policy` file.
 - Generated verifier packets pin prompt and output schema versions.
 - Structured `verifier_output` artifacts parse as `vouch.verifier_output.v0` and import pass/block findings into release policy.
@@ -341,7 +346,7 @@ Today, Vouch cannot check:
 - Whether tests were actually run unless the external runner preserves and signs the artifact chain.
 - Whether product intent was inferred correctly from code.
 - Whether release policy uses a general-purpose policy language such as Rego; the current policy evaluator is a small Vouch JSON rule engine.
-- Whether signed evidence is bound to a canonical bundle that includes manifest identity, artifact hashes, and covered obligation IDs.
+- Whether signer identities are authorized by an organization-level allowlist beyond the identities declared in the manifest artifacts.
 
 ## Validation Status
 
@@ -619,8 +624,8 @@ vouch --manifest FILE plan build --spec FILE --out FILE
 vouch artifacts build --spec FILE --out DIR
 vouch --repo DIR spec lint
 vouch --repo DIR --manifest FILE manifest check
-vouch --repo DIR manifest create --task-id ID --summary TEXT --agent NAME --run-id ID --out FILE
-vouch --repo DIR --manifest FILE manifest attach-artifact --id ID --kind KIND --path FILE --exit-code N [--signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE
+vouch --repo DIR manifest create --task-id ID --summary TEXT --agent NAME --run-id ID [--runner-identity ID --runner-oidc-issuer URL] --out FILE
+vouch --repo DIR --manifest FILE manifest attach-artifact --id ID --kind KIND --path FILE --exit-code N [--evidence-bundle FILE --signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE
 vouch --repo DIR --manifest FILE junit map --junit FILE --test-map FILE --out FILE
 vouch --repo DIR --manifest FILE policy simulate [--policy FILE] [--require-signed]
 vouch --repo DIR --manifest FILE verify [--policy FILE]

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,15 +212,19 @@ Planned work:
 
 Make the system usable by teams.
 
-Planned work:
+Implemented base:
 
 - Runner identity in manifests and evidence artifacts.
-- Allowed signer policy for contracts or repo policy.
-- Detached signatures over canonical evidence bundles.
+- Detached signatures over Vouch evidence bundles.
 - Hardened `gate --require-signed` mode that binds manifest, artifact hashes, and obligation IDs.
-- Signed specs and manifests.
-- Agent identity and run provenance.
 - Tamper-evident evidence bundles.
+- Agent identity and run provenance in bundle validation.
+
+Remaining work:
+
+- Allowed signer policy for contracts or repo policy.
+- Canonical JSON serialization rules for evidence bundles.
+- Signed specs and manifests.
 - Role-based approval exceptions.
 - Organization-level policy packs.
 - Multi-repo spec registry.
@@ -230,9 +234,8 @@ Planned work:
 
 The next useful contributions are:
 
-- Signed or hashed evidence bundle format.
-- Runner identity and allowed signer fields.
-- Hardened `gate --require-signed` production mode.
+- Allowed signer policy for contracts or repo policy.
+- Signed specs and manifests.
 - Rego policy adapter decision spike.
 - Reference workflow for `init -> manifest -> pytest -> junit map -> attach -> gate`.
 - Real-world case study showing a plausible bad agent change blocked by an obligation.

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -220,6 +220,8 @@ func manifestCreate(repo string, args []string, jsonOut bool, stdout io.Writer, 
 	agent := flags.String("agent", "", "agent name")
 	runID := flags.String("run-id", "", "agent run id")
 	model := flags.String("model", "", "agent model")
+	runnerIdentity := flags.String("runner-identity", "", "expected runner identity for signed evidence")
+	runnerOIDCIssuer := flags.String("runner-oidc-issuer", "", "expected runner OIDC issuer for signed evidence")
 	base := flags.String("base", "main", "git base ref")
 	head := flags.String("head", "HEAD", "git head ref")
 	risk := flags.String("risk", "", "risk override")
@@ -238,6 +240,8 @@ func manifestCreate(repo string, args []string, jsonOut bool, stdout io.Writer, 
 		Agent:            *agent,
 		RunID:            *runID,
 		Model:            *model,
+		RunnerIdentity:   *runnerIdentity,
+		RunnerOIDCIssuer: *runnerOIDCIssuer,
 		Base:             *base,
 		Head:             *head,
 		Risk:             Risk(*risk),
@@ -273,6 +277,7 @@ func manifestAttachArtifact(repo string, args []string, jsonOut bool, stdout io.
 	producer := flags.String("producer", "", "artifact producer")
 	command := flags.String("command", "", "command that produced artifact")
 	sha256 := flags.String("sha256", "", "expected sha256")
+	evidenceBundle := flags.String("evidence-bundle", "", "Vouch evidence bundle path")
 	signatureBundle := flags.String("signature-bundle", "", "cosign signature bundle path")
 	signerIdentity := flags.String("signer-identity", "", "expected cosign signer identity")
 	signerOIDCIssuer := flags.String("signer-oidc-issuer", "", "expected cosign signer OIDC issuer")
@@ -302,6 +307,7 @@ func manifestAttachArtifact(repo string, args []string, jsonOut bool, stdout io.
 		Command:          *command,
 		ExitCode:         *exitCode,
 		SHA256:           *sha256,
+		EvidenceBundle:   *evidenceBundle,
 		SignatureBundle:  *signatureBundle,
 		SignerIdentity:   *signerIdentity,
 		SignerOIDCIssuer: *signerOIDCIssuer,
@@ -680,8 +686,8 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  contract create --name ID --owner OWNER --risk RISK --paths GLOB --behavior TEXT --required-test TEXT")
 	fmt.Fprintln(out, "  spec lint")
 	fmt.Fprintln(out, "  manifest check")
-	fmt.Fprintln(out, "  manifest create --task-id ID --summary TEXT --agent NAME --run-id ID --out FILE")
-	fmt.Fprintln(out, "  manifest attach-artifact --manifest FILE --id ID --kind KIND --path FILE --exit-code N [--signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE")
+	fmt.Fprintln(out, "  manifest create --task-id ID --summary TEXT --agent NAME --run-id ID [--runner-identity ID --runner-oidc-issuer URL] --out FILE")
+	fmt.Fprintln(out, "  manifest attach-artifact --manifest FILE --id ID --kind KIND --path FILE --exit-code N [--evidence-bundle FILE --signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE")
 	fmt.Fprintln(out, "  junit map --manifest FILE --junit FILE --test-map FILE --out FILE")
 	fmt.Fprintln(out, "  policy simulate [--manifest FILE] [--policy FILE] [--require-signed]")
 	fmt.Fprintln(out, "  verify [--policy FILE]")

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -63,7 +63,7 @@ func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEv
 		Reasons:                []string{},
 	}
 	obligationIndex := NewObligationIndex(evidence.VerificationPlans)
-	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{RequireSigned: opts.RequireSigned})
+	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{RequireSigned: opts.RequireSigned})
 	buildCoverage(&evidence)
 	runVerifiers(&evidence)
 	importVerifierFindings(&evidence)

--- a/internal/vouch/evidence_artifacts.go
+++ b/internal/vouch/evidence_artifacts.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 type ObligationIndex struct {
@@ -32,7 +33,7 @@ func NewObligationIndex(plans map[string]VerificationPlan) ObligationIndex {
 	return index
 }
 
-func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index ObligationIndex, opts ArtifactLinkOptions) ([]ArtifactResult, []InvalidEvidence) {
+func LinkEvidenceArtifacts(repo string, manifest Manifest, artifacts []EvidenceArtifact, index ObligationIndex, opts ArtifactLinkOptions) ([]ArtifactResult, []InvalidEvidence) {
 	results := make([]ArtifactResult, 0, len(artifacts))
 	var invalid []InvalidEvidence
 	for _, artifact := range artifacts {
@@ -72,8 +73,8 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 					result.addIssue("artifact_missing", fmt.Sprintf("cannot read artifact path %s: %v", artifact.Path, err))
 				} else {
 					data = bytes
+					actual := sha256Hex(data)
 					if artifact.SHA256 != "" {
-						actual := sha256Hex(data)
 						if !strings.EqualFold(actual, artifact.SHA256) {
 							result.addIssue("sha256_mismatch", fmt.Sprintf("artifact %s sha256 mismatch: expected %s got %s", artifact.ID, artifact.SHA256, actual))
 						} else {
@@ -87,7 +88,7 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 		}
 
 		if opts.RequireSigned && len(data) > 0 {
-			verifyCosignBundle(repo, artifact, result.ResolvedPath, &result)
+			verifySignedEvidenceBundle(repo, manifest, artifact, data, &result)
 		}
 
 		if artifact.Kind == EvidenceVerifierOutput {
@@ -138,7 +139,11 @@ func LinkEvidenceArtifacts(repo string, artifacts []EvidenceArtifact, index Obli
 	return results, invalid
 }
 
-func verifyCosignBundle(repo string, artifact EvidenceArtifact, artifactPath string, result *ArtifactResult) {
+func verifySignedEvidenceBundle(repo string, manifest Manifest, artifact EvidenceArtifact, artifactData []byte, result *ArtifactResult) {
+	if artifact.EvidenceBundle == "" {
+		result.addIssue("missing_evidence_bundle", "evidence_bundle is required when signed evidence is enforced")
+		return
+	}
 	if artifact.SignatureBundle == "" {
 		result.addIssue("missing_signature_bundle", "signature_bundle is required when signed evidence is enforced")
 		return
@@ -151,12 +156,38 @@ func verifyCosignBundle(repo string, artifact EvidenceArtifact, artifactPath str
 		result.addIssue("missing_signer_oidc_issuer", "signer_oidc_issuer is required when signed evidence is enforced")
 		return
 	}
-	bundlePath, err := resolveArtifactPath(repo, artifact.SignatureBundle)
+	evidenceBundlePath, err := resolveArtifactPath(repo, artifact.EvidenceBundle)
+	if err != nil {
+		result.addIssue("evidence_bundle_path_escape", err.Error())
+		return
+	}
+	evidenceBundleData, err := os.ReadFile(evidenceBundlePath)
+	if err != nil {
+		result.addIssue("evidence_bundle_missing", fmt.Sprintf("cannot read evidence bundle %s: %v", artifact.EvidenceBundle, err))
+		return
+	}
+	bundle, issues := importEvidenceBundle(evidenceBundleData)
+	for _, issue := range issues {
+		result.addIssue("evidence_bundle_import", issue)
+	}
+	if len(issues) > 0 {
+		return
+	}
+	for _, issue := range validateEvidenceBundle(bundle, manifest, artifact, artifactData) {
+		result.addIssue("evidence_bundle", issue)
+	}
+	if len(result.Issues) > 0 {
+		return
+	}
+	result.HashVerified = true
+	result.BundleVerified = true
+
+	signatureBundlePath, err := resolveArtifactPath(repo, artifact.SignatureBundle)
 	if err != nil {
 		result.addIssue("signature_bundle_path_escape", err.Error())
 		return
 	}
-	if _, err := os.Stat(bundlePath); err != nil {
+	if _, err := os.Stat(signatureBundlePath); err != nil {
 		result.addIssue("signature_bundle_missing", fmt.Sprintf("cannot read signature bundle %s: %v", artifact.SignatureBundle, err))
 		return
 	}
@@ -167,8 +198,8 @@ func verifyCosignBundle(repo string, artifact EvidenceArtifact, artifactPath str
 	}
 	cmd := exec.Command(cosignPath,
 		"verify-blob",
-		artifactPath,
-		"--bundle", bundlePath,
+		evidenceBundlePath,
+		"--bundle", signatureBundlePath,
 		"--certificate-identity="+artifact.SignerIdentity,
 		"--certificate-oidc-issuer="+artifact.SignerOIDCIssuer,
 	)
@@ -182,6 +213,108 @@ func verifyCosignBundle(repo string, artifact EvidenceArtifact, artifactPath str
 		return
 	}
 	result.SignatureVerified = true
+}
+
+func importEvidenceBundle(data []byte) (EvidenceBundle, []string) {
+	var bundle EvidenceBundle
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&bundle); err != nil {
+		return bundle, []string{fmt.Sprintf("cannot parse evidence bundle JSON: %v", err)}
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return bundle, []string{"trailing JSON content after evidence bundle"}
+	}
+	return bundle, nil
+}
+
+func validateEvidenceBundle(bundle EvidenceBundle, manifest Manifest, artifact EvidenceArtifact, artifactData []byte) []string {
+	var issues []string
+	if bundle.Version != EvidenceBundleVersion {
+		issues = append(issues, fmt.Sprintf("version must be %s", EvidenceBundleVersion))
+	}
+	if bundle.ManifestID != manifest.Task.ID {
+		issues = append(issues, fmt.Sprintf("manifest_id %q does not match manifest task id %q", bundle.ManifestID, manifest.Task.ID))
+	}
+	if !sameStringSet(bundle.SpecsTouched, manifest.Change.SpecsTouched) {
+		issues = append(issues, "specs_touched must match manifest change.specs_touched")
+	}
+	if bundle.ChangeRisk != manifest.Change.Risk {
+		issues = append(issues, fmt.Sprintf("change_risk %q does not match manifest risk %q", bundle.ChangeRisk, manifest.Change.Risk))
+	}
+	if strings.TrimSpace(bundle.Timestamp) == "" {
+		issues = append(issues, "timestamp is required")
+	} else if _, err := time.Parse(time.RFC3339, bundle.Timestamp); err != nil {
+		issues = append(issues, "timestamp must be RFC3339")
+	}
+	issues = append(issues, validateEvidenceBundleArtifact(bundle.Artifact, artifact, artifactData)...)
+	issues = append(issues, validateEvidenceBundleRunner(bundle.Runner, manifest.Agent, artifact)...)
+	return issues
+}
+
+func validateEvidenceBundleArtifact(bundle EvidenceBundleArtifact, artifact EvidenceArtifact, artifactData []byte) []string {
+	var issues []string
+	if bundle.ID != artifact.ID {
+		issues = append(issues, fmt.Sprintf("artifact.id %q does not match manifest artifact id %q", bundle.ID, artifact.ID))
+	}
+	if bundle.Kind != artifact.Kind {
+		issues = append(issues, fmt.Sprintf("artifact.kind %q does not match manifest artifact kind %q", bundle.Kind, artifact.Kind))
+	}
+	if bundle.Path != artifact.Path {
+		issues = append(issues, fmt.Sprintf("artifact.path %q does not match manifest artifact path %q", bundle.Path, artifact.Path))
+	}
+	actualSHA := sha256Hex(artifactData)
+	if !strings.EqualFold(bundle.SHA256, actualSHA) {
+		issues = append(issues, fmt.Sprintf("artifact.sha256 mismatch: expected actual artifact hash %s got %s", actualSHA, bundle.SHA256))
+	}
+	if artifact.SHA256 != "" && !strings.EqualFold(bundle.SHA256, artifact.SHA256) {
+		issues = append(issues, "artifact.sha256 must match manifest artifact sha256")
+	}
+	if bundle.Producer != artifact.Producer {
+		issues = append(issues, fmt.Sprintf("artifact.producer %q does not match manifest artifact producer %q", bundle.Producer, artifact.Producer))
+	}
+	if bundle.Command != artifact.Command {
+		issues = append(issues, fmt.Sprintf("artifact.command %q does not match manifest artifact command %q", bundle.Command, artifact.Command))
+	}
+	if artifact.ExitCode == nil {
+		issues = append(issues, "manifest artifact exit_code is required")
+	} else if bundle.ExitCode != *artifact.ExitCode {
+		issues = append(issues, fmt.Sprintf("artifact.exit_code %d does not match manifest artifact exit_code %d", bundle.ExitCode, *artifact.ExitCode))
+	}
+	if !sameStringSet(bundle.Obligations, artifact.Obligations) {
+		issues = append(issues, "artifact.obligations must match manifest artifact obligations")
+	}
+	return issues
+}
+
+func validateEvidenceBundleRunner(runner EvidenceBundleRunner, agent Agent, artifact EvidenceArtifact) []string {
+	var issues []string
+	if strings.TrimSpace(runner.Identity) == "" {
+		issues = append(issues, "runner.identity is required")
+	} else if runner.Identity != artifact.SignerIdentity {
+		issues = append(issues, fmt.Sprintf("runner.identity %q does not match signer_identity %q", runner.Identity, artifact.SignerIdentity))
+	}
+	if strings.TrimSpace(runner.OIDCIssuer) == "" {
+		issues = append(issues, "runner.oidc_issuer is required")
+	} else if runner.OIDCIssuer != artifact.SignerOIDCIssuer {
+		issues = append(issues, fmt.Sprintf("runner.oidc_issuer %q does not match signer_oidc_issuer %q", runner.OIDCIssuer, artifact.SignerOIDCIssuer))
+	}
+	if agent.RunnerIdentity != "" && runner.Identity != agent.RunnerIdentity {
+		issues = append(issues, fmt.Sprintf("runner.identity %q does not match manifest agent.runner_identity %q", runner.Identity, agent.RunnerIdentity))
+	}
+	if agent.RunnerOIDCIssuer != "" && runner.OIDCIssuer != agent.RunnerOIDCIssuer {
+		issues = append(issues, fmt.Sprintf("runner.oidc_issuer %q does not match manifest agent.runner_oidc_issuer %q", runner.OIDCIssuer, agent.RunnerOIDCIssuer))
+	}
+	if agent.Name != "" && runner.AgentName != agent.Name {
+		issues = append(issues, fmt.Sprintf("runner.agent_name %q does not match manifest agent.name %q", runner.AgentName, agent.Name))
+	}
+	if agent.RunID != "" && runner.AgentRunID != agent.RunID {
+		issues = append(issues, fmt.Sprintf("runner.agent_run_id %q does not match manifest agent.run_id %q", runner.AgentRunID, agent.RunID))
+	}
+	if agent.Model != "" && runner.AgentModel != agent.Model {
+		issues = append(issues, fmt.Sprintf("runner.agent_model %q does not match manifest agent.model %q", runner.AgentModel, agent.Model))
+	}
+	return issues
 }
 
 func (r *ArtifactResult) addIssue(code string, message string) {

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -1734,7 +1734,7 @@ func TestRequireSignedBlocksUnsignedArtifacts(t *testing.T) {
 	if evidence.Decision != "block" {
 		t.Fatalf("expected signed-evidence gate to block unsigned artifacts, got %s", evidence.Decision)
 	}
-	if !hasInvalidEvidence(evidence, "behavior-trace", "missing_signature_bundle") {
+	if !hasInvalidEvidence(evidence, "behavior-trace", "missing_evidence_bundle") {
 		t.Fatalf("expected unsigned behavior artifact to be invalid: %#v", evidence.InvalidEvidence)
 	}
 }
@@ -1784,6 +1784,8 @@ func TestRequireSignedRequiresArtifactBackedEvidence(t *testing.T) {
 
 func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
 	installFakeCosign(t, 0)
+	signerIdentity := "https://github.com/example/repo/.github/workflows/vouch.yml@refs/heads/main"
+	signerOIDCIssuer := "https://token.actions.githubusercontent.com"
 	spec := Spec{
 		Version:    SpecSchemaVersion,
 		ID:         "ui.copy",
@@ -1807,9 +1809,10 @@ func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
 			Kind:             kind,
 			Producer:         "ci",
 			Path:             path,
+			EvidenceBundle:   "artifacts/" + id + ".vouch-bundle.json",
 			SignatureBundle:  "artifacts/" + id + ".sigstore.json",
-			SignerIdentity:   "https://github.com/example/repo/.github/workflows/vouch.yml@refs/heads/main",
-			SignerOIDCIssuer: "https://token.actions.githubusercontent.com",
+			SignerIdentity:   signerIdentity,
+			SignerOIDCIssuer: signerOIDCIssuer,
 			ExitCode:         exitCode(0),
 			Obligations:      obligations,
 		}
@@ -1822,6 +1825,13 @@ func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
 			SpecsTouched:    []string{"ui.copy"},
 			BehaviorChanged: true,
 			ChangedFiles:    []string{"src/ui/copy.ts"},
+		},
+		Agent: Agent{
+			Name:             "codex",
+			RunID:            "run-signed",
+			Model:            "gpt-5.2",
+			RunnerIdentity:   signerIdentity,
+			RunnerOIDCIssuer: signerOIDCIssuer,
 		},
 		Verification: Verification{
 			Commands:    []string{"go test ./..."},
@@ -1849,6 +1859,10 @@ func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
 	for _, artifact := range []string{"behavior", "security", "tests", "runtime", "rollback"} {
 		writeArtifact(t, repo, "artifacts/"+artifact+".sigstore.json", `{"mediaType":"application/vnd.dev.sigstore.bundle+json"}`)
 	}
+	manifest := mustLoadManifest(t, manifestPath)
+	for _, artifact := range manifest.Verification.Artifacts {
+		writeEvidenceBundle(t, repo, artifact.EvidenceBundle, manifest, artifact, nil)
+	}
 	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: true})
 	if err != nil {
 		t.Fatal(err)
@@ -1860,6 +1874,49 @@ func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
 		if !result.SignatureVerified {
 			t.Fatalf("expected signature verification for artifact %s: %#v", result.ID, evidence.ArtifactResults)
 		}
+		if !result.BundleVerified || !result.HashVerified {
+			t.Fatalf("expected bundle/hash verification for artifact %s: %#v", result.ID, evidence.ArtifactResults)
+		}
+	}
+}
+
+func TestRequireSignedRejectsEvidenceBundleHashMismatch(t *testing.T) {
+	installFakeCosign(t, 0)
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, nil)
+	attachSignedBundles(t, repo, manifestPath, func(artifact EvidenceArtifact, bundle *EvidenceBundle) {
+		if artifact.ID == "behavior" {
+			bundle.Artifact.SHA256 = strings.Repeat("0", 64)
+		}
+	})
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected tampered bundle hash to block, got %s", evidence.Decision)
+	}
+	if !hasInvalidEvidence(evidence, "behavior", "evidence_bundle") {
+		t.Fatalf("expected behavior bundle to be invalid: %#v", evidence.InvalidEvidence)
+	}
+}
+
+func TestRequireSignedRejectsRunnerIdentityMismatch(t *testing.T) {
+	installFakeCosign(t, 0)
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, nil)
+	attachSignedBundles(t, repo, manifestPath, func(artifact EvidenceArtifact, bundle *EvidenceBundle) {
+		if artifact.ID == "behavior" {
+			bundle.Runner.Identity = "https://github.com/example/repo/.github/workflows/other.yml@refs/heads/main"
+		}
+	})
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected runner identity mismatch to block, got %s", evidence.Decision)
+	}
+	if !hasInvalidEvidence(evidence, "behavior", "evidence_bundle") {
+		t.Fatalf("expected behavior bundle to be invalid: %#v", evidence.InvalidEvidence)
 	}
 }
 
@@ -2068,6 +2125,32 @@ func writeFullyCoveredUIScenario(t *testing.T, extra func(map[ObligationKind]str
 	return repo, manifestPath, ids
 }
 
+func attachSignedBundles(t *testing.T, repo string, manifestPath string, mutate func(EvidenceArtifact, *EvidenceBundle)) {
+	t.Helper()
+	signerIdentity := "https://github.com/example/repo/.github/workflows/vouch.yml@refs/heads/main"
+	signerOIDCIssuer := "https://token.actions.githubusercontent.com"
+	manifest := mustLoadManifest(t, manifestPath)
+	manifest.Agent = Agent{
+		Name:             "codex",
+		RunID:            "run-signed",
+		Model:            "gpt-5.2",
+		RunnerIdentity:   signerIdentity,
+		RunnerOIDCIssuer: signerOIDCIssuer,
+	}
+	for i := range manifest.Verification.Artifacts {
+		id := manifest.Verification.Artifacts[i].ID
+		manifest.Verification.Artifacts[i].EvidenceBundle = "artifacts/" + id + ".vouch-bundle.json"
+		manifest.Verification.Artifacts[i].SignatureBundle = "artifacts/" + id + ".sigstore.json"
+		manifest.Verification.Artifacts[i].SignerIdentity = signerIdentity
+		manifest.Verification.Artifacts[i].SignerOIDCIssuer = signerOIDCIssuer
+	}
+	writeJSON(t, manifestPath, manifest)
+	for _, artifact := range manifest.Verification.Artifacts {
+		writeArtifact(t, repo, artifact.SignatureBundle, `{"mediaType":"application/vnd.dev.sigstore.bundle+json"}`)
+		writeEvidenceBundle(t, repo, artifact.EvidenceBundle, manifest, artifact, mutate)
+	}
+}
+
 func writeScenario(t *testing.T, spec Spec, manifest Manifest) (string, string) {
 	t.Helper()
 	repo := t.TempDir()
@@ -2106,6 +2189,47 @@ func writeArtifact(t *testing.T, repo string, relPath string, data string) {
 func writeVerifierOutputArtifact(t *testing.T, repo string, relPath string, output VerifierOutput) {
 	t.Helper()
 	data, err := json.MarshalIndent(output, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeArtifact(t, repo, relPath, string(append(data, '\n')))
+}
+
+func writeEvidenceBundle(t *testing.T, repo string, relPath string, manifest Manifest, artifact EvidenceArtifact, mutate func(EvidenceArtifact, *EvidenceBundle)) {
+	t.Helper()
+	artifactData := mustReadFile(t, filepath.Join(repo, artifact.Path))
+	exitCode := 0
+	if artifact.ExitCode != nil {
+		exitCode = *artifact.ExitCode
+	}
+	bundle := EvidenceBundle{
+		Version:      EvidenceBundleVersion,
+		ManifestID:   manifest.Task.ID,
+		SpecsTouched: append([]string(nil), manifest.Change.SpecsTouched...),
+		ChangeRisk:   manifest.Change.Risk,
+		Artifact: EvidenceBundleArtifact{
+			ID:          artifact.ID,
+			Kind:        artifact.Kind,
+			Path:        artifact.Path,
+			SHA256:      sha256Hex(artifactData),
+			Producer:    artifact.Producer,
+			Command:     artifact.Command,
+			ExitCode:    exitCode,
+			Obligations: append([]string(nil), artifact.Obligations...),
+		},
+		Runner: EvidenceBundleRunner{
+			Identity:   artifact.SignerIdentity,
+			OIDCIssuer: artifact.SignerOIDCIssuer,
+			AgentName:  manifest.Agent.Name,
+			AgentRunID: manifest.Agent.RunID,
+			AgentModel: manifest.Agent.Model,
+		},
+		Timestamp: "2026-05-07T00:00:00Z",
+	}
+	if mutate != nil {
+		mutate(artifact, &bundle)
+	}
+	data, err := json.MarshalIndent(bundle, "", "  ")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -269,6 +269,8 @@ type ManifestCreateOptions struct {
 	Agent            string
 	RunID            string
 	Model            string
+	RunnerIdentity   string
+	RunnerOIDCIssuer string
 	Base             string
 	Head             string
 	Risk             Risk
@@ -335,9 +337,11 @@ func CreateManifest(repo string, opts ManifestCreateOptions) (Manifest, error) {
 			ChangedFiles:     changedFiles,
 		},
 		Agent: Agent{
-			Name:  opts.Agent,
-			RunID: opts.RunID,
-			Model: opts.Model,
+			Name:             opts.Agent,
+			RunID:            opts.RunID,
+			Model:            opts.Model,
+			RunnerIdentity:   opts.RunnerIdentity,
+			RunnerOIDCIssuer: opts.RunnerOIDCIssuer,
 		},
 		Verification: Verification{
 			CoversBehavior: []string{},
@@ -378,6 +382,7 @@ type AttachArtifactOptions struct {
 	Command          string
 	ExitCode         int
 	SHA256           string
+	EvidenceBundle   string
 	SignatureBundle  string
 	SignerIdentity   string
 	SignerOIDCIssuer string
@@ -398,7 +403,7 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 	if opts.ExitCode != 0 {
 		return Manifest{}, EvidenceArtifact{}, fmt.Errorf("artifact exit code must be 0, got %d", opts.ExitCode)
 	}
-	if err := validateSignatureMetadata(opts.SignatureBundle, opts.SignerIdentity, opts.SignerOIDCIssuer); err != nil {
+	if err := validateSignatureMetadata(opts.EvidenceBundle, opts.SignatureBundle, opts.SignerIdentity, opts.SignerOIDCIssuer); err != nil {
 		return Manifest{}, EvidenceArtifact{}, err
 	}
 	artifactPath := opts.Path
@@ -409,7 +414,7 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 		if opts.SHA256 != "" {
 			return Manifest{}, EvidenceArtifact{}, errors.New("--sha256 cannot be combined with --test-map because the mapped JUnit artifact is generated")
 		}
-		if opts.SignatureBundle != "" || opts.SignerIdentity != "" || opts.SignerOIDCIssuer != "" {
+		if opts.EvidenceBundle != "" || opts.SignatureBundle != "" || opts.SignerIdentity != "" || opts.SignerOIDCIssuer != "" {
 			return Manifest{}, EvidenceArtifact{}, errors.New("signature metadata cannot be combined with --test-map because the mapped JUnit artifact is generated")
 		}
 		mappedPath := defaultMappedJUnitArtifactPath(opts.ID)
@@ -468,6 +473,7 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 		Command:          opts.Command,
 		Path:             artifactPath,
 		SHA256:           opts.SHA256,
+		EvidenceBundle:   opts.EvidenceBundle,
 		SignatureBundle:  opts.SignatureBundle,
 		SignerIdentity:   opts.SignerIdentity,
 		SignerOIDCIssuer: opts.SignerOIDCIssuer,
@@ -485,12 +491,12 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 	return manifest, artifact, nil
 }
 
-func validateSignatureMetadata(bundle string, identity string, issuer string) error {
-	if bundle == "" && identity == "" && issuer == "" {
+func validateSignatureMetadata(evidenceBundle string, signatureBundle string, identity string, issuer string) error {
+	if evidenceBundle == "" && signatureBundle == "" && identity == "" && issuer == "" {
 		return nil
 	}
-	if bundle == "" || identity == "" || issuer == "" {
-		return errors.New("signed artifacts require --signature-bundle, --signer-identity, and --signer-oidc-issuer together")
+	if evidenceBundle == "" || signatureBundle == "" || identity == "" || issuer == "" {
+		return errors.New("signed artifacts require --evidence-bundle, --signature-bundle, --signer-identity, and --signer-oidc-issuer together")
 	}
 	return nil
 }

--- a/internal/vouch/onboarding_test.go
+++ b/internal/vouch/onboarding_test.go
@@ -80,12 +80,14 @@ func TestContractCreateAndManifestCreateMapChangedFilesToOwnedSpec(t *testing.T)
 	spec := createSampleContract(t, repo, RiskHigh)
 
 	manifest, err := CreateManifest(repo, ManifestCreateOptions{
-		TaskID:       "agent-1",
-		Summary:      "change app service",
-		Agent:        "codex",
-		RunID:        "run-1",
-		ChangedFiles: []string{"src/app/service.py", "tests/test_app.py"},
-		Out:          ".vouch/manifests/agent-1.json",
+		TaskID:           "agent-1",
+		Summary:          "change app service",
+		Agent:            "codex",
+		RunID:            "run-1",
+		RunnerIdentity:   "https://github.com/example/repo/.github/workflows/vouch.yml@refs/heads/main",
+		RunnerOIDCIssuer: "https://token.actions.githubusercontent.com",
+		ChangedFiles:     []string{"src/app/service.py", "tests/test_app.py"},
+		Out:              ".vouch/manifests/agent-1.json",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -102,6 +104,9 @@ func TestContractCreateAndManifestCreateMapChangedFilesToOwnedSpec(t *testing.T)
 	loaded := mustLoadManifest(t, filepath.Join(repo, ".vouch", "manifests", "agent-1.json"))
 	if loaded.Task.ID != "agent-1" {
 		t.Fatalf("manifest was not written: %#v", loaded.Task)
+	}
+	if loaded.Agent.RunnerIdentity == "" || loaded.Agent.RunnerOIDCIssuer == "" {
+		t.Fatalf("manifest did not preserve runner identity: %#v", loaded.Agent)
 	}
 	errors := CompileManifestPipeline(mustLoadSpecs(t, repo), loaded).ManifestErrors
 	if len(errors) != 0 {

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -6,6 +6,7 @@ const (
 	SpecSchemaVersion       = "vouch.spec.v0"
 	ManifestSchemaVersion   = "vouch.manifest.v0"
 	EvidenceSchemaVersion   = "vouch.evidence.v0"
+	EvidenceBundleVersion   = "vouch.evidence_bundle.v0"
 	ASTSchemaVersion        = "vouch.ast.v0"
 	IRSchemaVersion         = "vouch.ir.v0"
 	PlanSchemaVersion       = "vouch.plan.v0"
@@ -215,9 +216,11 @@ type Change struct {
 }
 
 type Agent struct {
-	Name  string `json:"name"`
-	RunID string `json:"run_id"`
-	Model string `json:"model"`
+	Name             string `json:"name"`
+	RunID            string `json:"run_id"`
+	Model            string `json:"model"`
+	RunnerIdentity   string `json:"runner_identity,omitempty"`
+	RunnerOIDCIssuer string `json:"runner_oidc_issuer,omitempty"`
 }
 
 type Verification struct {
@@ -237,11 +240,41 @@ type EvidenceArtifact struct {
 	Command          string       `json:"command,omitempty"`
 	Path             string       `json:"path,omitempty"`
 	SHA256           string       `json:"sha256,omitempty"`
+	EvidenceBundle   string       `json:"evidence_bundle,omitempty"`
 	SignatureBundle  string       `json:"signature_bundle,omitempty"`
 	SignerIdentity   string       `json:"signer_identity,omitempty"`
 	SignerOIDCIssuer string       `json:"signer_oidc_issuer,omitempty"`
 	ExitCode         *int         `json:"exit_code"`
 	Obligations      []string     `json:"obligations"`
+}
+
+type EvidenceBundle struct {
+	Version      string                 `json:"version"`
+	ManifestID   string                 `json:"manifest_id"`
+	SpecsTouched []string               `json:"specs_touched"`
+	ChangeRisk   Risk                   `json:"change_risk"`
+	Artifact     EvidenceBundleArtifact `json:"artifact"`
+	Runner       EvidenceBundleRunner   `json:"runner"`
+	Timestamp    string                 `json:"timestamp"`
+}
+
+type EvidenceBundleArtifact struct {
+	ID          string       `json:"id"`
+	Kind        EvidenceKind `json:"kind"`
+	Path        string       `json:"path"`
+	SHA256      string       `json:"sha256"`
+	Producer    string       `json:"producer,omitempty"`
+	Command     string       `json:"command,omitempty"`
+	ExitCode    int          `json:"exit_code"`
+	Obligations []string     `json:"obligations"`
+}
+
+type EvidenceBundleRunner struct {
+	Identity   string `json:"identity"`
+	OIDCIssuer string `json:"oidc_issuer"`
+	AgentName  string `json:"agent_name,omitempty"`
+	AgentRunID string `json:"agent_run_id,omitempty"`
+	AgentModel string `json:"agent_model,omitempty"`
 }
 
 type TestResults struct {
@@ -400,6 +433,7 @@ type ArtifactResult struct {
 	ResolvedPath       string          `json:"resolved_path,omitempty"`
 	Status             string          `json:"status"`
 	HashVerified       bool            `json:"hash_verified"`
+	BundleVerified     bool            `json:"bundle_verified"`
 	SignatureVerified  bool            `json:"signature_verified"`
 	CoveredObligations []string        `json:"covered_obligations"`
 	VerifierOutput     *VerifierOutput `json:"-"`

--- a/internal/vouch/validate.go
+++ b/internal/vouch/validate.go
@@ -133,6 +133,10 @@ func validateArtifacts(artifacts []EvidenceArtifact) []string {
 				errors = append(errors, owner+" sha256 must be 64 hex characters")
 			}
 		}
+		hasSignedField := artifact.EvidenceBundle != "" || artifact.SignatureBundle != "" || artifact.SignerIdentity != "" || artifact.SignerOIDCIssuer != ""
+		if hasSignedField && (artifact.EvidenceBundle == "" || artifact.SignatureBundle == "" || artifact.SignerIdentity == "" || artifact.SignerOIDCIssuer == "") {
+			errors = append(errors, owner+" signed artifacts require evidence_bundle, signature_bundle, signer_identity, and signer_oidc_issuer together")
+		}
 		if len(artifact.Obligations) == 0 {
 			errors = append(errors, owner+" must reference at least one obligation")
 		}


### PR DESCRIPTION
## Summary
  - Add `vouch.evidence_bundle.v0` evidence bundles
  - Bind signed evidence to manifest task/specs/risk, artifact hash, obligation IDs, and runner identity
  - Verify cosign signatures over evidence bundles under `gate --require-signed`
  - Add runner identity fields to manifest agent metadata

  ## Tests
  - `go test -count=1 ./...`
  - `git diff --check`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json gate`
  - `go run ./cmd/vouch --repo demo_repo --manifest demo_repo/.vouch/manifests/pass.json gate --require-signed`