### PR TITLE
feat: import junit evidence for gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,15 @@ cd /path/to/your/repo
 pytest --junitxml .vouch/artifacts/pytest.xml
 ```
 
+For the repo-level v0.2 flow, import JUnit evidence directly:
+
+```sh
+vouch --repo /path/to/your/repo evidence import junit .vouch/artifacts/pytest.xml
+vouch --repo /path/to/your/repo gate
+```
+
+This writes `.vouch/evidence/manifest.json` and gates against the compiled obligation IR. JUnit only satisfies required-test obligations, so security, runtime, rollback, and behavior obligations still need their own evidence.
+
 For a simple smoke check, write an artifact that names the obligation IDs it covers:
 
 ```json
@@ -446,6 +455,7 @@ The current implementation is early. Policy is file-backed but still simple, gen
 | `plan build` | IR plus change manifest | `vouch.plan.v0` verification plan |
 | `artifacts build` | Spec JSON | runner/verifier/release artifacts |
 | `junit map` | raw pytest/JUnit and `.vouch/test-map.json` | Vouch-compatible JUnit evidence |
+| `evidence import junit` | raw pytest/JUnit and compiled obligation IR | `.vouch/evidence/manifest.json` |
 | `policy simulate` | manifest, evidence, and release policy | policy input and release decision |
 | `evidence`, `verify`, `gate` | manifest and linked artifacts | findings and release decision |
 | Generic onboarding | repo shape and changed files | `.vouch` layout, contract suggestions, manifests, attached artifacts |
@@ -633,6 +643,13 @@ vouch --repo /path/to/repo manifest attach-artifact \
   --out .vouch/manifests/run-123.json
 ```
 
+For the repo-level v0.2 path, import raw JUnit into an evidence manifest:
+
+```sh
+vouch --repo /path/to/repo evidence import junit .vouch/artifacts/pytest.xml
+vouch --repo /path/to/repo gate
+```
+
 ## Commands
 
 ```sh
@@ -651,6 +668,7 @@ vouch --repo DIR --manifest FILE manifest check
 vouch --repo DIR manifest create --task-id ID --summary TEXT --agent NAME --run-id ID [--runner-identity ID --runner-oidc-issuer URL] --out FILE
 vouch --repo DIR --manifest FILE manifest attach-artifact --id ID --kind KIND --path FILE --exit-code N [--evidence-bundle FILE --signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE
 vouch --repo DIR --manifest FILE junit map --junit FILE --test-map FILE --out FILE
+vouch --repo DIR evidence import junit [--out FILE] FILE
 vouch --repo DIR --manifest FILE policy simulate [--policy FILE] [--require-signed]
 vouch --repo DIR --manifest FILE verify [--policy FILE]
 vouch --repo DIR --manifest FILE gate [--policy FILE] [--out FILE] [--require-signed]

--- a/demo_repo/README.md
+++ b/demo_repo/README.md
@@ -15,6 +15,7 @@ Run from the parent directory:
 ```sh
 vouch --repo demo_repo compile
 vouch --repo demo_repo compile --emit ir
+vouch --repo demo_repo evidence import junit artifacts/junit-pass.xml
 vouch intent parse --intent demo_repo/.vouch/intents/auth.password_reset.yaml --out /tmp/auth.password_reset.ast.json
 vouch intent compile --intent demo_repo/.vouch/intents/auth.password_reset.yaml --out /tmp/auth.password_reset.json
 vouch ir build --spec demo_repo/.vouch/specs/auth.password_reset.json --out /tmp/auth.password_reset.ir.json

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -96,6 +96,9 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 	case "gate":
 		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "gate", rest[1:])
 	case "evidence":
+		if len(rest) >= 3 && rest[1] == "import" {
+			return evidenceImport(absRepo, rest[2:], common.json, stdout, stderr)
+		}
 		return collectAndRender(absRepo, manifest, common.json, stdout, stderr, "evidence-no-exit", rest[1:])
 	}
 	usage(stderr)
@@ -447,6 +450,45 @@ func junitMap(repo string, args []string, jsonOut bool, stdout io.Writer, stderr
 	return 0
 }
 
+func evidenceImport(repo string, args []string, jsonOut bool, stdout io.Writer, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "evidence import requires a format: junit")
+		return 2
+	}
+	format := args[0]
+	flags := flag.NewFlagSet("evidence import "+format, flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	outPath := flags.String("out", "", "evidence manifest output path")
+	if err := flags.Parse(args[1:]); err != nil {
+		return 2
+	}
+	if format != "junit" {
+		fmt.Fprintf(stderr, "evidence import: unsupported format %q\n", format)
+		return 2
+	}
+	if flags.NArg() != 1 {
+		fmt.Fprintln(stderr, "evidence import junit requires exactly one JUnit XML path")
+		return 2
+	}
+	result, err := ImportJUnitEvidence(repo, EvidenceImportOptions{
+		ArtifactPath: flags.Arg(0),
+		Out:          *outPath,
+	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if jsonOut {
+		return renderCommandJSON(result, stdout, stderr)
+	}
+	fmt.Fprintf(stdout, "Imported JUnit evidence %s -> %s\n", result.InputPath, result.OutputPath)
+	fmt.Fprintf(stdout, "Linked obligations: %d\n", len(result.Links))
+	if len(result.UnmatchedObligations) > 0 {
+		fmt.Fprintf(stdout, "Unmatched obligations: %d\n", len(result.UnmatchedObligations))
+	}
+	return 0
+}
+
 func renderCommandJSON(value any, stdout io.Writer, stderr io.Writer) int {
 	data, err := json.MarshalIndent(value, "", "  ")
 	if err != nil {
@@ -715,7 +757,13 @@ func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.
 		fmt.Fprintf(stderr, "%s: unexpected argument %q\n", mode, flags.Arg(0))
 		return 2
 	}
-	evidence, err := CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: requireSigned, PolicyPath: *policyPath})
+	var evidence Evidence
+	var err error
+	if shouldUseEvidenceManifestFallback(repo, manifestPath) {
+		evidence, err = CollectEvidenceFromEvidenceManifest(repo, DefaultEvidenceManifest(repo), CollectEvidenceOptions{RequireSigned: requireSigned, PolicyPath: *policyPath})
+	} else {
+		evidence, err = CollectEvidenceWithOptions(repo, manifestPath, CollectEvidenceOptions{RequireSigned: requireSigned, PolicyPath: *policyPath})
+	}
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
@@ -776,6 +824,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  manifest attach-artifact --manifest FILE --id ID --kind KIND --path FILE --exit-code N [--evidence-bundle FILE --signature-bundle FILE --signer-identity ID --signer-oidc-issuer URL] --out FILE")
 	fmt.Fprintln(out, "  junit map --manifest FILE --junit FILE --test-map FILE --out FILE")
 	fmt.Fprintln(out, "  policy simulate [--manifest FILE] [--policy FILE] [--require-signed]")
+	fmt.Fprintln(out, "  evidence import junit [--out FILE] FILE")
 	fmt.Fprintln(out, "  verify [--policy FILE]")
 	fmt.Fprintln(out, "  gate [--policy FILE] [--out FILE] [--require-signed]")
 	fmt.Fprintln(out, "  evidence [--policy FILE]")

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -85,7 +85,7 @@ func buildCoverage(evidence *Evidence) {
 	securityCoverage := stringSet(evidence.Manifest.Verification.CoversSecurity)
 	runtimeCoverage := stringSet(evidence.Manifest.Runtime.Metrics)
 	artifactCoverage := artifactCoverageByKind(evidence.ArtifactResults)
-	useArtifacts := len(evidence.Manifest.Verification.Artifacts) > 0
+	useArtifacts := len(evidence.Manifest.Verification.Artifacts) > 0 || len(evidence.ArtifactResults) > 0
 	for _, specID := range evidence.Manifest.Change.SpecsTouched {
 		plan, ok := evidence.VerificationPlans[specID]
 		if !ok {
@@ -194,7 +194,8 @@ func verifyCompilation(evidence *Evidence) {
 }
 
 func verifyArtifactEvidence(evidence *Evidence) {
-	if evidence.SignedEvidenceRequired && evidence.Compilation.ObligationsBuilt > 0 && len(evidence.Manifest.Verification.Artifacts) == 0 {
+	hasLinkedArtifacts := len(evidence.Manifest.Verification.Artifacts) > 0 || len(evidence.ArtifactResults) > 0
+	if evidence.SignedEvidenceRequired && evidence.Compilation.ObligationsBuilt > 0 && !hasLinkedArtifacts {
 		evidence.Findings = append(evidence.Findings, Finding{
 			Verifier:    "evidence_linker",
 			Severity:    "high",
@@ -204,7 +205,7 @@ func verifyArtifactEvidence(evidence *Evidence) {
 			RequiredFix: "attach cosign-signed evidence artifacts for compiled obligations",
 		})
 	}
-	if evidence.Compilation.ObligationsBuilt > 0 && len(evidence.Manifest.Verification.Artifacts) == 0 && riskRank[evidence.Manifest.Change.Risk] >= riskRank[RiskMedium] {
+	if evidence.Compilation.ObligationsBuilt > 0 && !hasLinkedArtifacts && riskRank[evidence.Manifest.Change.Risk] >= riskRank[RiskMedium] {
 		evidence.Findings = append(evidence.Findings, Finding{
 			Verifier:    "evidence_linker",
 			Severity:    "high",
@@ -212,6 +213,19 @@ func verifyArtifactEvidence(evidence *Evidence) {
 			Claim:       "artifact-backed evidence is required for medium/high/critical changes",
 			Evidence:    fmt.Sprintf("change risk is %s and verification.artifacts is empty", evidence.Manifest.Change.Risk),
 			RequiredFix: "attach evidence artifacts that resolve to compiled obligations",
+		})
+	}
+	for _, artifact := range evidence.ArtifactResults {
+		if len(artifact.FailedTests) == 0 {
+			continue
+		}
+		evidence.Findings = append(evidence.Findings, Finding{
+			Verifier:    "test_adequacy",
+			Severity:    "high",
+			Decision:    "block",
+			Claim:       fmt.Sprintf("test evidence artifact %s reported failing tests", artifact.ID),
+			Evidence:    strings.Join(artifact.FailedTests, ", "),
+			RequiredFix: "fix failing tests before release",
 		})
 	}
 	for _, invalid := range evidence.InvalidEvidence {

--- a/internal/vouch/evidence_import_test.go
+++ b/internal/vouch/evidence_import_test.go
@@ -1,0 +1,95 @@
+package vouch
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEvidenceImportJUnitAndManifestlessGate(t *testing.T) {
+	repo := bootstrapFixture(t)
+	writeText(t, filepath.Join(repo, ".vouch", "artifacts", "pytest.xml"), `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="pytest" tests="1" failures="0" errors="0" skipped="0">
+  <testcase classname="tests.auth.test_password_reset" name="test_token_expiry" file="tests/auth/test_password_reset.py"></testcase>
+</testsuite>
+`)
+	var stdout, stderr bytes.Buffer
+
+	if code := Main([]string{"--repo", repo, "bootstrap"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("bootstrap failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main([]string{"--repo", repo, "compile"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("compile failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main([]string{"--repo", repo, "evidence", "import", "junit", ".vouch/artifacts/pytest.xml"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("evidence import failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Linked obligations: 1") {
+		t.Fatalf("unexpected import output: %s", stdout.String())
+	}
+	manifest := mustLoadEvidenceManifest(t, filepath.Join(repo, ".vouch", "evidence", "manifest.json"))
+	if len(manifest.Links) != 1 {
+		t.Fatalf("expected one evidence link, got %#v", manifest.Links)
+	}
+	link := manifest.Links[0]
+	if link.ObligationID != "auth.password_reset.required_test.token_expiry" || link.Status != "passed" {
+		t.Fatalf("unexpected evidence link: %#v", link)
+	}
+	if link.Testcase != "tests/auth/test_password_reset.py::test_token_expiry" {
+		t.Fatalf("expected source-file testcase link, got %#v", link)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Main([]string{"--repo", repo, "gate"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected gate to block missing non-JUnit evidence: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Release decision: block",
+		"Component:",
+		"auth.password_reset",
+		"Covered:",
+		"required_test.token_expiry",
+		"Missing:",
+		"security.security_sensitive_changes_require_explicit_evidence",
+		"accepted evidence: security_check",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected gate output to contain %q, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestEvidenceImportJUnitRejectsBeforeCompile(t *testing.T) {
+	repo := bootstrapFixture(t)
+	writeText(t, filepath.Join(repo, ".vouch", "artifacts", "pytest.xml"), `<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="pytest" tests="1">
+  <testcase classname="tests.auth.test_password_reset" name="test_token_expiry" file="tests/auth/test_password_reset.py"></testcase>
+</testsuite>
+`)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "evidence", "import", "junit", ".vouch/artifacts/pytest.xml"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected import to fail before compile: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "run vouch compile first") {
+		t.Fatalf("expected compile-first error, got stderr:\n%s", stderr.String())
+	}
+}
+
+func mustLoadEvidenceManifest(t *testing.T, path string) EvidenceManifest {
+	t.Helper()
+	manifest, err := LoadJSON[EvidenceManifest](path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return manifest
+}

--- a/internal/vouch/evidence_manifest.go
+++ b/internal/vouch/evidence_manifest.go
@@ -1,0 +1,388 @@
+package vouch
+
+import (
+	"encoding/xml"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func DefaultEvidenceManifest(repo string) string {
+	return filepath.Join(repo, ".vouch", "evidence", "manifest.json")
+}
+
+type EvidenceImportOptions struct {
+	ArtifactPath string
+	Out          string
+}
+
+func ImportJUnitEvidence(repo string, opts EvidenceImportOptions) (EvidenceImportResult, error) {
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return EvidenceImportResult{}, err
+	}
+	if opts.ArtifactPath == "" {
+		return EvidenceImportResult{}, errors.New("evidence import junit requires a JUnit XML artifact path")
+	}
+	outPath := opts.Out
+	if outPath == "" {
+		outPath = DefaultEvidenceManifest(absRepo)
+	} else {
+		outPath = resolveRepoOutput(absRepo, outPath)
+	}
+	artifactPath, err := resolveArtifactPath(absRepo, opts.ArtifactPath)
+	if err != nil {
+		return EvidenceImportResult{}, err
+	}
+	artifactRel := repoRelativePath(absRepo, artifactPath)
+	obligations, err := loadCompiledRequiredTests(absRepo)
+	if err != nil {
+		return EvidenceImportResult{}, err
+	}
+	data, err := os.ReadFile(artifactPath)
+	if err != nil {
+		return EvidenceImportResult{}, err
+	}
+	var root junitTestSuites
+	if err := xml.Unmarshal(data, &root); err != nil {
+		return EvidenceImportResult{}, fmt.Errorf("cannot parse JUnit XML: %w", err)
+	}
+	cases := collectJUnitCases(root)
+	if len(cases) == 0 {
+		return EvidenceImportResult{}, errors.New("JUnit XML contains no testcase elements")
+	}
+
+	links, unmatched := matchJUnitEvidenceLinks(obligations, cases, artifactRel)
+	manifest := EvidenceManifest{
+		Version:      EvidenceManifestVersion,
+		ArtifactType: "junit",
+		ArtifactPath: artifactRel,
+		Links:        links,
+	}
+	if err := writeJSONFile(outPath, manifest); err != nil {
+		return EvidenceImportResult{}, err
+	}
+	covered := make([]string, 0, len(links))
+	for _, link := range links {
+		if link.Status == "passed" {
+			covered = append(covered, link.ObligationID)
+		}
+	}
+	sort.Strings(covered)
+	sort.Strings(unmatched)
+	return EvidenceImportResult{
+		Version:              EvidenceManifestVersion,
+		InputPath:            artifactPath,
+		OutputPath:           outPath,
+		ArtifactType:         "junit",
+		Links:                links,
+		CoveredObligations:   covered,
+		UnmatchedObligations: unmatched,
+	}, nil
+}
+
+func CollectEvidenceFromEvidenceManifest(repo string, manifestPath string, opts CollectEvidenceOptions) (Evidence, error) {
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return Evidence{}, err
+	}
+	if manifestPath == "" {
+		manifestPath = DefaultEvidenceManifest(absRepo)
+	}
+	absManifest := resolveRepoOutput(absRepo, manifestPath)
+	evidenceManifest, err := LoadJSON[EvidenceManifest](absManifest)
+	if err != nil {
+		return Evidence{}, err
+	}
+	if evidenceManifest.Version != EvidenceManifestVersion {
+		return Evidence{}, fmt.Errorf("evidence manifest version must be %s", EvidenceManifestVersion)
+	}
+	specs, err := LoadSpecs(absRepo)
+	if err != nil {
+		return Evidence{}, err
+	}
+	specIDs := sortedStringKeys(specs)
+	if len(specIDs) == 0 {
+		return Evidence{}, errors.New("no compiled specs found; run vouch compile first")
+	}
+	risk := maxSpecRisk(specs, specIDs)
+	if risk == "" {
+		risk = RiskMedium
+	}
+	manifest := Manifest{
+		Version: ManifestSchemaVersion,
+		Task:    Task{ID: "compiled-evidence", Summary: "gate compiled evidence manifest"},
+		Change: Change{
+			Risk:         risk,
+			SpecsTouched: specIDs,
+		},
+		Agent: Agent{Name: "vouch"},
+		Verification: Verification{
+			Commands: []string{"vouch evidence import junit " + evidenceManifest.ArtifactPath},
+		},
+		Runtime: ManifestRuntime{
+			Metrics: runtimeMetricsForSpecs(specs, specIDs),
+			Canary: Canary{
+				Enabled:        canaryInitialPercent(risk) > 0,
+				InitialPercent: canaryInitialPercent(risk),
+			},
+		},
+		Rollback: rollbackForSpecs(specs, specIDs),
+	}
+	pipeline := CompileManifestPipeline(specs, manifest)
+	evidence := Evidence{
+		Version:                EvidenceSchemaVersion,
+		Repo:                   absRepo,
+		ManifestPath:           absManifest,
+		Compilation:            pipeline.Compilation,
+		Manifest:               manifest,
+		Specs:                  specs,
+		IRs:                    pipeline.IRs,
+		VerificationPlans:      pipeline.VerificationPlans,
+		Diagnostics:            pipeline.Diagnostics,
+		SignedEvidenceRequired: opts.RequireSigned,
+		SpecErrors:             pipeline.SpecErrors,
+		ManifestErrors:         pipeline.ManifestErrors,
+		ArtifactResults:        artifactResultsFromEvidenceManifest(evidenceManifest),
+		InvalidEvidence:        []InvalidEvidence{},
+		VerifierOutputs:        []VerifierOutput{},
+		RequiredObligations:    make(map[string][]Obligation),
+		CoveredObligations:     make(map[string][]Obligation),
+		MissingObligations:     make(map[string][]Obligation),
+		RequiredTests:          make(map[string][]string),
+		CoveredTests:           make(map[string][]string),
+		MissingTests:           make(map[string][]string),
+		RequiredSecurity:       make(map[string][]string),
+		CoveredSecurity:        make(map[string][]string),
+		MissingSecurity:        make(map[string][]string),
+		Findings:               []Finding{},
+		Reasons:                []string{},
+	}
+	buildCoverage(&evidence)
+	runVerifiers(&evidence)
+	importVerifierFindings(&evidence)
+	policy, policyPath, err := LoadReleasePolicy(absRepo, opts.PolicyPath)
+	if err != nil {
+		return Evidence{}, err
+	}
+	ApplyReleasePolicy(&evidence, policy, policyPath)
+	return evidence, nil
+}
+
+func loadCompiledRequiredTests(repo string) ([]Obligation, error) {
+	path := filepath.Join(repo, ".vouch", "build", "obligations.ir.json")
+	bundle, err := LoadJSON[ObligationIRBundle](path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("compiled obligation IR not found at %s; run vouch compile first", path)
+		}
+		return nil, err
+	}
+	var obligations []Obligation
+	for _, obligation := range bundle.Obligations {
+		if obligation.Kind == ObligationRequiredTest {
+			obligations = append(obligations, obligation)
+		}
+	}
+	sort.Slice(obligations, func(i, j int) bool { return obligations[i].ID < obligations[j].ID })
+	if len(obligations) == 0 {
+		return nil, errors.New("compiled obligation IR contains no required-test obligations")
+	}
+	return obligations, nil
+}
+
+func matchJUnitEvidenceLinks(obligations []Obligation, cases []junitTestCase, artifactPath string) ([]EvidenceManifestLink, []string) {
+	var links []EvidenceManifestLink
+	var unmatched []string
+	for _, obligation := range obligations {
+		testCase, ok := bestJUnitMatch(obligation, cases)
+		if !ok {
+			unmatched = append(unmatched, obligation.ID)
+			continue
+		}
+		links = append(links, EvidenceManifestLink{
+			ObligationID:     obligation.ID,
+			ArtifactType:     "junit",
+			ArtifactPath:     artifactPath,
+			Testcase:         junitEvidenceTestcase(testCase),
+			Status:           junitEvidenceStatus(testCase),
+			Component:        componentFromObligationID(obligation.ID),
+			RequiredEvidence: obligation.RequiredEvidence,
+		})
+	}
+	sort.Slice(links, func(i, j int) bool { return links[i].ObligationID < links[j].ObligationID })
+	return links, unmatched
+}
+
+func bestJUnitMatch(obligation Obligation, cases []junitTestCase) (junitTestCase, bool) {
+	bestScore := 0
+	var best junitTestCase
+	for _, testCase := range cases {
+		score := junitMatchScore(obligation, testCase)
+		if score > bestScore {
+			bestScore = score
+			best = testCase
+		}
+	}
+	return best, bestScore > 0
+}
+
+func junitMatchScore(obligation Obligation, testCase junitTestCase) int {
+	selectors := strings.ToLower(strings.Join(junitCaseSelectors(testCase), " "))
+	score := 0
+	if strings.Contains(selectors, strings.ToLower(obligation.ID)) {
+		score += 100
+	}
+	if obligation.Generated != nil {
+		sourceFile := strings.ToLower(filepath.ToSlash(obligation.Generated.Source.File))
+		sourceSymbol := strings.ToLower(obligation.Generated.Source.Symbol)
+		if sourceFile != "" && strings.Contains(selectors, strings.TrimSuffix(sourceFile, ".py")) {
+			score += 60
+		}
+		if sourceSymbol != "" && strings.Contains(selectors, sourceSymbol) {
+			score += 80
+		}
+	}
+	if testCase.Name != "" && wordSet(testCase.Name)[obligationTailWord(obligation.ID)] {
+		score += 30
+	}
+	score += 10 * sharedWordCount(obligationWords(obligation), wordSet(selectors))
+	componentWords := wordSet(componentFromObligationID(obligation.ID))
+	score += 5 * sharedWordCountFromSet(componentWords, wordSet(selectors))
+	if junitEvidenceStatus(testCase) != "passed" {
+		score -= 1
+	}
+	return score
+}
+
+func obligationWords(obligation Obligation) map[string]bool {
+	words := wordSet(obligation.ID)
+	for word := range wordSet(obligation.Text) {
+		words[word] = true
+	}
+	return words
+}
+
+func wordSet(value string) map[string]bool {
+	words := map[string]bool{}
+	var b strings.Builder
+	flush := func() {
+		if b.Len() == 0 {
+			return
+		}
+		word := b.String()
+		if len(word) > 1 {
+			words[word] = true
+		}
+		b.Reset()
+	}
+	for _, r := range strings.ToLower(value) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteRune(r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return words
+}
+
+func sharedWordCount(left map[string]bool, right map[string]bool) int {
+	return sharedWordCountFromSet(left, right)
+}
+
+func sharedWordCountFromSet(left map[string]bool, right map[string]bool) int {
+	count := 0
+	for word := range left {
+		if right[word] {
+			count++
+		}
+	}
+	return count
+}
+
+func obligationTailWord(obligationID string) string {
+	parts := strings.Split(obligationID, ".")
+	if len(parts) == 0 {
+		return ""
+	}
+	words := strings.FieldsFunc(parts[len(parts)-1], func(r rune) bool { return r == '_' || r == '-' })
+	if len(words) == 0 {
+		return parts[len(parts)-1]
+	}
+	return words[len(words)-1]
+}
+
+func componentFromObligationID(obligationID string) string {
+	parts := strings.Split(obligationID, ".")
+	if len(parts) < 3 {
+		return obligationID
+	}
+	return strings.Join(parts[:len(parts)-2], ".")
+}
+
+func junitEvidenceStatus(testCase junitTestCase) string {
+	switch {
+	case testCase.Failure != nil || testCase.Error != nil:
+		return "failed"
+	case testCase.Skipped != nil:
+		return "skipped"
+	default:
+		return "passed"
+	}
+}
+
+func junitEvidenceTestcase(testCase junitTestCase) string {
+	if testCase.File != "" && testCase.Name != "" {
+		return filepath.ToSlash(testCase.File) + "::" + testCase.Name
+	}
+	if testCase.Classname != "" && testCase.Name != "" {
+		return testCase.Classname + "::" + testCase.Name
+	}
+	return testCase.Label()
+}
+
+func artifactResultsFromEvidenceManifest(manifest EvidenceManifest) []ArtifactResult {
+	result := ArtifactResult{
+		ID:             manifest.ArtifactType,
+		Kind:           EvidenceTestCoverage,
+		Path:           manifest.ArtifactPath,
+		ResolvedPath:   manifest.ArtifactPath,
+		Status:         "valid",
+		HashVerified:   false,
+		BundleVerified: false,
+	}
+	seen := map[string]bool{}
+	for _, link := range manifest.Links {
+		if link.Status == "passed" {
+			if !seen[link.ObligationID] {
+				result.CoveredObligations = append(result.CoveredObligations, link.ObligationID)
+				seen[link.ObligationID] = true
+			}
+			continue
+		}
+		result.FailedTests = append(result.FailedTests, link.Testcase)
+	}
+	sort.Strings(result.CoveredObligations)
+	sort.Strings(result.FailedTests)
+	return []ArtifactResult{result}
+}
+
+func shouldUseEvidenceManifestFallback(repo string, manifestPath string) bool {
+	absRepo, err := filepath.Abs(repo)
+	if err != nil {
+		return false
+	}
+	absManifest, err := filepath.Abs(manifestPath)
+	if err != nil {
+		return false
+	}
+	defaultManifest := DefaultManifest(absRepo)
+	if absManifest != defaultManifest {
+		return false
+	}
+	return !fileExists(absManifest) && fileExists(DefaultEvidenceManifest(absRepo))
+}

--- a/internal/vouch/render.go
+++ b/internal/vouch/render.go
@@ -29,6 +29,22 @@ func RenderGate(evidence Evidence) string {
 	for _, reason := range evidence.Reasons {
 		fmt.Fprintf(&b, "- %s\n", reason)
 	}
+	for _, specID := range sortedRenderKeys(evidence.RequiredObligations) {
+		fmt.Fprintf(&b, "\nComponent:\n  %s\n", specID)
+		if len(evidence.CoveredObligations[specID]) > 0 {
+			b.WriteString("Covered:\n")
+			for _, obligation := range evidence.CoveredObligations[specID] {
+				fmt.Fprintf(&b, "  - %s\n", renderShortObligationID(specID, obligation.ID))
+			}
+		}
+		if len(evidence.MissingObligations[specID]) > 0 {
+			b.WriteString("Missing:\n")
+			for _, obligation := range evidence.MissingObligations[specID] {
+				fmt.Fprintf(&b, "  - %s\n", renderShortObligationID(specID, obligation.ID))
+				fmt.Fprintf(&b, "    accepted evidence: %s\n", obligation.RequiredEvidence)
+			}
+		}
+	}
 	return b.String()
 }
 
@@ -207,4 +223,8 @@ func obligationTextMap(items map[string][]Obligation) map[string][]string {
 		}
 	}
 	return out
+}
+
+func renderShortObligationID(specID string, obligationID string) string {
+	return strings.TrimPrefix(obligationID, specID+".")
 }

--- a/internal/vouch/types.go
+++ b/internal/vouch/types.go
@@ -6,6 +6,7 @@ const (
 	SpecSchemaVersion       = "vouch.spec.v0"
 	ManifestSchemaVersion   = "vouch.manifest.v0"
 	EvidenceSchemaVersion   = "vouch.evidence.v0"
+	EvidenceManifestVersion = "vouch.evidence_manifest.v0"
 	EvidenceBundleVersion   = "vouch.evidence_bundle.v0"
 	IntentSchemaVersion     = "vouch.intent.v0"
 	ASTSchemaVersion        = "vouch.ast.v0"
@@ -437,6 +438,33 @@ type Evidence struct {
 	Findings               []Finding                   `json:"findings"`
 	Decision               string                      `json:"decision"`
 	Reasons                []string                    `json:"reasons"`
+}
+
+type EvidenceManifest struct {
+	Version      string                 `json:"version"`
+	ArtifactType string                 `json:"artifact_type"`
+	ArtifactPath string                 `json:"artifact_path"`
+	Links        []EvidenceManifestLink `json:"links"`
+}
+
+type EvidenceManifestLink struct {
+	ObligationID     string       `json:"obligation_id"`
+	ArtifactType     string       `json:"artifact_type"`
+	ArtifactPath     string       `json:"artifact_path"`
+	Testcase         string       `json:"testcase"`
+	Status           string       `json:"status"`
+	Component        string       `json:"component"`
+	RequiredEvidence EvidenceKind `json:"required_evidence"`
+}
+
+type EvidenceImportResult struct {
+	Version              string                 `json:"version"`
+	InputPath            string                 `json:"input_path"`
+	OutputPath           string                 `json:"output_path"`
+	ArtifactType         string                 `json:"artifact_type"`
+	Links                []EvidenceManifestLink `json:"links"`
+	CoveredObligations   []string               `json:"covered_obligations"`
+	UnmatchedObligations []string               `json:"unmatched_obligations"`
 }
 
 type CompilationStats struct {


### PR DESCRIPTION
## Summary

Added JUnit evidence import and gate linking.
  
## What Changed

  - Added:

  vouch evidence import junit FILE

  - Writes:

  ```.vouch/evidence/manifest.json```

  - Links JUnit testcases to compiled required_test obligations
  - Allows vouch gate to use .vouch/evidence/manifest.json when no change manifest exists
  - Improves gate output to show:
      - covered obligations
      - missing obligations
      - accepted evidence type for missing items

## Validation

  ```go test ./...```