### PR TITLE
feat: enforce allowed evidence signers

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,19 @@ Signature fields are optional in beta. To attach signed evidence, first write a
 `vouch.evidence_bundle.v0` JSON file for the artifact. The bundle binds the
 manifest task, touched specs, artifact ID/kind/path/hash, covered obligation
 IDs, runner identity, and timestamp. Sign that evidence bundle with cosign, then
-include the bundle paths and expected identity when attaching the artifact:
+include the bundle paths and expected identity when attaching the artifact.
+The signer must also be listed in `.vouch/config.json`:
+
+```json
+{
+  "allowed_signers": [
+    {
+      "identity": "https://github.com/ORG/REPO/.github/workflows/vouch.yml@refs/heads/main",
+      "oidc_issuer": "https://token.actions.githubusercontent.com"
+    }
+  ]
+}
+```
 
 ```sh
 cosign sign-blob .vouch/artifacts/behavior.vouch-bundle.json \
@@ -245,7 +257,8 @@ vouch --repo /path/to/your/repo \
 using the artifact's `signature_bundle`, `signer_identity`, and
 `signer_oidc_issuer` fields. It also rejects bundles whose manifest identity,
 artifact hash, obligation IDs, runner identity, or runner OIDC issuer do not
-match the manifest and artifact being gated.
+match the manifest and artifact being gated, or whose signer is not present in
+`config.allowed_signers`.
 
 ### 7. Gate The Change
 
@@ -327,7 +340,7 @@ Today, Vouch can check:
 - Artifact paths stay inside the repo and files exist.
 - Artifact exit codes are present and zero.
 - Optional artifact SHA-256 values match file contents.
-- Optional `gate --require-signed` mode verifies signed `vouch.evidence_bundle.v0` files and binds manifest identity, artifact hashes, obligation IDs, runner identity, and expected signer metadata.
+- Optional `gate --require-signed` mode verifies signed `vouch.evidence_bundle.v0` files, binds manifest identity, artifact hashes, obligation IDs, and runner identity, and requires signer metadata to match `config.allowed_signers`.
 - Release policy is loaded from `.vouch/policy/release-policy.json` or an explicit `--policy` file.
 - Generated verifier packets pin prompt and output schema versions.
 - Structured `verifier_output` artifacts parse as `vouch.verifier_output.v0` and import pass/block findings into release policy.
@@ -346,7 +359,7 @@ Today, Vouch cannot check:
 - Whether tests were actually run unless the external runner preserves and signs the artifact chain.
 - Whether product intent was inferred correctly from code.
 - Whether release policy uses a general-purpose policy language such as Rego; the current policy evaluator is a small Vouch JSON rule engine.
-- Whether signer identities are authorized by an organization-level allowlist beyond the identities declared in the manifest artifacts.
+- Whether signer identities should vary by contract owner, path, or risk tier; the current allowlist is repo-level.
 
 ## Validation Status
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -218,11 +218,12 @@ Implemented base:
 - Detached signatures over Vouch evidence bundles.
 - Hardened `gate --require-signed` mode that binds manifest, artifact hashes, and obligation IDs.
 - Tamper-evident evidence bundles.
+- Repo-level allowed signer policy in `.vouch/config.json`.
 - Agent identity and run provenance in bundle validation.
 
 Remaining work:
 
-- Allowed signer policy for contracts or repo policy.
+- Contract- or path-scoped allowed signer policy.
 - Canonical JSON serialization rules for evidence bundles.
 - Signed specs and manifests.
 - Role-based approval exceptions.
@@ -234,7 +235,8 @@ Remaining work:
 
 The next useful contributions are:
 
-- Allowed signer policy for contracts or repo policy.
+- Contract- or path-scoped allowed signer policy.
+- Canonical JSON serialization rules for evidence bundles.
 - Signed specs and manifests.
 - Rego policy adapter decision spike.
 - Reference workflow for `init -> manifest -> pytest -> junit map -> attach -> gate`.

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -33,6 +33,7 @@ func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEv
 	if err != nil {
 		return Evidence{}, err
 	}
+	config := LoadConfigOrDefault(absRepo)
 	pipeline := CompileManifestPipeline(specs, manifest)
 	evidence := Evidence{
 		Version:                EvidenceSchemaVersion,
@@ -63,7 +64,10 @@ func CollectEvidenceWithOptions(repo string, manifestPath string, opts CollectEv
 		Reasons:                []string{},
 	}
 	obligationIndex := NewObligationIndex(evidence.VerificationPlans)
-	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{RequireSigned: opts.RequireSigned})
+	evidence.ArtifactResults, evidence.InvalidEvidence = LinkEvidenceArtifacts(absRepo, manifest, manifest.Verification.Artifacts, obligationIndex, ArtifactLinkOptions{
+		RequireSigned:  opts.RequireSigned,
+		AllowedSigners: config.AllowedSigners,
+	})
 	buildCoverage(&evidence)
 	runVerifiers(&evidence)
 	importVerifierFindings(&evidence)

--- a/internal/vouch/evidence_artifacts.go
+++ b/internal/vouch/evidence_artifacts.go
@@ -20,7 +20,8 @@ type ObligationIndex struct {
 }
 
 type ArtifactLinkOptions struct {
-	RequireSigned bool
+	RequireSigned  bool
+	AllowedSigners []AllowedSigner
 }
 
 func NewObligationIndex(plans map[string]VerificationPlan) ObligationIndex {
@@ -88,7 +89,7 @@ func LinkEvidenceArtifacts(repo string, manifest Manifest, artifacts []EvidenceA
 		}
 
 		if opts.RequireSigned && len(data) > 0 {
-			verifySignedEvidenceBundle(repo, manifest, artifact, data, &result)
+			verifySignedEvidenceBundle(repo, manifest, artifact, data, opts.AllowedSigners, &result)
 		}
 
 		if artifact.Kind == EvidenceVerifierOutput {
@@ -139,7 +140,7 @@ func LinkEvidenceArtifacts(repo string, manifest Manifest, artifacts []EvidenceA
 	return results, invalid
 }
 
-func verifySignedEvidenceBundle(repo string, manifest Manifest, artifact EvidenceArtifact, artifactData []byte, result *ArtifactResult) {
+func verifySignedEvidenceBundle(repo string, manifest Manifest, artifact EvidenceArtifact, artifactData []byte, allowedSigners []AllowedSigner, result *ArtifactResult) {
 	if artifact.EvidenceBundle == "" {
 		result.addIssue("missing_evidence_bundle", "evidence_bundle is required when signed evidence is enforced")
 		return
@@ -154,6 +155,14 @@ func verifySignedEvidenceBundle(repo string, manifest Manifest, artifact Evidenc
 	}
 	if artifact.SignerOIDCIssuer == "" {
 		result.addIssue("missing_signer_oidc_issuer", "signer_oidc_issuer is required when signed evidence is enforced")
+		return
+	}
+	if len(allowedSigners) == 0 {
+		result.addIssue("missing_allowed_signers", "config.allowed_signers must list accepted runner identities when signed evidence is enforced")
+		return
+	}
+	if !signerAllowed(allowedSigners, artifact.SignerIdentity, artifact.SignerOIDCIssuer) {
+		result.addIssue("signer_not_allowed", fmt.Sprintf("signer %q with issuer %q is not allowed by config.allowed_signers", artifact.SignerIdentity, artifact.SignerOIDCIssuer))
 		return
 	}
 	evidenceBundlePath, err := resolveArtifactPath(repo, artifact.EvidenceBundle)
@@ -213,6 +222,15 @@ func verifySignedEvidenceBundle(repo string, manifest Manifest, artifact Evidenc
 		return
 	}
 	result.SignatureVerified = true
+}
+
+func signerAllowed(allowed []AllowedSigner, identity string, issuer string) bool {
+	for _, signer := range allowed {
+		if signer.Identity == identity && signer.OIDCIssuer == issuer {
+			return true
+		}
+	}
+	return false
 }
 
 func importEvidenceBundle(data []byte) (EvidenceBundle, []string) {

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -1847,6 +1847,7 @@ func TestRequireSignedAcceptsCosignVerifiedArtifacts(t *testing.T) {
 		Runtime:  ManifestRuntime{Metrics: []string{"ui.rendered"}},
 		Rollback: ManifestRollback{Strategy: "revert_commit"},
 	})
+	writeAllowedSigners(t, repo, signerIdentity, signerOIDCIssuer)
 	writeArtifact(t, repo, "artifacts/behavior.json", `{"status":"pass","obligations":["`+behaviorID+`"]}`)
 	writeArtifact(t, repo, "artifacts/security.json", `{"status":"pass","obligations":["`+securityID+`"]}`)
 	writeArtifact(t, repo, "artifacts/runtime.json", `{"status":"pass","obligations":["`+runtimeID+`"]}`)
@@ -1917,6 +1918,23 @@ func TestRequireSignedRejectsRunnerIdentityMismatch(t *testing.T) {
 	}
 	if !hasInvalidEvidence(evidence, "behavior", "evidence_bundle") {
 		t.Fatalf("expected behavior bundle to be invalid: %#v", evidence.InvalidEvidence)
+	}
+}
+
+func TestRequireSignedRejectsSignerOutsideRepoAllowlist(t *testing.T) {
+	installFakeCosign(t, 0)
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, nil)
+	attachSignedBundles(t, repo, manifestPath, nil)
+	writeAllowedSigners(t, repo, "https://github.com/example/repo/.github/workflows/other.yml@refs/heads/main", "https://token.actions.githubusercontent.com")
+	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected signer outside allowlist to block, got %s", evidence.Decision)
+	}
+	if !hasInvalidEvidence(evidence, "behavior", "signer_not_allowed") {
+		t.Fatalf("expected behavior signer to be rejected: %#v", evidence.InvalidEvidence)
 	}
 }
 
@@ -2129,6 +2147,7 @@ func attachSignedBundles(t *testing.T, repo string, manifestPath string, mutate 
 	t.Helper()
 	signerIdentity := "https://github.com/example/repo/.github/workflows/vouch.yml@refs/heads/main"
 	signerOIDCIssuer := "https://token.actions.githubusercontent.com"
+	writeAllowedSigners(t, repo, signerIdentity, signerOIDCIssuer)
 	manifest := mustLoadManifest(t, manifestPath)
 	manifest.Agent = Agent{
 		Name:             "codex",
@@ -2149,6 +2168,20 @@ func attachSignedBundles(t *testing.T, repo string, manifestPath string, mutate 
 		writeArtifact(t, repo, artifact.SignatureBundle, `{"mediaType":"application/vnd.dev.sigstore.bundle+json"}`)
 		writeEvidenceBundle(t, repo, artifact.EvidenceBundle, manifest, artifact, mutate)
 	}
+}
+
+func writeAllowedSigners(t *testing.T, repo string, identity string, issuer string) {
+	t.Helper()
+	config := LoadConfigOrDefault(repo)
+	config.AllowedSigners = []AllowedSigner{{
+		Identity:   identity,
+		OIDCIssuer: issuer,
+	}}
+	configPath := filepath.Join(repo, ".vouch", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeJSON(t, configPath, config)
 }
 
 func writeScenario(t *testing.T, spec Spec, manifest Manifest) (string, string) {

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -36,12 +36,13 @@ func DefaultConfig(repo string) Config {
 	profiles := DetectProfiles(repo)
 	commands := DetectCommands(repo, profiles)
 	return Config{
-		Version:     ConfigSchemaVersion,
-		Profiles:    profiles,
-		Commands:    commands,
-		ArtifactDir: ".vouch/artifacts",
-		ManifestDir: ".vouch/manifests",
-		BuildDir:    ".vouch/build",
+		Version:        ConfigSchemaVersion,
+		Profiles:       profiles,
+		Commands:       commands,
+		ArtifactDir:    ".vouch/artifacts",
+		ManifestDir:    ".vouch/manifests",
+		BuildDir:       ".vouch/build",
+		AllowedSigners: []AllowedSigner{},
 		IgnoredPaths: []string{
 			".git/**",
 			".vouch/artifacts/**",

--- a/internal/vouch/onboarding_test.go
+++ b/internal/vouch/onboarding_test.go
@@ -40,6 +40,9 @@ test = { cmd = "pytest" }
 	if config.Version != ConfigSchemaVersion {
 		t.Fatalf("unexpected config version %s", config.Version)
 	}
+	if config.AllowedSigners == nil {
+		t.Fatalf("expected allowed_signers to render as an array, got nil")
+	}
 	if !contains(config.Commands, "fyn run pytest --junitxml .vouch/artifacts/junit.xml") {
 		t.Fatalf("expected pytest command, got %#v", config.Commands)
 	}

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -465,13 +465,14 @@ type GateResult struct {
 }
 
 type Config struct {
-	Version      string   `json:"version"`
-	Profiles     []string `json:"profiles"`
-	Commands     []string `json:"commands"`
-	ArtifactDir  string   `json:"artifact_dir"`
-	ManifestDir  string   `json:"manifest_dir"`
-	BuildDir     string   `json:"build_dir"`
-	IgnoredPaths []string `json:"ignored_paths"`
+	Version        string          `json:"version"`
+	Profiles       []string        `json:"profiles"`
+	Commands       []string        `json:"commands"`
+	ArtifactDir    string          `json:"artifact_dir"`
+	ManifestDir    string          `json:"manifest_dir"`
+	BuildDir       string          `json:"build_dir"`
+	IgnoredPaths   []string        `json:"ignored_paths"`
+	AllowedSigners []AllowedSigner `json:"allowed_signers"`
 }
 
 type InitResult struct {
@@ -482,6 +483,11 @@ type InitResult struct {
 	Commands    []string `json:"commands"`
 	CreatedDirs []string `json:"created_dirs"`
 	Created     bool     `json:"created"`
+}
+
+type AllowedSigner struct {
+	Identity   string `json:"identity"`
+	OIDCIssuer string `json:"oidc_issuer"`
 }
 
 type ContractSuggestion struct {


### PR DESCRIPTION
## Summary
  - Add repo-level `config.allowed_signers`
  - Require signed evidence signer identity and OIDC issuer to match the repo allowlist under `gate --require-signed`
  - Reject signed evidence when the manifest-declared signer is not allowed
  - Keep path-scoped signer policy and signed manifests as remaining trust work

  ## Tests
  - `go test -count=1 ./...`
  - `git diff --check`