### PR TITLE
feat: add repo compiler pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -432,12 +432,14 @@ Vouch has compiler-like stages:
 
 Making it more compiler-like is useful because it makes the system more accurate in the areas that matter here. These things include deterministic parsing, typed intermediate representations, structured diagnostics, generated artifacts, and auditable policy decisions.
 
-The current implementation is early. Policy is still hard-coded, generic non-JUnit artifacts are shallow, and contract suggestions are structural heuristics. The compiler direction is still the right direction because the value is in deterministic obligations and evidence linkage, not in another generic "merge or don't merge" opinion.
+The current implementation is early. Policy is file-backed but still simple, generic non-JUnit artifacts are shallow, and contract suggestions are structural heuristics. The compiler direction is still the right direction because the value is in deterministic obligations and evidence linkage, not in another generic "merge or don't merge" opinion.
 
 ## Current Pipeline
 
 | Command Area | Input | Output |
 | --- | --- | --- |
+| `bootstrap` | repo signals | draft intents plus bootstrap report |
+| `compile` | `.vouch/intents/*.yaml` | specs, aggregate obligation IR, and verification plan |
 | `intent parse` | `.vouch/intents/*.yaml` | `vouch.ast.v0` with source spans and diagnostics |
 | `intent compile` | Intent AST | `vouch.spec.v0` JSON |
 | `ir build` | Spec JSON | `vouch.ir.v0` obligations |
@@ -515,6 +517,13 @@ The demo uses a synthetic high-risk `auth.password_reset` change because it exer
 - Email side effects.
 
 The demo exercises the compiler plumbing and failure modes. It does not prove Vouch can infer or verify password reset correctness from application code.
+
+Run the repo-level compiler pipeline:
+
+```sh
+vouch --repo demo_repo compile
+vouch --repo demo_repo compile --emit ir
+```
 
 Parse intent into a typed AST:
 
@@ -628,6 +637,8 @@ vouch --repo /path/to/repo manifest attach-artifact \
 
 ```sh
 vouch --repo DIR init
+vouch --repo DIR bootstrap
+vouch --repo DIR compile [--emit ast|spec|ir|plan]
 vouch --repo DIR contract suggest
 vouch --repo DIR contract create --name ID --owner OWNER --risk RISK --paths GLOB --behavior TEXT --required-test TEXT
 vouch intent parse --intent FILE --out FILE

--- a/demo_repo/.vouch/intents/auth.password_reset.yaml
+++ b/demo_repo/.vouch/intents/auth.password_reset.yaml
@@ -1,3 +1,4 @@
+version: vouch.intent.v0
 feature: auth.password_reset
 owner: platform
 owned_paths:

--- a/demo_repo/README.md
+++ b/demo_repo/README.md
@@ -13,6 +13,8 @@ It contains one high-risk feature contract and three agent-change manifests:
 Run from the parent directory:
 
 ```sh
+vouch --repo demo_repo compile
+vouch --repo demo_repo compile --emit ir
 vouch intent parse --intent demo_repo/.vouch/intents/auth.password_reset.yaml --out /tmp/auth.password_reset.ast.json
 vouch intent compile --intent demo_repo/.vouch/intents/auth.password_reset.yaml --out /tmp/auth.password_reset.json
 vouch ir build --spec demo_repo/.vouch/specs/auth.password_reset.json --out /tmp/auth.password_reset.ir.json

--- a/internal/vouch/bootstrap/generator.go
+++ b/internal/vouch/bootstrap/generator.go
@@ -92,10 +92,11 @@ func obligationsForDraft(draft Draft, opts Options) []Obligation {
 	}
 	if draft.Risk == "high" && len(obligations) > 0 {
 		source := firstSource(draft.Signals)
+		description := "security-sensitive changes require explicit evidence"
 		obligations = append(obligations, Obligation{
-			ID:          draft.Component + ".security.security_sensitive_change_reviewed",
+			ID:          draft.Component + ".security." + slug(description),
 			Kind:        "security",
-			Description: "security-sensitive changes require explicit evidence",
+			Description: description,
 			Generated:   generated(source),
 		})
 	}

--- a/internal/vouch/bootstrap/writer.go
+++ b/internal/vouch/bootstrap/writer.go
@@ -41,6 +41,7 @@ func needsWrite(repo string, result Result) bool {
 
 func renderIntent(draft Draft) string {
 	var b strings.Builder
+	writeScalar(&b, "version", "vouch.intent.v0")
 	writeScalar(&b, "feature", draft.Component)
 	writeScalar(&b, "owner", draft.Owner)
 	writeScalar(&b, "risk", draft.Risk)

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -41,6 +41,8 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 		return initCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "bootstrap":
 		return bootstrapCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "compile":
+		return compileCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "intent":
 		if len(rest) >= 2 && rest[1] == "parse" {
 			return intentParse(rest[2:], stdout, stderr)
@@ -138,6 +140,43 @@ func bootstrapCommand(repo string, args []string, jsonOut bool, stdout io.Writer
 	if *check && result.NeedsWrite {
 		return 1
 	}
+	return 0
+}
+
+func compileCommand(repo string, args []string, jsonOut bool, stdout io.Writer, stderr io.Writer) int {
+	flags := flag.NewFlagSet("compile", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	emit := flags.String("emit", "", "emit one compiler stage: ast, spec, ir, or plan")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() > 0 {
+		fmt.Fprintf(stderr, "compile: unexpected argument %q\n", flags.Arg(0))
+		return 2
+	}
+	if *emit != "" && *emit != "ast" && *emit != "spec" && *emit != "ir" && *emit != "plan" {
+		fmt.Fprintln(stderr, "compile: --emit must be one of ast, spec, ir, or plan")
+		return 2
+	}
+	output, err := CompileRepo(repo)
+	if err != nil {
+		if diagnosticErr, ok := err.(DiagnosticError); ok {
+			fmt.Fprintln(stderr, "Compile failed:")
+			for _, diagnostic := range diagnosticErr.Diagnostics {
+				fmt.Fprintf(stderr, "- %s\n", FormatDiagnostic(diagnostic))
+			}
+			return 1
+		}
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if *emit != "" {
+		return renderCommandJSON(output.EmitArtifact(*emit), stdout, stderr)
+	}
+	if jsonOut {
+		return renderCommandJSON(output.Result, stdout, stderr)
+	}
+	fmt.Fprint(stdout, RenderCompileResult(output.Result))
 	return 0
 }
 
@@ -723,6 +762,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "commands:")
 	fmt.Fprintln(out, "  init [--profile auto|python|node|go|rust|generic] [--force]")
 	fmt.Fprintln(out, "  bootstrap [--dry-run] [--check] [--aggressive]")
+	fmt.Fprintln(out, "  compile [--emit ast|spec|ir|plan]")
 	fmt.Fprintln(out, "  intent parse --intent FILE --out FILE")
 	fmt.Fprintln(out, "  intent compile --intent FILE --out FILE")
 	fmt.Fprintln(out, "  ir build --spec FILE --out FILE")

--- a/internal/vouch/compile.go
+++ b/internal/vouch/compile.go
@@ -1,0 +1,422 @@
+package vouch
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	bootstrap "vouch/internal/vouch/bootstrap"
+)
+
+type RepoCompileOutput struct {
+	Result RepoCompileResult
+	ASTs   IntentASTBundle
+	Specs  SpecBundle
+	IR     ObligationIRBundle
+	Plan   VerificationPlanBundle
+}
+
+type RepoCompileResult struct {
+	Version          string              `json:"version"`
+	Repo             string              `json:"repo"`
+	SpecsCompiled    int                 `json:"specs_compiled"`
+	ObligationsBuilt int                 `json:"obligations_built"`
+	Components       []CompiledComponent `json:"components"`
+	Wrote            []string            `json:"wrote"`
+	Diagnostics      []Diagnostic        `json:"diagnostics,omitempty"`
+}
+
+type CompiledComponent struct {
+	Component   string   `json:"component"`
+	Risk        Risk     `json:"risk"`
+	IntentPath  string   `json:"intent_path"`
+	ASTPath     string   `json:"ast_path"`
+	SpecPath    string   `json:"spec_path"`
+	Obligations []string `json:"obligations"`
+}
+
+type IntentASTBundle struct {
+	Version string      `json:"version"`
+	Repo    string      `json:"repo"`
+	ASTs    []IntentAST `json:"asts"`
+}
+
+type SpecBundle struct {
+	Version string `json:"version"`
+	Repo    string `json:"repo"`
+	Specs   []Spec `json:"specs"`
+}
+
+type ObligationIRBundle struct {
+	Version     string       `json:"version"`
+	Repo        string       `json:"repo"`
+	Components  []IR         `json:"components"`
+	Obligations []Obligation `json:"obligations"`
+}
+
+type VerificationPlanBundle struct {
+	Version string             `json:"version"`
+	Repo    string             `json:"repo"`
+	Plans   []VerificationPlan `json:"plans"`
+}
+
+func CompileRepo(repo string) (RepoCompileOutput, error) {
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return RepoCompileOutput{}, err
+	}
+	output := RepoCompileOutput{
+		Result: RepoCompileResult{
+			Version:     CompileResultVersion,
+			Repo:        absRepo,
+			Components:  []CompiledComponent{},
+			Wrote:       []string{},
+			Diagnostics: []Diagnostic{},
+		},
+		ASTs:  IntentASTBundle{Version: ASTSchemaVersion, Repo: absRepo, ASTs: []IntentAST{}},
+		Specs: SpecBundle{Version: SpecSchemaVersion, Repo: absRepo, Specs: []Spec{}},
+		IR:    ObligationIRBundle{Version: ObligationsIRVersion, Repo: absRepo, Components: []IR{}, Obligations: []Obligation{}},
+		Plan:  VerificationPlanBundle{Version: PlanBundleVersion, Repo: absRepo, Plans: []VerificationPlan{}},
+	}
+
+	if _, _, err := LoadReleasePolicy(absRepo, ""); err != nil {
+		output.Result.Diagnostics = append(output.Result.Diagnostics, diagnostic("error", "compile.policy_missing", err.Error(), ".vouch/policy/release-policy.json", SourceSpan{}))
+	}
+	intentPaths, err := repoIntentFiles(absRepo)
+	if err != nil {
+		return output, err
+	}
+	if len(intentPaths) == 0 {
+		output.Result.Diagnostics = append(output.Result.Diagnostics, diagnostic("error", "compile.no_intents", "no intent YAML files found under .vouch/intents", ".vouch/intents", SourceSpan{}))
+	}
+	if HasErrorDiagnostics(output.Result.Diagnostics) {
+		return output, DiagnosticError{Diagnostics: output.Result.Diagnostics}
+	}
+
+	generated := loadBootstrapGenerated(absRepo)
+	for _, intentPath := range intentPaths {
+		compiled, diagnostics, err := compileIntentForRepo(absRepo, intentPath, generated)
+		output.Result.Diagnostics = append(output.Result.Diagnostics, diagnostics...)
+		if err != nil {
+			return output, err
+		}
+		if compiled == nil {
+			continue
+		}
+		output.ASTs.ASTs = append(output.ASTs.ASTs, compiled.AST)
+		output.Specs.Specs = append(output.Specs.Specs, compiled.Spec)
+		output.IR.Components = append(output.IR.Components, compiled.IR)
+		output.IR.Obligations = append(output.IR.Obligations, compiled.IR.Obligations...)
+		output.Plan.Plans = append(output.Plan.Plans, compiled.Plan)
+		output.Result.Components = append(output.Result.Components, compiled.Component)
+		output.Result.SpecsCompiled++
+		output.Result.ObligationsBuilt += len(compiled.IR.Obligations)
+	}
+	if HasErrorDiagnostics(output.Result.Diagnostics) {
+		return output, DiagnosticError{Diagnostics: output.Result.Diagnostics}
+	}
+	if err := writeRepoCompileOutput(absRepo, &output); err != nil {
+		return output, err
+	}
+	return output, nil
+}
+
+func (output RepoCompileOutput) EmitArtifact(name string) any {
+	switch name {
+	case "ast":
+		return output.ASTs
+	case "spec":
+		return output.Specs
+	case "ir":
+		return output.IR
+	case "plan":
+		return output.Plan
+	default:
+		return output.Result
+	}
+}
+
+type compiledIntent struct {
+	AST       IntentAST
+	Spec      Spec
+	IR        IR
+	Plan      VerificationPlan
+	Component CompiledComponent
+}
+
+func compileIntentForRepo(repo string, intentPath string, generated generatedIndex) (*compiledIntent, []Diagnostic, error) {
+	var diagnostics []Diagnostic
+	ast, parseDiagnostics, err := ParseIntentASTFile(intentPath)
+	if err != nil {
+		return nil, diagnostics, err
+	}
+	diagnostics = append(diagnostics, parseDiagnostics...)
+	if HasErrorDiagnostics(parseDiagnostics) {
+		return nil, diagnostics, nil
+	}
+	typed, typedDiagnostics := AnalyzeIntentAST(ast)
+	diagnostics = append(diagnostics, typedDiagnostics...)
+	diagnostics = append(diagnostics, validateCompileIntent(ast, typed)...)
+	if HasErrorDiagnostics(diagnostics) {
+		return nil, diagnostics, nil
+	}
+	spec := SpecFromIntent(typed.Intent())
+	specDiagnostics := stringDiagnostics("spec", ValidateSpec(spec))
+	diagnostics = append(diagnostics, specDiagnostics...)
+	if HasErrorDiagnostics(specDiagnostics) {
+		return nil, diagnostics, nil
+	}
+	ir := IRFromSpec(spec)
+	attachGeneratedInfo(&ir, generated)
+	irDiagnostics := validateCompiledIR(ir)
+	diagnostics = append(diagnostics, irDiagnostics...)
+	if HasErrorDiagnostics(irDiagnostics) {
+		return nil, diagnostics, nil
+	}
+	plan := VerificationPlanFromIR(ir, Manifest{
+		Change: Change{
+			Risk:         spec.Risk,
+			SpecsTouched: []string{spec.ID},
+		},
+	})
+	relIntent := repoRelativePath(repo, intentPath)
+	astPath := filepath.ToSlash(filepath.Join(".vouch", "build", "ast", spec.ID+".ast.json"))
+	specPath := filepath.ToSlash(filepath.Join(".vouch", "specs", spec.ID+".spec.json"))
+	return &compiledIntent{
+		AST:  ast,
+		Spec: spec,
+		IR:   ir,
+		Plan: plan,
+		Component: CompiledComponent{
+			Component:   spec.ID,
+			Risk:        spec.Risk,
+			IntentPath:  relIntent,
+			ASTPath:     astPath,
+			SpecPath:    specPath,
+			Obligations: obligationIDs(ir.Obligations),
+		},
+	}, diagnostics, nil
+}
+
+func validateCompileIntent(ast IntentAST, typed TypedIntent) []Diagnostic {
+	var diagnostics []Diagnostic
+	version := findCompileASTNode(ast, "version")
+	if version == nil || strings.TrimSpace(version.Value) == "" {
+		diagnostics = append(diagnostics, diagnostic("error", "compile.required_version", "version is required for repo-level compile", "version", SourceSpan{File: ast.File}))
+	} else if version.Value != IntentSchemaVersion {
+		diagnostics = append(diagnostics, diagnostic("error", "compile.invalid_version", fmt.Sprintf("version must be %s", IntentSchemaVersion), "version", version.Span))
+	}
+	if typed.Feature.Value != "" {
+		if err := validateContractName(typed.Feature.Value); err != nil {
+			diagnostics = append(diagnostics, diagnostic("error", "compile.invalid_name", err.Error(), "feature", typed.Feature.Span))
+		}
+	}
+	if len(typed.OwnedPaths) == 0 {
+		diagnostics = append(diagnostics, diagnostic("warning", "compile.missing_paths", "owned_paths is empty; generated plans may not map changed files", "owned_paths", typed.span("owned_paths")))
+	}
+	if typed.Owner.Value == "unowned" {
+		diagnostics = append(diagnostics, diagnostic("warning", "compile.unowned_contract", "owner is unowned; assign a real owner before relying on this contract", "owner", typed.Owner.Span))
+	}
+	return diagnostics
+}
+
+func validateCompiledIR(ir IR) []Diagnostic {
+	var diagnostics []Diagnostic
+	for _, obligation := range ir.Obligations {
+		if obligation.ID == "" {
+			diagnostics = append(diagnostics, diagnostic("error", "compile.empty_obligation_id", "obligation id must be non-empty", "obligations", SourceSpan{}))
+		}
+		if strings.ContainsAny(obligation.ID, " \t\r\n") {
+			diagnostics = append(diagnostics, diagnostic("error", "compile.unstable_obligation_id", fmt.Sprintf("obligation id %q contains whitespace", obligation.ID), "obligations", SourceSpan{}))
+		}
+		prefix := fmt.Sprintf("%s.%s.", ir.Feature, obligation.Kind)
+		if !strings.HasPrefix(obligation.ID, prefix) {
+			diagnostics = append(diagnostics, diagnostic("error", "compile.unstable_obligation_id", fmt.Sprintf("obligation id %q must start with %q", obligation.ID, prefix), "obligations", SourceSpan{}))
+		}
+		if !validObligationKind(obligation.Kind) {
+			diagnostics = append(diagnostics, diagnostic("error", "compile.unknown_obligation_kind", fmt.Sprintf("unknown obligation kind %q", obligation.Kind), "obligations", SourceSpan{}))
+		}
+		if !validEvidenceKind(obligation.RequiredEvidence) {
+			diagnostics = append(diagnostics, diagnostic("error", "compile.unknown_required_evidence", fmt.Sprintf("unknown required evidence %q", obligation.RequiredEvidence), "obligations", SourceSpan{}))
+		}
+	}
+	return diagnostics
+}
+
+func validObligationKind(kind ObligationKind) bool {
+	switch kind {
+	case ObligationBehavior, ObligationSecurity, ObligationRequiredTest, ObligationRuntimeSignal, ObligationRollback:
+		return true
+	default:
+		return false
+	}
+}
+
+func writeRepoCompileOutput(repo string, output *RepoCompileOutput) error {
+	for i, component := range output.Result.Components {
+		if err := writeJSONFile(filepath.Join(repo, filepath.FromSlash(component.ASTPath)), output.ASTs.ASTs[i]); err != nil {
+			return err
+		}
+		if err := writeJSONFile(filepath.Join(repo, filepath.FromSlash(component.SpecPath)), output.Specs.Specs[i]); err != nil {
+			return err
+		}
+		output.Result.Wrote = append(output.Result.Wrote, component.ASTPath, component.SpecPath)
+	}
+	irPath := filepath.ToSlash(filepath.Join(".vouch", "build", "obligations.ir.json"))
+	planPath := filepath.ToSlash(filepath.Join(".vouch", "build", "verification-plan.json"))
+	if err := writeJSONFile(filepath.Join(repo, filepath.FromSlash(irPath)), output.IR); err != nil {
+		return err
+	}
+	if err := writeJSONFile(filepath.Join(repo, filepath.FromSlash(planPath)), output.Plan); err != nil {
+		return err
+	}
+	output.Result.Wrote = append(output.Result.Wrote, irPath, planPath)
+	return nil
+}
+
+func RenderCompileResult(result RepoCompileResult) string {
+	var b strings.Builder
+	if len(result.Components) == 0 {
+		b.WriteString("Compiled 0 contract drafts into 0 obligations.\n")
+		return b.String()
+	}
+	fmt.Fprintf(&b, "Compiled %d contract drafts into %d obligations.\n\n", result.SpecsCompiled, result.ObligationsBuilt)
+	b.WriteString("Pipeline: repo signals -> contracts -> obligation IR -> verification plan\n\n")
+	for _, component := range result.Components {
+		fmt.Fprintf(&b, "%s %s\n", compileRiskLabel(component.Risk), component.Component)
+		for _, obligationID := range component.Obligations {
+			shortID := strings.TrimPrefix(obligationID, component.Component+".")
+			fmt.Fprintf(&b, "  - %s\n", shortID)
+		}
+		b.WriteByte('\n')
+	}
+	if len(result.Wrote) > 0 {
+		b.WriteString("Wrote:\n")
+		for _, path := range result.Wrote {
+			fmt.Fprintf(&b, "  %s\n", path)
+		}
+	}
+	warnings := warningDiagnostics(result.Diagnostics)
+	if len(warnings) > 0 {
+		b.WriteString("Warnings:\n")
+		for _, warning := range warnings {
+			fmt.Fprintf(&b, "  - %s\n", FormatDiagnostic(warning))
+		}
+	}
+	return b.String()
+}
+
+func repoIntentFiles(repo string) ([]string, error) {
+	var paths []string
+	for _, pattern := range []string{"*.yaml", "*.yml"} {
+		matches, err := filepath.Glob(filepath.Join(repo, ".vouch", "intents", pattern))
+		if err != nil {
+			return nil, err
+		}
+		paths = append(paths, matches...)
+	}
+	sort.Strings(paths)
+	return paths, nil
+}
+
+func repoRelativePath(repo string, path string) string {
+	rel, err := filepath.Rel(repo, path)
+	if err != nil {
+		return filepath.ToSlash(path)
+	}
+	return filepath.ToSlash(rel)
+}
+
+func obligationIDs(obligations []Obligation) []string {
+	out := make([]string, 0, len(obligations))
+	for _, obligation := range obligations {
+		out = append(out, obligation.ID)
+	}
+	return out
+}
+
+func findCompileASTNode(ast IntentAST, key string) *ASTNode {
+	for i := range ast.Nodes {
+		if ast.Nodes[i].Key == key {
+			return &ast.Nodes[i]
+		}
+	}
+	return nil
+}
+
+func warningDiagnostics(diagnostics []Diagnostic) []Diagnostic {
+	var out []Diagnostic
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Severity == "warning" {
+			out = append(out, diagnostic)
+		}
+	}
+	return out
+}
+
+func compileRiskLabel(risk Risk) string {
+	switch risk {
+	case RiskLow:
+		return "LOW"
+	case RiskMedium:
+		return "MED"
+	case RiskHigh:
+		return "HIGH"
+	case RiskCritical:
+		return "CRIT"
+	default:
+		return strings.ToUpper(string(risk))
+	}
+}
+
+type generatedIndex struct {
+	byID       map[string]GeneratedInfo
+	byKindText map[string]GeneratedInfo
+}
+
+func loadBootstrapGenerated(repo string) generatedIndex {
+	index := generatedIndex{
+		byID:       map[string]GeneratedInfo{},
+		byKindText: map[string]GeneratedInfo{},
+	}
+	report, err := LoadJSON[bootstrap.Result](filepath.Join(repo, ".vouch", "build", "bootstrap-report.json"))
+	if err != nil {
+		return index
+	}
+	for _, draft := range report.Drafts {
+		for _, obligation := range draft.Obligations {
+			generated := GeneratedInfo{
+				By:         obligation.Generated.By,
+				Mode:       obligation.Generated.Mode,
+				Confidence: obligation.Generated.Confidence,
+				Source: GeneratedSource{
+					Type:   obligation.Generated.Source.Type,
+					File:   obligation.Generated.Source.File,
+					Symbol: obligation.Generated.Source.Symbol,
+					Detail: obligation.Generated.Source.Detail,
+				},
+			}
+			index.byID[obligation.ID] = generated
+			index.byKindText[generatedKey(obligation.Kind, obligation.Description)] = generated
+		}
+	}
+	return index
+}
+
+func attachGeneratedInfo(ir *IR, index generatedIndex) {
+	for i := range ir.Obligations {
+		generated, ok := index.byID[ir.Obligations[i].ID]
+		if !ok {
+			generated, ok = index.byKindText[generatedKey(string(ir.Obligations[i].Kind), ir.Obligations[i].Text)]
+		}
+		if ok {
+			copy := generated
+			ir.Obligations[i].Generated = &copy
+		}
+	}
+}
+
+func generatedKey(kind string, text string) string {
+	return kind + "\x00" + text
+}

--- a/internal/vouch/compile_cli_test.go
+++ b/internal/vouch/compile_cli_test.go
@@ -1,0 +1,155 @@
+package vouch
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompileCommandBuildsRepoCompilerPipeline(t *testing.T) {
+	repo := bootstrapFixture(t)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "bootstrap"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("bootstrap failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Main([]string{"--repo", repo, "compile"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("compile failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"Compiled 1 contract drafts into",
+		"Pipeline: repo signals -> contracts -> obligation IR -> verification plan",
+		"HIGH auth.password_reset",
+		"required_test.token_expiry",
+		".vouch/specs/auth.password_reset.spec.json",
+		".vouch/build/obligations.ir.json",
+		".vouch/build/verification-plan.json",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected compile output to contain %q, got:\n%s", want, out)
+		}
+	}
+	if !fileExists(filepath.Join(repo, ".vouch", "build", "ast", "auth.password_reset.ast.json")) {
+		t.Fatal("compile did not write AST artifact")
+	}
+	spec := mustLoadSpecFile(t, filepath.Join(repo, ".vouch", "specs", "auth.password_reset.spec.json"))
+	if spec.ID != "auth.password_reset" || spec.Risk != RiskHigh {
+		t.Fatalf("unexpected compiled spec: %#v", spec)
+	}
+	ir := mustLoadIRBundle(t, filepath.Join(repo, ".vouch", "build", "obligations.ir.json"))
+	requiredTest := findBundleObligation(ir, "auth.password_reset.required_test.token_expiry")
+	if requiredTest == nil {
+		t.Fatalf("missing compiled required-test obligation: %#v", ir.Obligations)
+	}
+	if requiredTest.Generated == nil || requiredTest.Generated.By != "vouch.bootstrap" {
+		t.Fatalf("generated provenance was not preserved: %#v", requiredTest)
+	}
+	plan := mustLoadPlanBundle(t, filepath.Join(repo, ".vouch", "build", "verification-plan.json"))
+	if len(plan.Plans) != 1 || plan.Plans[0].Feature != "auth.password_reset" {
+		t.Fatalf("unexpected verification plan bundle: %#v", plan)
+	}
+}
+
+func TestCompileEmitIRPrintsAggregateIR(t *testing.T) {
+	repo := bootstrapFixture(t)
+	var stdout, stderr bytes.Buffer
+
+	if code := Main([]string{"--repo", repo, "bootstrap"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("bootstrap failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main([]string{"--repo", repo, "compile", "--emit", "ir"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("compile --emit ir failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	ir, err := decodeJSON[ObligationIRBundle](stdout.Bytes())
+	if err != nil {
+		t.Fatalf("compile --emit ir did not print IR JSON: %v\n%s", err, stdout.String())
+	}
+	if ir.Version != ObligationsIRVersion || len(ir.Obligations) == 0 {
+		t.Fatalf("unexpected emitted IR: %#v", ir)
+	}
+}
+
+func TestCompileRequiresVersionedIntents(t *testing.T) {
+	repo := initializedRepo(t)
+	writeText(t, filepath.Join(repo, ".vouch", "intents", "legacy.yaml"), `feature: legacy.service
+owner: platform
+owned_paths:
+  - src/legacy/**
+risk: medium
+behavior:
+  - legacy behavior
+security:
+  - legacy invariant
+required_tests:
+  - legacy test
+runtime_metrics:
+  - legacy.metric
+rollback:
+  strategy: revert_change
+`)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "compile"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected compile to reject missing version: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "compile.required_version") {
+		t.Fatalf("expected missing version diagnostic, got stderr:\n%s", stderr.String())
+	}
+	if fileExists(filepath.Join(repo, ".vouch", "specs", "legacy.service.spec.json")) {
+		t.Fatal("compile wrote spec despite missing version")
+	}
+}
+
+func mustLoadSpecFile(t *testing.T, path string) Spec {
+	t.Helper()
+	spec, err := LoadJSON[Spec](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return spec
+}
+
+func mustLoadIRBundle(t *testing.T, path string) ObligationIRBundle {
+	t.Helper()
+	ir, err := LoadJSON[ObligationIRBundle](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return ir
+}
+
+func mustLoadPlanBundle(t *testing.T, path string) VerificationPlanBundle {
+	t.Helper()
+	plan, err := LoadJSON[VerificationPlanBundle](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return plan
+}
+
+func findBundleObligation(bundle ObligationIRBundle, id string) *Obligation {
+	for i := range bundle.Obligations {
+		if bundle.Obligations[i].ID == id {
+			return &bundle.Obligations[i]
+		}
+	}
+	return nil
+}
+
+func decodeJSON[T any](data []byte) (T, error) {
+	var value T
+	err := json.Unmarshal(data, &value)
+	return value, err
+}

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -120,8 +120,9 @@ func TestIntentParsesToStableASTWithSourceSpans(t *testing.T) {
 	if ast.Version != ASTSchemaVersion {
 		t.Fatalf("unexpected AST version %s", ast.Version)
 	}
-	if len(ast.Nodes) == 0 || ast.Nodes[0].Key != "feature" || ast.Nodes[0].Value != "auth.password_reset" {
-		t.Fatalf("unexpected first AST node: %#v", ast.Nodes)
+	feature := findASTNode(ast, "feature")
+	if feature == nil || feature.Value != "auth.password_reset" {
+		t.Fatalf("unexpected feature AST node: %#v", ast.Nodes)
 	}
 	behavior := findASTNode(ast, "behavior")
 	if behavior == nil {

--- a/internal/vouch/intent.go
+++ b/internal/vouch/intent.go
@@ -259,6 +259,7 @@ type SourceValue[T any] struct {
 }
 
 type TypedIntent struct {
+	Version        SourceValue[string]
 	Feature        SourceValue[string]
 	Owner          SourceValue[string]
 	OwnedPaths     []SourceValue[string]
@@ -286,6 +287,8 @@ func AnalyzeIntentAST(ast IntentAST) (TypedIntent, []Diagnostic) {
 	for _, node := range ast.Nodes {
 		spans[node.Key] = node.Span
 		switch node.Key {
+		case "version":
+			typed.Version = SourceValue[string]{Value: node.Value, Span: node.Span}
 		case "feature":
 			typed.Feature = SourceValue[string]{Value: node.Value, Span: node.Span}
 		case "owner":
@@ -324,6 +327,7 @@ func AnalyzeIntentAST(ast IntentAST) (TypedIntent, []Diagnostic) {
 
 func (typed TypedIntent) Intent() Intent {
 	return Intent{
+		Version:        typed.Version.Value,
 		Feature:        typed.Feature.Value,
 		Owner:          typed.Owner.Value,
 		OwnedPaths:     sourceValues(typed.OwnedPaths),
@@ -356,6 +360,7 @@ func ValidateIntentDiagnostics(intent Intent) []Diagnostic {
 func ValidateIntentDiagnosticsWithSpans(intent Intent, spans map[string]SourceSpan) []Diagnostic {
 	typed := TypedIntent{
 		Feature:        SourceValue[string]{Value: intent.Feature, Span: spans["feature"]},
+		Version:        SourceValue[string]{Value: intent.Version, Span: spans["version"]},
 		Owner:          SourceValue[string]{Value: intent.Owner, Span: spans["owner"]},
 		OwnedPaths:     sourceStringsWithSpan(intent.OwnedPaths, spans["owned_paths"]),
 		Risk:           SourceValue[Risk]{Value: intent.Risk, Span: spans["risk"]},
@@ -376,6 +381,9 @@ func ValidateIntentDiagnosticsWithSpans(intent Intent, spans map[string]SourceSp
 
 func ValidateTypedIntent(intent TypedIntent) []Diagnostic {
 	var diagnostics []Diagnostic
+	if intent.Version.Value != "" && intent.Version.Value != IntentSchemaVersion {
+		diagnostics = append(diagnostics, diagnostic("error", "intent.invalid_version", fmt.Sprintf("version must be %s", IntentSchemaVersion), "version", intent.span("version")))
+	}
 	if intent.Feature.Value == "" {
 		diagnostics = append(diagnostics, diagnostic("error", "intent.required_feature", "feature is required", "feature", intent.span("feature")))
 	}
@@ -436,7 +444,7 @@ func supportedIntentKey(key string) bool {
 }
 
 func supportedScalarIntentKey(key string) bool {
-	return key == "feature" || key == "owner" || key == "risk" || key == "goal"
+	return key == "version" || key == "feature" || key == "owner" || key == "risk" || key == "goal"
 }
 
 func supportsListSection(key string) bool {

--- a/internal/vouch/load.go
+++ b/internal/vouch/load.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 )
 
@@ -45,7 +46,10 @@ func LoadSpecs(repo string) (map[string]Spec, error) {
 			return nil, err
 		}
 		if spec.ID != "" {
-			if _, exists := specs[spec.ID]; exists {
+			if existing, exists := specs[spec.ID]; exists {
+				if reflect.DeepEqual(existing, spec) {
+					continue
+				}
 				return nil, fmt.Errorf("duplicate spec id %q in %s", spec.ID, path)
 			}
 			specs[spec.ID] = spec

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -804,6 +804,7 @@ func sanitizeContractName(value string) string {
 
 func renderIntentYAML(intent Intent) string {
 	var b bytes.Buffer
+	writeYAMLScalar(&b, "version", IntentSchemaVersion)
 	writeYAMLScalar(&b, "feature", intent.Feature)
 	writeYAMLScalar(&b, "owner", intent.Owner)
 	writeYAMLList(&b, "owned_paths", intent.OwnedPaths)

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -7,10 +7,14 @@ const (
 	ManifestSchemaVersion   = "vouch.manifest.v0"
 	EvidenceSchemaVersion   = "vouch.evidence.v0"
 	EvidenceBundleVersion   = "vouch.evidence_bundle.v0"
+	IntentSchemaVersion     = "vouch.intent.v0"
 	ASTSchemaVersion        = "vouch.ast.v0"
 	IRSchemaVersion         = "vouch.ir.v0"
 	PlanSchemaVersion       = "vouch.plan.v0"
 	ConfigSchemaVersion     = "vouch.config.v0"
+	CompileResultVersion    = "vouch.compile_result.v0"
+	ObligationsIRVersion    = "vouch.obligations_ir.v0"
+	PlanBundleVersion       = "vouch.verification_plan_bundle.v0"
 	TestMapSchemaVersion    = "vouch.test_map.v0"
 	PolicySchemaVersion     = "vouch.policy.v0"
 	PolicyInputVersion      = "vouch.policy_input.v0"
@@ -83,6 +87,7 @@ const (
 )
 
 type Intent struct {
+	Version        string
 	Feature        string
 	Owner          string
 	OwnedPaths     []string
@@ -188,6 +193,21 @@ type Obligation struct {
 	Severity         string         `json:"severity"`
 	Source           string         `json:"source"`
 	RequiredEvidence EvidenceKind   `json:"required_evidence"`
+	Generated        *GeneratedInfo `json:"generated,omitempty"`
+}
+
+type GeneratedInfo struct {
+	By         string          `json:"by"`
+	Mode       string          `json:"mode"`
+	Confidence string          `json:"confidence"`
+	Source     GeneratedSource `json:"source"`
+}
+
+type GeneratedSource struct {
+	Type   string `json:"type"`
+	File   string `json:"file,omitempty"`
+	Symbol string `json:"symbol,omitempty"`
+	Detail string `json:"detail,omitempty"`
 }
 
 type Manifest struct {


### PR DESCRIPTION
## Summary

Added `vouch compile`. Makes vouch’s compiler flow visible in one command:

```
  intent YAML -> spec JSON -> obligation IR -> verification plan
```

## What Changed

  - Added vouch compile
  - Added:
      - vouch compile --emit ast
      - vouch compile --emit spec
      - vouch compile --emit ir
      - vouch compile --emit plan
  - Writes:
      - .vouch/specs/<component>.spec.json
      - .vouch/build/obligations.ir.json
      - .vouch/build/verification-plan.json
  - Adds version: vouch.intent.v0 to generated intents
  - Validates intent version, policy presence, obligation IDs, obligation kinds, and required evidence kinds
  - Carries bootstrap provenance into compiled obligations

  ## Why

  Users can run `vouch compile` and see:

  ```
repo signals -> contracts -> obligation IR -> verification plan
```

  ## Validation

  go test ./...
