### PR TITLE
feat: add github summary packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,15 @@
   <img src="assets/vouch.png" alt="Vouch logo" width="240">
 </p>
 
-# Vouch (Beta)
+# Vouch
+
+Vouch is an intent compiler for AI-written code.
+
+It drafts conservative release contracts from signals already present in your repo: tests, CODEOWNERS, OpenAPI specs, CI config, and evidence artifacts. It then compiles accepted contracts into machine-checkable obligations and gates releases on linked evidence.
+
+Vouch does not guess your product intent. Humans own intent. `vouch bootstrap` creates contract drafts with provenance so you can accept, edit, or reject them.
 
 ## What Vouch Is Today
-
-Vouch is a beta contract-and-evidence gate for agent-written changes.
 
 It compiles human-owned intent YAML into typed specs, obligation IR, verification plans, and runner/verifier/release artifacts. It then validates a change manifest and linked evidence artifacts to produce a deterministic release decision: `block`, `human_escalation`, `canary`, or `auto_merge`.
 
@@ -20,7 +24,13 @@ Use this when you have an existing repo and want Vouch to produce a release deci
 
 ### 0. Install The CLI
 
-From the Vouch checkout:
+Install from GitHub:
+
+```sh
+go install github.com/duriantaco/vouch/cmd/vouch@latest
+```
+
+Or, from the Vouch checkout:
 
 ```sh
 go install ./cmd/vouch
@@ -39,6 +49,16 @@ export PATH="$(go env GOPATH)/bin:$PATH"
 ```
 
 If you are developing Vouch itself and do not want to install the binary, replace `vouch` with `go run ./cmd/vouch` in the commands below.
+
+Fast v0.2 flow:
+
+```sh
+vouch bootstrap
+vouch compile
+pytest --junitxml .vouch/artifacts/pytest.xml
+vouch evidence import junit .vouch/artifacts/pytest.xml
+vouch gate
+```
 
 The mental model:
 
@@ -650,6 +670,16 @@ vouch --repo /path/to/repo evidence import junit .vouch/artifacts/pytest.xml
 vouch --repo /path/to/repo gate
 ```
 
+## GitHub PR Summary
+
+Use `gate --github-summary` in GitHub Actions to append a Markdown decision report to the pull request job summary:
+
+```sh
+vouch gate --github-summary
+```
+
+The command writes to `$GITHUB_STEP_SUMMARY` and still exits non-zero when the release decision is `block`. A copyable workflow example lives at [`docs/github-action-example.yml`](docs/github-action-example.yml).
+
 ## Commands
 
 ```sh
@@ -671,7 +701,7 @@ vouch --repo DIR --manifest FILE junit map --junit FILE --test-map FILE --out FI
 vouch --repo DIR evidence import junit [--out FILE] FILE
 vouch --repo DIR --manifest FILE policy simulate [--policy FILE] [--require-signed]
 vouch --repo DIR --manifest FILE verify [--policy FILE]
-vouch --repo DIR --manifest FILE gate [--policy FILE] [--out FILE] [--require-signed]
+vouch --repo DIR --manifest FILE gate [--policy FILE] [--out FILE] [--github-summary] [--require-signed]
 vouch --repo DIR --manifest FILE evidence [--policy FILE]
 ```
 

--- a/cmd/vouch/main.go
+++ b/cmd/vouch/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"os"
 
-	"vouch/internal/vouch"
+	"github.com/duriantaco/vouch/internal/vouch"
 )
 
 func main() {

--- a/demo_repo/README.md
+++ b/demo_repo/README.md
@@ -1,9 +1,12 @@
 # Demo Repo
 
-This directory is a tiny fixture for the Vouch compiler MVP.
+This directory is a tiny password-reset fixture for the Vouch compiler MVP.
 
-It contains one high-risk feature contract and three agent-change manifests:
+It contains a small app surface, one high-risk feature contract, and three agent-change manifests:
 
+- `src/auth/password_reset.py`
+- `tests/auth/test_password_reset.py`
+- `CODEOWNERS`
 - `.vouch/intents/auth.password_reset.yaml`
 - `.vouch/specs/auth.password_reset.json`
 - `.vouch/manifests/blocked.json`
@@ -16,6 +19,7 @@ Run from the parent directory:
 vouch --repo demo_repo compile
 vouch --repo demo_repo compile --emit ir
 vouch --repo demo_repo evidence import junit artifacts/junit-pass.xml
+GITHUB_STEP_SUMMARY=/tmp/vouch-summary.md vouch --repo demo_repo gate --github-summary || true
 vouch intent parse --intent demo_repo/.vouch/intents/auth.password_reset.yaml --out /tmp/auth.password_reset.ast.json
 vouch intent compile --intent demo_repo/.vouch/intents/auth.password_reset.yaml --out /tmp/auth.password_reset.json
 vouch ir build --spec demo_repo/.vouch/specs/auth.password_reset.json --out /tmp/auth.password_reset.ir.json
@@ -32,3 +36,5 @@ Expected gate results:
 | --- | --- |
 | `blocked.json` | `block` |
 | `pass.json` | `canary` |
+
+The local tests can pass while Vouch still blocks if security, runtime, or rollback evidence is missing. That is the point of the demo: test results are evidence for required-test obligations, not proof that every release obligation is covered.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module vouch
+module github.com/duriantaco/vouch
 
 go 1.26
 

--- a/internal/vouch/bootstrap_cli_test.go
+++ b/internal/vouch/bootstrap_cli_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	bootstrap "vouch/internal/vouch/bootstrap"
+	bootstrap "github.com/duriantaco/vouch/internal/vouch/bootstrap"
 )
 
 func TestBootstrapDryRunDraftsConservativeContracts(t *testing.T) {

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	bootstrap "vouch/internal/vouch/bootstrap"
+	bootstrap "github.com/duriantaco/vouch/internal/vouch/bootstrap"
 )
 
 func Main(args []string, stdout io.Writer, stderr io.Writer) int {
@@ -745,10 +745,12 @@ func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.
 	flags.SetOutput(stderr)
 	gateOut := ""
 	requireSigned := false
+	githubSummary := false
 	policyPath := flags.String("policy", "", "release policy path")
 	if mode == "gate" {
 		flags.StringVar(&gateOut, "out", "", "path to write compact gate result JSON")
 		flags.BoolVar(&requireSigned, "require-signed", false, "require cosign-verified evidence artifacts")
+		flags.BoolVar(&githubSummary, "github-summary", false, "append a Markdown gate summary to GITHUB_STEP_SUMMARY")
 	}
 	if err := flags.Parse(args); err != nil {
 		return 2
@@ -770,6 +772,12 @@ func collectAndRender(repo string, manifestPath string, jsonOut bool, stdout io.
 	}
 	if gateOut != "" {
 		if err := writeJSONFile(resolveRepoOutput(repo, gateOut), GateResultFromEvidence(evidence)); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+	}
+	if githubSummary {
+		if err := appendGitHubSummary(evidence); err != nil {
 			fmt.Fprintln(stderr, err)
 			return 1
 		}
@@ -826,6 +834,25 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  policy simulate [--manifest FILE] [--policy FILE] [--require-signed]")
 	fmt.Fprintln(out, "  evidence import junit [--out FILE] FILE")
 	fmt.Fprintln(out, "  verify [--policy FILE]")
-	fmt.Fprintln(out, "  gate [--policy FILE] [--out FILE] [--require-signed]")
+	fmt.Fprintln(out, "  gate [--policy FILE] [--out FILE] [--github-summary] [--require-signed]")
 	fmt.Fprintln(out, "  evidence [--policy FILE]")
+}
+
+func appendGitHubSummary(evidence Evidence) error {
+	path := strings.TrimSpace(os.Getenv("GITHUB_STEP_SUMMARY"))
+	if path == "" {
+		return errors.New("gate --github-summary requires GITHUB_STEP_SUMMARY to be set")
+	}
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if _, err := fmt.Fprint(file, RenderGitHubSummary(evidence)); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprint(file, "\n"); err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/vouch/compile.go
+++ b/internal/vouch/compile.go
@@ -6,7 +6,7 @@ import (
 	"sort"
 	"strings"
 
-	bootstrap "vouch/internal/vouch/bootstrap"
+	bootstrap "github.com/duriantaco/vouch/internal/vouch/bootstrap"
 )
 
 type RepoCompileOutput struct {

--- a/internal/vouch/github_summary_test.go
+++ b/internal/vouch/github_summary_test.go
@@ -1,0 +1,54 @@
+package vouch
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGateGitHubSummaryWritesStepSummary(t *testing.T) {
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, nil)
+	summaryPath := filepath.Join(t.TempDir(), "summary.md")
+	t.Setenv("GITHUB_STEP_SUMMARY", summaryPath)
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "--manifest", manifestPath, "gate", "--github-summary"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("gate --github-summary failed: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Release decision: auto_merge") {
+		t.Fatalf("expected normal gate output, got %s", stdout.String())
+	}
+	data, err := os.ReadFile(summaryPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	summary := string(data)
+	for _, want := range []string{
+		"# Vouch Gate",
+		"| Decision | `auto_merge` |",
+		"| Obligations | `5/5 covered` |",
+		"### `ui.copy`",
+		"| Covered | `required_test.button_label_renders` | `test_coverage` |",
+	} {
+		if !strings.Contains(summary, want) {
+			t.Fatalf("expected summary to contain %q, got:\n%s", want, summary)
+		}
+	}
+}
+
+func TestGateGitHubSummaryRequiresEnvironment(t *testing.T) {
+	repo, manifestPath, _ := writeFullyCoveredUIScenario(t, nil)
+	t.Setenv("GITHUB_STEP_SUMMARY", "")
+	var stdout, stderr bytes.Buffer
+
+	code := Main([]string{"--repo", repo, "--manifest", manifestPath, "gate", "--github-summary"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected missing summary env to fail: code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "GITHUB_STEP_SUMMARY") {
+		t.Fatalf("expected missing GITHUB_STEP_SUMMARY error, got %s", stderr.String())
+	}
+}

--- a/internal/vouch/render.go
+++ b/internal/vouch/render.go
@@ -48,6 +48,56 @@ func RenderGate(evidence Evidence) string {
 	return b.String()
 }
 
+func RenderGitHubSummary(evidence Evidence) string {
+	covered, total := obligationCoverageCounts(evidence)
+	var b strings.Builder
+	b.WriteString("# Vouch Gate\n\n")
+	b.WriteString("| Field | Value |\n")
+	b.WriteString("| --- | --- |\n")
+	fmt.Fprintf(&b, "| Decision | `%s` |\n", markdownCell(evidence.Decision))
+	fmt.Fprintf(&b, "| Risk | `%s` |\n", markdownCell(string(evidence.Manifest.Change.Risk)))
+	fmt.Fprintf(&b, "| Obligations | `%d/%d covered` |\n", covered, total)
+	fmt.Fprintf(&b, "| Policy | `%s` |\n", markdownCell(evidence.PolicyPath))
+	b.WriteByte('\n')
+
+	if len(evidence.Reasons) > 0 {
+		b.WriteString("## Reasons\n\n")
+		for _, reason := range evidence.Reasons {
+			fmt.Fprintf(&b, "- %s\n", reason)
+		}
+		b.WriteByte('\n')
+	}
+
+	b.WriteString("## Components\n\n")
+	if len(evidence.RequiredObligations) == 0 {
+		b.WriteString("No compiled obligations were required for this gate.\n\n")
+	} else {
+		for _, specID := range sortedRenderKeys(evidence.RequiredObligations) {
+			fmt.Fprintf(&b, "### `%s`\n\n", markdownCell(specID))
+			b.WriteString("| Status | Obligation | Accepted Evidence |\n")
+			b.WriteString("| --- | --- | --- |\n")
+			for _, obligation := range evidence.CoveredObligations[specID] {
+				fmt.Fprintf(&b, "| Covered | `%s` | `%s` |\n", markdownCell(renderShortObligationID(specID, obligation.ID)), obligation.RequiredEvidence)
+			}
+			for _, obligation := range evidence.MissingObligations[specID] {
+				fmt.Fprintf(&b, "| Missing | `%s` | `%s` |\n", markdownCell(renderShortObligationID(specID, obligation.ID)), obligation.RequiredEvidence)
+			}
+			b.WriteByte('\n')
+		}
+	}
+
+	if len(evidence.Findings) > 0 {
+		b.WriteString("## Findings\n\n")
+		b.WriteString("| Decision | Verifier | Claim | Required Fix |\n")
+		b.WriteString("| --- | --- | --- | --- |\n")
+		for _, finding := range evidence.Findings {
+			fmt.Fprintf(&b, "| `%s` | `%s` | %s | %s |\n", markdownCell(finding.Decision), markdownCell(finding.Verifier), markdownCell(finding.Claim), markdownCell(finding.RequiredFix))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
 func GateResultFromEvidence(evidence Evidence) GateResult {
 	return GateResult{
 		Version:            "vouch.gate_result.v0",
@@ -227,4 +277,20 @@ func obligationTextMap(items map[string][]Obligation) map[string][]string {
 
 func renderShortObligationID(specID string, obligationID string) string {
 	return strings.TrimPrefix(obligationID, specID+".")
+}
+
+func obligationCoverageCounts(evidence Evidence) (int, int) {
+	total := 0
+	covered := 0
+	for _, specID := range sortedRenderKeys(evidence.RequiredObligations) {
+		total += len(evidence.RequiredObligations[specID])
+		covered += len(evidence.CoveredObligations[specID])
+	}
+	return covered, total
+}
+
+func markdownCell(value string) string {
+	value = strings.ReplaceAll(value, "|", "\\|")
+	value = strings.ReplaceAll(value, "\n", " ")
+	return strings.TrimSpace(value)
 }


### PR DESCRIPTION
## Summary

  Add GitHub PR visibility and product packaging. Makes Vouch easier to understand from CI and the README.

## What Changed

  - Added:

```bash
  vouch gate --github-summary
```
  
- Writes a Markdown gate report to:

  $GITHUB_STEP_SUMMARY

  - GitHub summary includes:
      - release decision
      - risk
      - obligation coverage
      - policy path
      - covered obligations
      - missing obligations
      - findings
      
  - Added GitHub Action example:
  docs/github-action-example.yml

  ## Validation

  ```go test ./...```