### PR TITLE
feat: add conservative contract bootstrap

### DIFF
--- a/internal/vouch/bootstrap/ci.go
+++ b/internal/vouch/bootstrap/ci.go
@@ -1,0 +1,16 @@
+package bootstrap
+
+import "strings"
+
+func isWorkflowFile(path string) bool {
+	return strings.HasPrefix(path, ".github/workflows/") && (strings.HasSuffix(path, ".yml") || strings.HasSuffix(path, ".yaml"))
+}
+
+func isOpenAPIFile(path string) bool {
+	base := slashBase(path)
+	return base == "openapi.yaml" || base == "openapi.yml" || base == "swagger.yaml" || base == "swagger.yml"
+}
+
+func isCoverageFile(path string) bool {
+	return slashBase(path) == "coverage.xml"
+}

--- a/internal/vouch/bootstrap/generator.go
+++ b/internal/vouch/bootstrap/generator.go
@@ -1,0 +1,259 @@
+package bootstrap
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func Run(repo string, opts Options) (Result, error) {
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return Result{}, err
+	}
+	signals, err := scan(absRepo, opts.Aggressive)
+	if err != nil {
+		return Result{}, err
+	}
+	result := Result{
+		Version: Version,
+		Repo:    absRepo,
+		Mode:    modeName(opts),
+		Check:   opts.Check,
+		Drafts:  draftsFromSignals(signals, opts),
+	}
+	for i := range result.Drafts {
+		result.Drafts[i].IntentPath = filepath.ToSlash(filepath.Join(".vouch", "intents", result.Drafts[i].Component+".yaml"))
+	}
+	result.NeedsWrite = needsWrite(absRepo, result)
+	if !opts.DryRun && !opts.Check {
+		wrote, err := writeResult(absRepo, result)
+		if err != nil {
+			return Result{}, err
+		}
+		result.Wrote = wrote
+		result.ReportPath = filepath.ToSlash(filepath.Join(".vouch", "build", "bootstrap-report.json"))
+		result.NeedsWrite = false
+	}
+	return result, nil
+}
+
+func draftsFromSignals(signals []Signal, opts Options) []Draft {
+	grouped := make(map[string][]Signal)
+	for _, signal := range signals {
+		component := componentForSignal(signal)
+		if component == "" || component == "repo" {
+			continue
+		}
+		grouped[component] = append(grouped[component], signal)
+	}
+	drafts := make([]Draft, 0, len(grouped))
+	for _, component := range sortedKeys(grouped) {
+		signals := grouped[component]
+		if !opts.Aggressive && !hasSignalType(signals, "test") {
+			continue
+		}
+		draft := Draft{
+			Component: component,
+			Owner:     ownerFromSignals(signals),
+			Risk:      riskFromSignals(component, signals),
+			Paths:     pathsFromSignals(component, signals),
+			Signals:   signals,
+		}
+		draft.Obligations = obligationsForDraft(draft, opts)
+		if len(draft.Obligations) == 0 {
+			continue
+		}
+		drafts = append(drafts, draft)
+	}
+	return drafts
+}
+
+func obligationsForDraft(draft Draft, opts Options) []Obligation {
+	var obligations []Obligation
+	limit := 2
+	if opts.Aggressive {
+		limit = 5
+	}
+	for _, signal := range draft.Signals {
+		if signal.Type != "test" || signal.Symbol == "" {
+			continue
+		}
+		label := testLabel(signal.Symbol)
+		obligations = append(obligations, Obligation{
+			ID:          draft.Component + ".required_test." + slug(label),
+			Kind:        "required_test",
+			Description: label,
+			Generated:   generated(signal),
+		})
+		if len(obligations) >= limit {
+			break
+		}
+	}
+	if draft.Risk == "high" && len(obligations) > 0 {
+		source := firstSource(draft.Signals)
+		obligations = append(obligations, Obligation{
+			ID:          draft.Component + ".security.security_sensitive_change_reviewed",
+			Kind:        "security",
+			Description: "security-sensitive changes require explicit evidence",
+			Generated:   generated(source),
+		})
+	}
+	return uniqueObligations(obligations)
+}
+
+func generated(signal Signal) Generated {
+	return Generated{
+		By:         "vouch.bootstrap",
+		Mode:       "deterministic",
+		Confidence: "high",
+		Source: SignalSource{
+			Type:   signal.Type,
+			File:   signal.File,
+			Symbol: signal.Symbol,
+			Detail: signal.Detail,
+		},
+	}
+}
+
+func componentForSignal(signal Signal) string {
+	path := signal.File
+	if path == "" {
+		return ""
+	}
+	parts := strings.Split(path, "/")
+	if len(parts) == 0 {
+		return ""
+	}
+	if parts[0] == "tests" {
+		return componentFromTestPath(parts)
+	}
+	return componentFromPath(parts)
+}
+
+func componentFromTestPath(parts []string) string {
+	if len(parts) == 1 {
+		return strings.TrimSuffix(strings.TrimPrefix(parts[0], "test_"), filepath.Ext(parts[0]))
+	}
+	base := strings.TrimSuffix(parts[len(parts)-1], filepath.Ext(parts[len(parts)-1]))
+	base = strings.TrimPrefix(base, "test_")
+	componentParts := append([]string{}, parts[1:len(parts)-1]...)
+	if base != "" && base != "test" {
+		componentParts = append(componentParts, base)
+	}
+	return cleanComponent(componentParts)
+}
+
+func componentFromPath(parts []string) string {
+	filtered := make([]string, 0, len(parts))
+	for _, part := range parts {
+		switch part {
+		case "internal", "src", "pkg", "lib", "app":
+			continue
+		default:
+			filtered = append(filtered, part)
+		}
+	}
+	if len(filtered) == 0 {
+		return ""
+	}
+	last := filtered[len(filtered)-1]
+	filtered[len(filtered)-1] = strings.TrimSuffix(last, filepath.Ext(last))
+	return cleanComponent(filtered)
+}
+
+func cleanComponent(parts []string) string {
+	cleaned := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = slug(part)
+		if part != "" && part != "test" {
+			cleaned = append(cleaned, part)
+		}
+	}
+	if len(cleaned) == 0 {
+		return ""
+	}
+	if len(cleaned) > 2 {
+		cleaned = cleaned[len(cleaned)-2:]
+	}
+	return strings.Join(cleaned, ".")
+}
+
+func ownerFromSignals(signals []Signal) string {
+	for _, signal := range signals {
+		if signal.Type == "owner" && signal.Detail != "" {
+			return signal.Detail
+		}
+	}
+	return "unowned"
+}
+
+func riskFromSignals(component string, signals []Signal) string {
+	risks := []string{riskFor(component)}
+	for _, signal := range signals {
+		risks = append(risks, signal.Risk)
+	}
+	return maxRisk(risks...)
+}
+
+func pathsFromSignals(component string, signals []Signal) []string {
+	paths := []string{}
+	for _, signal := range signals {
+		if signal.File == "" {
+			continue
+		}
+		if signal.Type == "test" {
+			paths = append(paths, signal.File)
+			paths = append(paths, guessedOwnedPath(component, signal.File))
+		}
+		if signal.Type == "path" {
+			paths = append(paths, signal.File)
+		}
+	}
+	return unique(paths)
+}
+
+func hasSignalType(signals []Signal, signalType string) bool {
+	for _, signal := range signals {
+		if signal.Type == signalType {
+			return true
+		}
+	}
+	return false
+}
+
+func guessedOwnedPath(component string, testFile string) string {
+	parts := strings.Split(component, ".")
+	if len(parts) == 0 {
+		return testFile
+	}
+	return filepath.ToSlash(filepath.Join("**", filepath.Join(parts...), "*"))
+}
+
+func uniqueObligations(values []Obligation) []Obligation {
+	seen := make(map[string]bool, len(values))
+	var out []Obligation
+	for _, value := range values {
+		if value.ID == "" || seen[value.ID] {
+			continue
+		}
+		seen[value.ID] = true
+		out = append(out, value)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out
+}
+
+func firstSource(signals []Signal) Signal {
+	if len(signals) == 0 {
+		return Signal{Type: "path"}
+	}
+	return signals[0]
+}
+
+func modeName(opts Options) string {
+	if opts.Aggressive {
+		return "aggressive"
+	}
+	return "conservative"
+}

--- a/internal/vouch/bootstrap/owners.go
+++ b/internal/vouch/bootstrap/owners.go
@@ -1,0 +1,67 @@
+package bootstrap
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type ownerRule struct {
+	Pattern string
+	Owners  []string
+}
+
+func loadOwners(repo string) []ownerRule {
+	var rules []ownerRule
+	for _, name := range []string{"CODEOWNERS", ".github/CODEOWNERS", "docs/CODEOWNERS"} {
+		data, err := os.ReadFile(filepath.Join(repo, filepath.FromSlash(name)))
+		if err == nil {
+			rules = append(rules, parseOwners(string(data))...)
+		}
+	}
+	return rules
+}
+
+func parseOwners(data string) []ownerRule {
+	var rules []ownerRule
+	for _, line := range strings.Split(data, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		rules = append(rules, ownerRule{Pattern: fields[0], Owners: fields[1:]})
+	}
+	return rules
+}
+
+func ownerForPath(rules []ownerRule, relPath string) string {
+	for i := len(rules) - 1; i >= 0; i-- {
+		if ownerPatternMatches(rules[i].Pattern, relPath) && len(rules[i].Owners) > 0 {
+			return strings.TrimPrefix(rules[i].Owners[0], "@")
+		}
+	}
+	return "unowned"
+}
+
+func ownerPatternMatches(pattern string, relPath string) bool {
+	pattern = strings.TrimPrefix(filepath.ToSlash(pattern), "/")
+	relPath = filepath.ToSlash(relPath)
+	if strings.HasSuffix(pattern, "/**") {
+		return strings.HasPrefix(relPath, strings.TrimSuffix(pattern, "**"))
+	}
+	if strings.HasSuffix(pattern, "/") {
+		return strings.HasPrefix(relPath, pattern)
+	}
+	if strings.ContainsAny(pattern, "*?[") {
+		matched, err := path.Match(pattern, relPath)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return relPath == pattern || strings.HasPrefix(relPath, strings.TrimSuffix(pattern, "/")+"/")
+}

--- a/internal/vouch/bootstrap/report.go
+++ b/internal/vouch/bootstrap/report.go
@@ -1,0 +1,78 @@
+package bootstrap
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func RenderText(result Result) string {
+	var b strings.Builder
+	if len(result.Drafts) == 0 {
+		b.WriteString("Detected 0 contract drafts.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Detected %d contract drafts:\n\n", len(result.Drafts))
+	for _, draft := range result.Drafts {
+		fmt.Fprintf(&b, "%s %s\n", strings.ToUpper(draft.Risk), draft.Component)
+		b.WriteString("  paths:\n")
+		for _, path := range draft.Paths {
+			fmt.Fprintf(&b, "    %s\n", path)
+		}
+		b.WriteString("  signals:\n")
+		for _, signal := range conciseSignals(draft.Signals) {
+			if signal.Symbol != "" {
+				fmt.Fprintf(&b, "    %s: %s::%s\n", signal.Type, signal.File, signal.Symbol)
+			} else if signal.Detail != "" {
+				fmt.Fprintf(&b, "    %s: %s\n", signal.Type, signal.Detail)
+			} else {
+				fmt.Fprintf(&b, "    %s: %s\n", signal.Type, signal.File)
+			}
+		}
+		b.WriteString("  drafted obligations:\n")
+		for _, obligation := range draft.Obligations {
+			shortID := strings.TrimPrefix(obligation.ID, draft.Component+".")
+			fmt.Fprintf(&b, "    %s\n", shortID)
+			if obligation.Generated.Source.File != "" {
+				fmt.Fprintf(&b, "      from %s", obligation.Generated.Source.File)
+				if obligation.Generated.Source.Symbol != "" {
+					fmt.Fprintf(&b, "::%s", obligation.Generated.Source.Symbol)
+				}
+				b.WriteByte('\n')
+			}
+		}
+		b.WriteByte('\n')
+	}
+	if len(result.Wrote) > 0 {
+		b.WriteString("Wrote:\n")
+		for _, path := range result.Wrote {
+			fmt.Fprintf(&b, "  %s\n", path)
+		}
+	}
+	if result.Check && result.NeedsWrite {
+		b.WriteString("Bootstrap check failed: generated drafts are not up to date.\n")
+	}
+	return b.String()
+}
+
+func conciseSignals(signals []Signal) []Signal {
+	filtered := make([]Signal, 0, len(signals))
+	for _, signal := range signals {
+		if signal.Type == "test" || signal.Type == "owner" || signal.Type == "openapi" || signal.Type == "ci" {
+			filtered = append(filtered, signal)
+		}
+	}
+	sort.Slice(filtered, func(i, j int) bool {
+		if filtered[i].Type == filtered[j].Type {
+			if filtered[i].File == filtered[j].File {
+				return filtered[i].Symbol < filtered[j].Symbol
+			}
+			return filtered[i].File < filtered[j].File
+		}
+		return filtered[i].Type < filtered[j].Type
+	})
+	if len(filtered) > 5 {
+		return filtered[:5]
+	}
+	return filtered
+}

--- a/internal/vouch/bootstrap/risk.go
+++ b/internal/vouch/bootstrap/risk.go
@@ -1,0 +1,45 @@
+package bootstrap
+
+import "strings"
+
+func riskFor(values ...string) string {
+	joined := strings.ToLower(strings.Join(values, "/"))
+	switch {
+	case containsAny(joined, "auth", "login", "password", "session", "token", "jwt", "oauth"):
+		return "high"
+	case containsAny(joined, "payment", "billing", "checkout", "stripe", "invoice"):
+		return "high"
+	case containsAny(joined, "admin", "role", "permission", "rbac"):
+		return "high"
+	case containsAny(joined, "secret", "key", "credential", "vault"):
+		return "high"
+	case containsAny(joined, "migration", "schema", "database", "db"):
+		return "medium"
+	case containsAny(joined, "api", "route", "handler", "controller"):
+		return "medium"
+	case containsAny(joined, "docs", "static", "css", "readme"):
+		return "low"
+	default:
+		return "medium"
+	}
+}
+
+func maxRisk(values ...string) string {
+	rank := map[string]int{"low": 0, "medium": 1, "high": 2, "critical": 3}
+	out := "low"
+	for _, value := range values {
+		if rank[value] > rank[out] {
+			out = value
+		}
+	}
+	return out
+}
+
+func containsAny(value string, needles ...string) bool {
+	for _, needle := range needles {
+		if strings.Contains(value, needle) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/vouch/bootstrap/scanner.go
+++ b/internal/vouch/bootstrap/scanner.go
@@ -1,0 +1,89 @@
+package bootstrap
+
+import (
+	"io/fs"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func scan(repo string, aggressive bool) ([]Signal, error) {
+	owners := loadOwners(repo)
+	var signals []Signal
+	err := filepath.WalkDir(repo, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(repo, path)
+		if err != nil {
+			return err
+		}
+		rel = filepath.ToSlash(rel)
+		if rel == "." {
+			return nil
+		}
+		if entry.IsDir() {
+			if skipDir(rel) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		switch {
+		case isTestFile(rel):
+			for _, symbol := range testSymbols(path, rel) {
+				signals = append(signals, Signal{
+					Type:   "test",
+					File:   rel,
+					Symbol: symbol,
+					Risk:   riskFor(rel, symbol),
+				})
+			}
+		case isWorkflowFile(rel):
+			signals = append(signals, Signal{Type: "ci", File: rel, Detail: "github workflow", Risk: "low"})
+		case isOpenAPIFile(rel):
+			signals = append(signals, Signal{Type: "openapi", File: rel, Detail: "api contract", Risk: riskFor(rel, "api")})
+		case isCoverageFile(rel):
+			signals = append(signals, Signal{Type: "coverage", File: rel, Detail: "coverage xml", Risk: "low"})
+		case sourceLike(rel):
+			signals = append(signals, Signal{Type: "path", File: rel, Detail: "source path", Risk: riskFor(rel)})
+		}
+		if owner := ownerForPath(owners, rel); owner != "unowned" {
+			signals = append(signals, Signal{Type: "owner", File: rel, Detail: owner, Risk: "low"})
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	sort.Slice(signals, func(i, j int) bool {
+		if signals[i].File == signals[j].File {
+			if signals[i].Type == signals[j].Type {
+				return signals[i].Symbol < signals[j].Symbol
+			}
+			return signals[i].Type < signals[j].Type
+		}
+		return signals[i].File < signals[j].File
+	})
+	return signals, nil
+}
+
+func skipDir(path string) bool {
+	switch path {
+	case ".git", ".vouch", "node_modules", "vendor", "dist", "build", "target":
+		return true
+	default:
+		return strings.HasPrefix(path, ".git/") || strings.HasPrefix(path, ".vouch/")
+	}
+}
+
+func sourceLike(path string) bool {
+	if isTestFile(path) {
+		return false
+	}
+	switch filepath.Ext(path) {
+	case ".go", ".py", ".ts", ".tsx", ".js", ".jsx", ".rs":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/vouch/bootstrap/signals.go
+++ b/internal/vouch/bootstrap/signals.go
@@ -1,0 +1,61 @@
+package bootstrap
+
+const (
+	Version = "vouch.bootstrap_report.v0"
+)
+
+type Options struct {
+	DryRun     bool
+	Check      bool
+	Aggressive bool
+}
+
+type Result struct {
+	Version    string   `json:"version"`
+	Repo       string   `json:"repo"`
+	Mode       string   `json:"mode"`
+	Drafts     []Draft  `json:"drafts"`
+	Wrote      []string `json:"wrote"`
+	ReportPath string   `json:"report_path,omitempty"`
+	NeedsWrite bool     `json:"needs_write"`
+	Check      bool     `json:"check,omitempty"`
+}
+
+type Draft struct {
+	Component   string       `json:"component"`
+	Owner       string       `json:"owner"`
+	Risk        string       `json:"risk"`
+	Paths       []string     `json:"paths"`
+	Signals     []Signal     `json:"signals"`
+	Obligations []Obligation `json:"obligations"`
+	IntentPath  string       `json:"intent_path"`
+}
+
+type Signal struct {
+	Type   string `json:"type"`
+	File   string `json:"file,omitempty"`
+	Symbol string `json:"symbol,omitempty"`
+	Detail string `json:"detail,omitempty"`
+	Risk   string `json:"risk,omitempty"`
+}
+
+type Obligation struct {
+	ID          string    `json:"id"`
+	Kind        string    `json:"kind"`
+	Description string    `json:"description"`
+	Generated   Generated `json:"generated"`
+}
+
+type Generated struct {
+	By         string       `json:"by"`
+	Mode       string       `json:"mode"`
+	Confidence string       `json:"confidence"`
+	Source     SignalSource `json:"source"`
+}
+
+type SignalSource struct {
+	Type   string `json:"type"`
+	File   string `json:"file,omitempty"`
+	Symbol string `json:"symbol,omitempty"`
+	Detail string `json:"detail,omitempty"`
+}

--- a/internal/vouch/bootstrap/tests.go
+++ b/internal/vouch/bootstrap/tests.go
@@ -1,0 +1,61 @@
+package bootstrap
+
+import (
+	"os"
+	"regexp"
+	"strings"
+)
+
+var (
+	pythonTestPattern = regexp.MustCompile(`(?m)^\s*def\s+(test_[A-Za-z0-9_]+)\s*\(`)
+	goTestPattern     = regexp.MustCompile(`(?m)^\s*func\s+(Test[A-Za-z0-9_]+)\s*\(`)
+	jsTestPattern     = regexp.MustCompile(`(?m)\b(?:it|test)\s*\(\s*["']([^"']+)["']`)
+)
+
+func isTestFile(path string) bool {
+	base := slashBase(path)
+	return strings.HasPrefix(path, "tests/") ||
+		strings.HasSuffix(base, "_test.go") ||
+		(strings.HasPrefix(base, "test_") && strings.HasSuffix(base, ".py")) ||
+		strings.HasSuffix(base, ".test.ts") ||
+		strings.HasSuffix(base, ".spec.ts")
+}
+
+func testSymbols(absPath string, relPath string) []string {
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		return nil
+	}
+	var matches [][]string
+	switch {
+	case strings.HasSuffix(relPath, ".py"):
+		matches = pythonTestPattern.FindAllStringSubmatch(string(data), -1)
+	case strings.HasSuffix(relPath, ".go"):
+		matches = goTestPattern.FindAllStringSubmatch(string(data), -1)
+	case strings.HasSuffix(relPath, ".ts"):
+		matches = jsTestPattern.FindAllStringSubmatch(string(data), -1)
+	}
+	symbols := make([]string, 0, len(matches))
+	for _, match := range matches {
+		if len(match) > 1 && strings.TrimSpace(match[1]) != "" {
+			symbols = append(symbols, strings.TrimSpace(match[1]))
+		}
+	}
+	if len(symbols) == 0 && isTestFile(relPath) {
+		return []string{strings.TrimSuffix(slashBase(relPath), slashExt(relPath))}
+	}
+	return unique(symbols)
+}
+
+func testLabel(symbol string) string {
+	label := symbol
+	label = strings.TrimPrefix(label, "test_")
+	label = strings.TrimPrefix(label, "Test")
+	label = strings.ReplaceAll(label, "_", " ")
+	label = splitCamel(label)
+	label = strings.ToLower(strings.TrimSpace(label))
+	if label == "" {
+		return "required test"
+	}
+	return label
+}

--- a/internal/vouch/bootstrap/utils.go
+++ b/internal/vouch/bootstrap/utils.go
@@ -1,0 +1,70 @@
+package bootstrap
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+func sortedKeys[V any](items map[string]V) []string {
+	keys := make([]string, 0, len(items))
+	for key := range items {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func unique(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	var out []string
+	for _, value := range values {
+		value = strings.TrimSpace(filepath.ToSlash(value))
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func slug(value string) string {
+	value = strings.TrimSpace(strings.ToLower(value))
+	var b strings.Builder
+	previousUnderscore := false
+	for _, r := range value {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			previousUnderscore = false
+			continue
+		}
+		if !previousUnderscore {
+			b.WriteByte('_')
+			previousUnderscore = true
+		}
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func splitCamel(value string) string {
+	var b strings.Builder
+	for i, r := range value {
+		if i > 0 && unicode.IsUpper(r) {
+			b.WriteByte(' ')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func slashBase(path string) string {
+	parts := strings.Split(filepath.ToSlash(path), "/")
+	return parts[len(parts)-1]
+}
+
+func slashExt(path string) string {
+	return filepath.Ext(filepath.ToSlash(path))
+}

--- a/internal/vouch/bootstrap/writer.go
+++ b/internal/vouch/bootstrap/writer.go
@@ -1,0 +1,168 @@
+package bootstrap
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func writeResult(repo string, result Result) ([]string, error) {
+	var wrote []string
+	for _, draft := range result.Drafts {
+		path := filepath.Join(repo, filepath.FromSlash(draft.IntentPath))
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			return nil, err
+		}
+		if err := os.WriteFile(path, []byte(renderIntent(draft)), 0o644); err != nil {
+			return nil, err
+		}
+		wrote = append(wrote, draft.IntentPath)
+	}
+	reportPath := filepath.Join(repo, ".vouch", "build", "bootstrap-report.json")
+	if err := writeJSON(reportPath, result); err != nil {
+		return nil, err
+	}
+	wrote = append(wrote, filepath.ToSlash(filepath.Join(".vouch", "build", "bootstrap-report.json")))
+	return wrote, nil
+}
+
+func needsWrite(repo string, result Result) bool {
+	for _, draft := range result.Drafts {
+		path := filepath.Join(repo, filepath.FromSlash(draft.IntentPath))
+		data, err := os.ReadFile(path)
+		if err != nil || string(data) != renderIntent(draft) {
+			return true
+		}
+	}
+	return false
+}
+
+func renderIntent(draft Draft) string {
+	var b strings.Builder
+	writeScalar(&b, "feature", draft.Component)
+	writeScalar(&b, "owner", draft.Owner)
+	writeScalar(&b, "risk", draft.Risk)
+	writeScalar(&b, "goal", "Drafted from repository signals; human review required before treating this as product intent.")
+	writeList(&b, "owned_paths", draft.Paths, nil)
+	writeList(&b, "behavior", behaviorItems(draft), draft.Obligations)
+	writeList(&b, "security", securityItems(draft), securityObligations(draft.Obligations))
+	writeList(&b, "required_tests", requiredTestItems(draft.Obligations), requiredTestObligations(draft.Obligations))
+	writeList(&b, "runtime_metrics", []string{"vouch.gate.decision"}, nil)
+	b.WriteString("runtime_alerts: []\n")
+	b.WriteString("rollback:\n")
+	b.WriteString("  strategy: revert_change\n")
+	return b.String()
+}
+
+func writeScalar(b *strings.Builder, key string, value string) {
+	b.WriteString(key)
+	b.WriteString(": ")
+	b.WriteString(quote(value))
+	b.WriteByte('\n')
+}
+
+func writeList(b *strings.Builder, key string, values []string, obligations []Obligation) {
+	b.WriteString(key)
+	b.WriteString(":\n")
+	if len(values) == 0 {
+		b.WriteString("  []\n")
+		return
+	}
+	for i, value := range values {
+		if i < len(obligations) {
+			writeGeneratedComment(b, obligations[i])
+		}
+		b.WriteString("  - ")
+		b.WriteString(quote(value))
+		b.WriteByte('\n')
+	}
+}
+
+func writeGeneratedComment(b *strings.Builder, obligation Obligation) {
+	b.WriteString("  # generated:\n")
+	b.WriteString("  #   by: vouch.bootstrap\n")
+	b.WriteString("  #   mode: deterministic\n")
+	b.WriteString("  #   confidence: high\n")
+	b.WriteString("  #   obligation_id: ")
+	b.WriteString(obligation.ID)
+	b.WriteByte('\n')
+	if obligation.Generated.Source.File != "" {
+		b.WriteString("  #   source: ")
+		b.WriteString(obligation.Generated.Source.File)
+		if obligation.Generated.Source.Symbol != "" {
+			b.WriteString("::")
+			b.WriteString(obligation.Generated.Source.Symbol)
+		}
+		b.WriteByte('\n')
+	}
+}
+
+func behaviorItems(draft Draft) []string {
+	var items []string
+	for _, obligation := range requiredTestObligations(draft.Obligations) {
+		items = append(items, draft.Component+" behavior remains covered by "+obligation.Description)
+	}
+	if len(items) == 0 {
+		items = append(items, draft.Component+" behavior remains covered by accepted evidence")
+	}
+	return unique(items)
+}
+
+func securityItems(draft Draft) []string {
+	if draft.Risk == "high" {
+		return []string{"security-sensitive changes require explicit evidence"}
+	}
+	return []string{"no owned-path changes bypass this contract"}
+}
+
+func requiredTestItems(obligations []Obligation) []string {
+	var items []string
+	for _, obligation := range requiredTestObligations(obligations) {
+		items = append(items, obligation.Description)
+	}
+	return items
+}
+
+func requiredTestObligations(obligations []Obligation) []Obligation {
+	var out []Obligation
+	for _, obligation := range obligations {
+		if obligation.Kind == "required_test" {
+			out = append(out, obligation)
+		}
+	}
+	return out
+}
+
+func securityObligations(obligations []Obligation) []Obligation {
+	var out []Obligation
+	for _, obligation := range obligations {
+		if obligation.Kind == "security" {
+			out = append(out, obligation)
+		}
+	}
+	return out
+}
+
+func quote(value string) string {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return `""`
+	}
+	return string(data)
+}
+
+func writeJSON(path string, value any) error {
+	var data bytes.Buffer
+	encoder := json.NewEncoder(&data)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(value); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data.Bytes(), 0o644)
+}

--- a/internal/vouch/bootstrap_cli_test.go
+++ b/internal/vouch/bootstrap_cli_test.go
@@ -1,0 +1,143 @@
+package vouch
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	bootstrap "vouch/internal/vouch/bootstrap"
+)
+
+func TestBootstrapDryRunDraftsConservativeContracts(t *testing.T) {
+	repo := bootstrapFixture(t)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "bootstrap", "--dry-run"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bootstrap --dry-run failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Detected 1 contract drafts:",
+		"HIGH auth.password_reset",
+		"internal/auth/password_reset.go",
+		"test: tests/auth/test_password_reset.py::test_token_expiry",
+		"required_test.token_expiry",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected dry-run output to contain %q, got:\n%s", want, out)
+		}
+	}
+	if _, err := LoadJSON[bootstrap.Result](filepath.Join(repo, ".vouch", "build", "bootstrap-report.json")); err == nil {
+		t.Fatal("dry-run wrote bootstrap report")
+	}
+	if fileExists(filepath.Join(repo, ".vouch", "intents", "auth.password_reset.yaml")) {
+		t.Fatal("dry-run wrote intent file")
+	}
+}
+
+func TestBootstrapWritesIntentReportAndCompileCompatibleContract(t *testing.T) {
+	repo := bootstrapFixture(t)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "bootstrap"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bootstrap failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	intentPath := filepath.Join(repo, ".vouch", "intents", "auth.password_reset.yaml")
+	reportPath := filepath.Join(repo, ".vouch", "build", "bootstrap-report.json")
+	if !fileExists(filepath.Join(repo, ".vouch", "policy", "release-policy.json")) {
+		t.Fatal("bootstrap did not initialize the default release policy")
+	}
+	if !fileExists(intentPath) {
+		t.Fatal("bootstrap did not write the generated intent")
+	}
+	report := mustLoadBootstrapReport(t, reportPath)
+	if len(report.Drafts) != 1 {
+		t.Fatalf("expected one bootstrap draft, got %#v", report.Drafts)
+	}
+	obligations := report.Drafts[0].Obligations
+	if len(obligations) == 0 {
+		t.Fatalf("expected generated obligations, got %#v", report.Drafts[0])
+	}
+	if obligations[0].Generated.By != "vouch.bootstrap" || obligations[0].Generated.Source.File == "" {
+		t.Fatalf("expected structured provenance on obligation, got %#v", obligations[0])
+	}
+
+	spec, err := CompileIntentFile(intentPath, filepath.Join(repo, ".vouch", "specs", "auth.password_reset.spec.json"))
+	if err != nil {
+		t.Fatalf("generated intent did not compile: %v", err)
+	}
+	if spec.ID != "auth.password_reset" || spec.Risk != RiskHigh || spec.Owner != "security-team" {
+		t.Fatalf("compiled unexpected spec metadata: %#v", spec)
+	}
+	if !contains(spec.OwnedPaths, "internal/auth/password_reset.go") {
+		t.Fatalf("expected generated spec to preserve source path, got %#v", spec.OwnedPaths)
+	}
+	if !contains(spec.Tests.Required, "token expiry") {
+		t.Fatalf("expected generated spec to preserve required test, got %#v", spec.Tests.Required)
+	}
+}
+
+func TestBootstrapCheckFailsUntilGeneratedFilesAreCurrent(t *testing.T) {
+	repo := bootstrapFixture(t)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "bootstrap", "--check"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected bootstrap --check to fail before files are written: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Bootstrap check failed") {
+		t.Fatalf("expected check failure message, got:\n%s", stdout.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Main([]string{"--repo", repo, "bootstrap"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bootstrap write failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Main([]string{"--repo", repo, "bootstrap", "--check"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected bootstrap --check to pass after write: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Bootstrap check failed") {
+		t.Fatalf("unexpected check failure after write:\n%s", stdout.String())
+	}
+}
+
+func bootstrapFixture(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	writeText(t, filepath.Join(repo, "pyproject.toml"), `[tool.pytest.ini_options]
+testpaths = ["tests"]
+`)
+	writeText(t, filepath.Join(repo, "CODEOWNERS"), `/internal/auth/** @security-team
+/tests/auth/** @security-team
+`)
+	writeText(t, filepath.Join(repo, "internal", "auth", "password_reset.go"), `package auth
+
+func ResetPassword() {}
+`)
+	writeText(t, filepath.Join(repo, "tests", "auth", "test_password_reset.py"), `def test_token_expiry():
+    assert True
+`)
+	writeText(t, filepath.Join(repo, ".github", "workflows", "ci.yml"), `name: CI
+`)
+	return repo
+}
+
+func mustLoadBootstrapReport(t *testing.T, path string) bootstrap.Result {
+	t.Helper()
+	report, err := LoadJSON[bootstrap.Result](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return report
+}

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	bootstrap "vouch/internal/vouch/bootstrap"
 )
 
 func Main(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -37,6 +39,8 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 	switch rest[0] {
 	case "init":
 		return initCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "bootstrap":
+		return bootstrapCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "intent":
 		if len(rest) >= 2 && rest[1] == "parse" {
 			return intentParse(rest[2:], stdout, stderr)
@@ -94,6 +98,47 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 	}
 	usage(stderr)
 	return 2
+}
+
+func bootstrapCommand(repo string, args []string, jsonOut bool, stdout io.Writer, stderr io.Writer) int {
+	flags := flag.NewFlagSet("bootstrap", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	dryRun := flags.Bool("dry-run", false, "print generated contract drafts without writing files")
+	check := flags.Bool("check", false, "fail when bootstrap outputs are not up to date")
+	aggressive := flags.Bool("aggressive", false, "draft more obligations from path signals")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "bootstrap: unexpected argument %q\n", flags.Arg(0))
+		return 2
+	}
+	if *dryRun && *check {
+		fmt.Fprintln(stderr, "bootstrap: --dry-run and --check cannot be combined")
+		return 2
+	}
+	if !*dryRun && !*check {
+		if _, err := InitRepo(repo, "auto", false); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+	}
+	result, err := bootstrap.Run(repo, bootstrap.Options{DryRun: *dryRun, Check: *check, Aggressive: *aggressive})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if jsonOut {
+		if code := renderCommandJSON(result, stdout, stderr); code != 0 {
+			return code
+		}
+	} else {
+		fmt.Fprint(stdout, bootstrap.RenderText(result))
+	}
+	if *check && result.NeedsWrite {
+		return 1
+	}
+	return 0
 }
 
 func initCommand(repo string, args []string, jsonOut bool, stdout io.Writer, stderr io.Writer) int {
@@ -677,6 +722,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "commands:")
 	fmt.Fprintln(out, "  init [--profile auto|python|node|go|rust|generic] [--force]")
+	fmt.Fprintln(out, "  bootstrap [--dry-run] [--check] [--aggressive]")
 	fmt.Fprintln(out, "  intent parse --intent FILE --out FILE")
 	fmt.Fprintln(out, "  intent compile --intent FILE --out FILE")
 	fmt.Fprintln(out, "  ir build --spec FILE --out FILE")


### PR DESCRIPTION
## Summary

Introduce `vouch bootstrap` to draft release contracts from existing repo signals without claiming to discover product intent. Bootstrap only creates reviewable drafts with provenance.

## Validation

  ```bash
  go test ./...
```