### PR TITLE
chore: add demo packaging files

### DIFF
--- a/demo_repo/.github/workflows/ci.yml
+++ b/demo_repo/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: Demo CI
+
+on:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pytest --junitxml artifacts/junit-pass.xml

--- a/demo_repo/CODEOWNERS
+++ b/demo_repo/CODEOWNERS
@@ -1,0 +1,2 @@
+/src/auth/** @platform
+/tests/auth/** @platform

--- a/demo_repo/src/auth/password_reset.py
+++ b/demo_repo/src/auth/password_reset.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from hashlib import sha256
+
+
+TOKEN_TTL = timedelta(minutes=30)
+
+
+def issue_reset_token(email: str, now: datetime | None = None) -> dict[str, str]:
+    now = now or datetime.now(timezone.utc)
+    token = sha256(f"{email}:{now.isoformat()}".encode()).hexdigest()
+    expires_at = now + TOKEN_TTL
+    return {
+        "message": "If an account exists, reset instructions have been sent.",
+        "token_hash": sha256(token.encode()).hexdigest(),
+        "expires_at": expires_at.isoformat(),
+    }

--- a/demo_repo/tests/auth/test_password_reset.py
+++ b/demo_repo/tests/auth/test_password_reset.py
@@ -1,0 +1,16 @@
+from datetime import datetime, timezone
+
+from src.auth.password_reset import issue_reset_token
+
+
+def test_token_expires():
+    issued = issue_reset_token("user@example.com", datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    assert issued["expires_at"] == "2026-01-01T00:30:00+00:00"
+
+
+def test_unknown_email_receives_same_response_shape():
+    issued = issue_reset_token("missing@example.com", datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+    assert set(issued) == {"message", "token_hash", "expires_at"}
+    assert issued["message"] == "If an account exists, reset instructions have been sent."

--- a/docs/github-action-example.yml
+++ b/docs/github-action-example.yml
@@ -1,0 +1,32 @@
+name: Vouch
+
+on:
+  pull_request:
+
+jobs:
+  vouch:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install Vouch
+        run: go install github.com/duriantaco/vouch/cmd/vouch@latest
+
+      - name: Bootstrap Vouch contracts
+        run: vouch bootstrap --check || vouch bootstrap
+
+      - name: Compile Vouch obligations
+        run: vouch compile
+
+      - name: Run tests
+        run: pytest --junitxml .vouch/artifacts/pytest.xml
+
+      - name: Import JUnit evidence
+        run: vouch evidence import junit .vouch/artifacts/pytest.xml
+
+      - name: Gate PR
+        run: vouch gate --github-summary


### PR DESCRIPTION
## Summary

  Adds the packaging and demo files

## What Changed

  - Adds GitHub Action example workflow:

  ```text
  docs/github-action-example.yml

  - Adds demo repo packaging files:
      - demo_repo/CODEOWNERS
      - demo_repo/.github/workflows/ci.yml
      - demo_repo/src/auth/password_reset.py
      - demo_repo/tests/auth/test_password_reset.py

## Why

PR #10 added gate --github-summary and README/docs references, but these new demo and docs files were accidentally left out

## Validation
```
  go test ./...
```