### PR TITLE
test: strengthen vouchbench acceptance harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,19 +4,239 @@
 
 # Vouch
 
-Vouch is an intent compiler for AI-written code.
+Vouch is a contract-and-evidence release gate for AI-written code.
 
-It drafts conservative release contracts from signals already present in your repo: tests, CODEOWNERS, OpenAPI specs, CI config, and evidence artifacts. It then compiles accepted contracts into machine-checkable obligations and gates releases on linked evidence.
+It does one narrow job: given human-owned intent for a part of a repo, Vouch compiles that intent into machine-checkable obligations, links runner-produced evidence to those obligations, and returns a deterministic release decision: `block`, `human_escalation`, `canary`, or `auto_merge`.
 
-Vouch does not guess your product intent. Humans own intent. `vouch bootstrap` creates contract drafts with provenance so you can accept, edit, or reject them.
+## Contents
 
-## What Vouch Is Today
+- [The Problem](#the-problem)
+- [Why Use It](#why-use-it)
+- [Why Not Just Use Another Agent?](#why-not-just-use-another-agent)
+- [Current Validation](#current-validation)
+- [Real Repo Walkthrough](#real-repo-walkthrough)
+- [Clear Limits](#clear-limits)
+- [Quickstart](#quickstart)
+- [FAQ](#faq)
+- [Project Docs](#project-docs)
+- [Validation Status](#validation-status)
+- [Demo](#demo)
+- [Commands](#commands)
 
-It compiles human-owned intent YAML into typed specs, obligation IR, verification plans, and runner/verifier/release artifacts. It then validates a change manifest and linked evidence artifacts to produce a deterministic release decision: `block`, `human_escalation`, `canary`, or `auto_merge`.
+## The Problem
 
-It is **NOT** a code reviewer. It does not read a diff and decide whether the implementation is good. It does not run your tests today. External runners execute tests, probes, scanners, and deployment checks. Vouch checks whether the resulting evidence maps to the obligations compiled from explicit contracts.
+AI agents can produce code faster than humans can carefully review every line. CI can tell you whether commands passed, but it usually cannot answer the release question that matters for agent changes:
 
-Use it as experimental infrastructure for designing Vouch verification contracts, not as a replacement for production security review, code review, incident response, or human ownership of product intent.
+> For the contracts this change touches, are the required behavior, security, test, runtime, and rollback obligations covered by valid evidence?
+
+Vouch adds that missing control plane. Humans declare what must remain true, existing runners produce evidence, and Vouch checks whether the evidence is complete enough for the repo's release policy.
+
+## Why Use It
+
+Use Vouch when you want:
+
+- Agent changes tied to explicit, human-owned product and release contracts.
+- Passing tests to be necessary but not sufficient for risky changes.
+- Stable obligation IDs that connect intent, changed files, evidence artifacts, and release decisions.
+- A CI-friendly gate that consumes existing JUnit, JSON, text, verifier, metric, and rollback artifacts instead of replacing your runner.
+- Optional signed evidence checks that bind artifacts to approved runner identities.
+
+Do not use Vouch for every small change. For low-risk edits, normal CI and review may be enough. Vouch is useful when the cost of a bad agent change is high enough that "tests passed" and "another agent said it looks fine" are not strong enough release criteria.
+
+## Why Not Just Use Another Agent?
+
+Another agent can review a diff, but it is still an opinion over code. It may miss the same release concerns a human skim misses, and its output is hard to turn into a stable merge rule.
+
+Vouch is different because it asks for explicit release evidence:
+
+| Question | Another Agent | Vouch |
+| --- | --- | --- |
+| Who owns the intended behavior? | Usually inferred from the diff or prompt. | Declared in a human-owned contract. |
+| What must be checked before release? | Whatever the agent decides to inspect. | Compiled into stable obligation IDs. |
+| What happens when tests pass but rollout evidence is missing? | Often depends on reviewer judgment. | Gate blocks or escalates according to policy. |
+| Can the result be audited later? | Usually a prose comment or chat transcript. | Manifest, evidence artifacts, coverage, policy rule, and decision. |
+| Can CI enforce it deterministically? | Not reliably without custom glue. | Yes, `vouch gate` exits non-zero on `block`. |
+
+The benefit is not "more AI review." The benefit is a release boundary that says: for this kind of change, these obligations must have these evidence artifacts, or the change does not ship.
+
+That is also why there are several moving parts:
+
+- contracts define intent
+- compile turns intent into stable obligations
+- runners produce evidence
+- gate checks evidence coverage and policy
+
+You only pay that cost where the release risk justifies it: auth, payments, permissions, data deletion, migrations, external side effects, public APIs, production rollout, and other changes where a vague approval is not enough.
+
+## Current Validation
+
+Vouch includes a repo-local acceptance suite, VouchBench, for the current release-gate behavior. It builds the local CLI, runs isolated fixture repos, and fails non-zero if expected decisions, exit codes, coverage counts, missing obligation IDs, invalid evidence codes, policy rules, manifest/spec errors, or selected artifact statuses regress.
+
+The current VouchBench corpus passes 10/10 scenarios and 114/114 assertions:
+
+| Scenario | Baseline | Expected Vouch Decision | Validation Signal |
+| --- | --- | --- | --- |
+| High-risk auth with JUnit only | tests pass | `block` | Tests alone do not cover behavior, security, runtime, or rollback obligations. |
+| High-risk auth with partial release evidence | tests pass | `block` | Partial artifacts are not enough when compiled obligations remain uncovered. |
+| High-risk auth with full evidence but bad manifest traceability | tests pass | `block` | Full obligation coverage can still block when changed files are not owned by touched specs. |
+| High-risk auth with non-zero test artifact | tests fail | `block` | Artifact exit codes are enforced. This is a negative control tests already catch. |
+| High-risk auth with complete evidence and canary | tests pass | `canary` | Complete evidence routes high-risk auth to canary, not auto-merge. |
+| High-risk auth with complete evidence but no canary | tests pass | `human_escalation` | High-risk complete evidence without canary escalates to a human. |
+| Medium/high platform change across auth, payments, and API with partial evidence | tests pass | `block` | A 25-obligation multi-component release blocks when one high-risk component lacks security, runtime, and rollback evidence. |
+| Medium/high platform change across auth, payments, and API with complete evidence | tests pass | `canary` | A larger multi-component release can pass to canary when all obligations are covered. |
+| Medium-risk API-only change inside the platform repo | tests pass | `auto_merge` | Vouch scopes obligations to the touched medium-risk contract instead of gating the whole repo. |
+| Low-risk docs with complete evidence | tests pass | `auto_merge` | Vouch is not just a blocker. Low-risk complete evidence can pass. |
+
+The generic onboarding flow has also been exercised against temp copies of real Python repos (`sundae`, `sago`, and `wooster`) using `init`, `contract suggest`, `contract create`, `manifest create`, JUnit mapping/import, artifact attachment, and `gate`.
+
+This validation is evidence of deterministic gate behavior over the stated corpus. It does not certify arbitrary code. See [Benchmarks](docs/BENCHMARKS.md) for the harness, assertions, and limits.
+
+## Real Repo Walkthrough
+
+This walkthrough uses [Pallets Click](https://github.com/pallets/click), a widely used Python CLI library. Pallets projects use `pytest` for tests, and Click 8.3.2 declares a `tests` dependency group with `pytest`.
+
+The point of this walkthrough is not to claim Vouch understands Click. The point is to show the whole first-run workflow on a real repository:
+
+```text
+repo -> draft contracts -> compile obligations -> run tests -> import JUnit -> gate
+```
+
+### 1. Clone A Pinned Real Repo
+
+Use a pinned tag so the counts below are reproducible:
+
+```sh
+mkdir -p /tmp/vouch-real-repo
+cd /tmp/vouch-real-repo
+
+git clone --depth 1 --branch 8.3.2 https://github.com/pallets/click.git
+cd click
+```
+
+### 2. Install Test Dependencies
+
+```sh
+python3 -m venv .venv
+. .venv/bin/activate
+
+python -m pip install -U pip
+python -m pip install -e . pytest
+```
+
+### 3. Draft And Compile Vouch Contracts
+
+Run Vouch before running tests so generated `__pycache__` files do not become repo signals.
+
+```sh
+vouch init
+vouch bootstrap --dry-run
+vouch bootstrap
+vouch compile
+```
+
+On Click 8.3.2, `vouch compile` currently produces:
+
+```text
+Compiled 31 contract drafts into 195 obligations.
+```
+
+This means Vouch found repo signals, wrote draft intent files under `.vouch/intents/`, compiled specs under `.vouch/specs/`, and built aggregate obligation IR under `.vouch/build/obligations.ir.json`.
+
+At this point a human should inspect the generated intents. Bootstrap is conservative scaffolding, not product understanding. You should edit owners, risk levels, paths, behavior, security invariants, runtime signals, and rollback expectations before relying on the gate.
+
+### 4. Run The Project Tests With JUnit
+
+```sh
+mkdir -p .vouch/artifacts
+python -m pytest --junitxml .vouch/artifacts/pytest.xml
+```
+
+On one local run against Click 8.3.2, pytest reported:
+
+```text
+1384 passed, 22 skipped, 30000 deselected, 1 xfailed
+```
+
+The exact test count can vary with Python and dependency versions. The important artifact is `.vouch/artifacts/pytest.xml`.
+
+### 5. Import Test Evidence
+
+```sh
+vouch evidence import junit .vouch/artifacts/pytest.xml
+```
+
+On the same Click run, Vouch linked:
+
+```text
+Linked obligations: 51
+```
+
+That means JUnit satisfied 51 required-test obligations. It does not satisfy behavior, security, runtime, or rollback obligations.
+
+### 6. Run The Gate
+
+```sh
+vouch gate
+```
+
+Expected first-run result:
+
+```text
+Release decision: block
+```
+
+That block is expected. It means:
+
+- tests passed
+- Vouch imported test evidence
+- required-test obligations were covered
+- other generated obligations still lack accepted evidence
+
+That is the main difference from plain CI. CI answers "did pytest pass?" Vouch asks "for the contracts touched by this release, are all required evidence classes covered?"
+
+### 7. What You Do Next
+
+For a real adoption pass, do not try to make every generated draft pass blindly. Tighten the contract set:
+
+1. Delete or merge low-value generated intent files.
+2. Assign real owners instead of `unowned`.
+3. Keep contracts that match real release boundaries, for example `click.parser`, `click.termui`, `click.shell_completion`, and `click.testing`.
+4. Replace generated behavior text with human-owned behavior obligations.
+5. Keep required-test obligations mapped to real tests.
+6. Add security, runtime, and rollback evidence only where those obligations matter for the component risk.
+7. Re-run `vouch compile`, `vouch evidence import junit`, and `vouch gate`.
+
+If you only want a non-destructive evaluation of another repo, use the snapshot evaluator from the Vouch checkout:
+
+```sh
+cd /path/to/vouch
+
+scripts/vouchbench-repo.sh \
+  --repo /path/to/repo \
+  --test-command "mkdir -p .vouch/artifacts && python -m pytest --junitxml .vouch/artifacts/pytest.xml" \
+  --junit .vouch/artifacts/pytest.xml \
+  --out /tmp/vouchbench-repo
+```
+
+That copies the target repo into a temp directory and writes Vouch files only inside the snapshot.
+
+## Clear Limits
+
+Vouch is beta infrastructure, not a production-ready assurance system.
+
+It does **not**:
+
+- Review arbitrary diffs or decide whether an implementation is good.
+- Infer product intent automatically. `vouch bootstrap` drafts conservative contracts from repo signals, but humans must accept, edit, or reject them.
+- Run tests, probes, scanners, or deployment checks. External runners produce evidence. Vouch checks how that evidence maps to compiled obligations.
+- Validate a generic JSON or text artifact as truthful beyond structure, status, obligation IDs, path, exit code, optional hash, and optional signature checks.
+- Replace production code review, security review, incident response, rollout ownership, or human ownership of product intent.
+
+## What Vouch Does Today
+
+Vouch drafts conservative release contracts from signals already present in your repo, including tests, CODEOWNERS, OpenAPI specs, CI config, and evidence artifacts. It compiles accepted intent YAML into typed specs, obligation IR, verification plans, and runner/verifier/release artifacts. It then validates a change manifest and linked evidence artifacts to produce a release decision.
+
+Use it today as experimental infrastructure for designing and exercising verification contracts for agent-authored changes.
 
 ## Quickstart
 
@@ -93,7 +313,7 @@ This creates:
 vouch --repo /path/to/your/repo contract suggest --json
 ```
 
-Pick one suggestion as a starting point. Vouch suggestions are structural; you still need to write the real product intent.
+Pick one suggestion as a starting point. Vouch suggestions are structural. You still need to write the real product intent.
 
 ### 3. Create A Contract
 
@@ -337,6 +557,8 @@ vouch --repo /path/to/your/repo \
 
 - [Roadmap](ROADMAP.md) explains where the project is going and what remains before this can be production infrastructure.
 - [Comparison](COMPARISON.md) explains how Vouch composes with Sigstore, SLSA, in-toto, OPA, and Conftest.
+- [Benchmarks](docs/BENCHMARKS.md) explains the repo-local VouchBench harness, assertions, and current validation scope.
+- `scripts/vouchbench-repo.sh --repo /path/to/repo` runs a non-destructive Vouch evaluation against an external repo snapshot.
 - [Contributing](CONTRIBUTING.md) explains how to help and which areas need work.
 
 The problem it attempts to solve is:
@@ -355,7 +577,7 @@ Vouch's answer is:
 8. Deterministic evidence checks
 9. Release decision
 
-The output is not generated product code, and it is not proof that the implementation is correct. The output is an auditable answer to a narrower question. For the contracts this change claims to touch, are the required obligations covered by evidence artifacts that pass Vouch's current checks?
+The output is not generated product code, and it does not certify that the implementation is correct. The output is an auditable answer to a narrower question. For the contracts this change claims to touch, are the required obligations covered by evidence artifacts that pass Vouch's current checks?
 
 ## Current Assurance Level
 
@@ -387,10 +609,18 @@ Today, Vouch cannot check:
 - Whether a generic JSON/text artifact is truthful beyond its structure, IDs, status, path, exit code, and optional hash.
 - Whether tests were actually run unless the external runner preserves and signs the artifact chain.
 - Whether product intent was inferred correctly from code.
-- Whether release policy uses a general-purpose policy language such as Rego; the current policy evaluator is a small Vouch JSON rule engine.
-- Whether signer identities should vary by contract owner, path, or risk tier; the current allowlist is repo-level.
+- Whether release policy uses a general-purpose policy language such as Rego. The current policy evaluator is a small Vouch JSON rule engine.
+- Whether signer identities should vary by contract owner, path, or risk tier. The current allowlist is repo-level.
 
 ## Validation Status
+
+For repeatable local validation, run:
+
+```sh
+scripts/vouchbench.sh
+```
+
+That harness compares baseline outcomes with Vouch's gate decision across fixed scenarios. The current corpus checks missing release evidence, manifest traceability, invalid artifact exit codes, high-risk canary routing, high-risk human escalation, and low-risk auto-merge. See [Benchmarks](docs/BENCHMARKS.md) for the exact scenarios, assertions, and limits.
 
 The generic flow has been validated against temp copies of real Python repos:
 
@@ -402,7 +632,7 @@ The generic flow has been validated against temp copies of real Python repos:
 
 Those runs exercised `init`, `contract suggest`, `contract create`, `manifest create`, `manifest check`, `junit map`, `manifest attach-artifact`, and `gate`.
 
-This validates the generic workflow plumbing. It does not prove Vouch understands those products automatically. Vouch still needs human-owned contracts; suggestions are structural starting points based on repo shape and ownership paths.
+This validates the generic workflow plumbing. It does not mean Vouch understands those products automatically. Vouch still needs human-owned contracts. Suggestions are structural starting points based on repo shape and ownership paths.
 
 ## What This Solves
 
@@ -546,7 +776,7 @@ The demo uses a synthetic high-risk `auth.password_reset` change because it exer
 - Feature-flag rollback.
 - Email side effects.
 
-The demo exercises the compiler plumbing and failure modes. It does not prove Vouch can infer or verify password reset correctness from application code.
+The demo exercises the compiler plumbing and failure modes. It does not mean Vouch can infer or verify password reset correctness from application code.
 
 Run the repo-level compiler pipeline:
 
@@ -706,6 +936,83 @@ vouch --repo DIR --manifest FILE evidence [--policy FILE]
 ```
 
 `--json` emits machine-readable evidence for commands that collect evidence. For `gate`, `--json` emits the compact gate result to stdout and `--out FILE` writes the same gate-result shape as a JSON artifact.
+
+## FAQ
+
+### Why is this more complicated than normal CI?
+
+Because Vouch is checking a different thing. CI usually answers whether commands passed. Vouch asks whether the change has the required evidence for the contracts it touches. That needs contracts, compiled obligations, evidence artifacts, and policy.
+
+For low-risk changes, this ceremony may not be worth it. For auth, payments, permissions, migrations, public APIs, external side effects, and production rollout, the extra structure is the point.
+
+### Why not just ask another agent to review the code?
+
+An agent review is still an opinion over a diff. Vouch produces a deterministic gate result from declared obligations and evidence artifacts. You can audit which obligation was required, which artifact covered it, which policy rule fired, and why the gate returned `block`, `human_escalation`, `canary`, or `auto_merge`.
+
+### Does Vouch replace tests?
+
+No. Tests are one evidence source. Vouch consumes test output, currently JUnit, and checks whether it covers required-test obligations. It does not run your test suite itself.
+
+### Why did `vouch gate` block even though tests passed?
+
+Usually because JUnit only covers required-test obligations. Behavior, security, runtime, and rollback obligations require their own accepted evidence. That is expected on a first run.
+
+### Does Vouch infer product intent from code?
+
+No. `vouch bootstrap` drafts conservative contracts from repo signals such as tests, paths, CODEOWNERS, and CI files. Humans still own the intent and must accept, edit, merge, or delete generated contracts.
+
+### What do I have to write myself?
+
+You need to review or write the release contract:
+
+- component ownership
+- risk level
+- behavior obligations
+- security invariants
+- required tests
+- runtime signals
+- rollback expectations
+
+Bootstrap can create a starting point, but the contract is only useful once a human makes it match the product.
+
+### What is the first useful adoption step?
+
+Pick one high-risk component instead of trying to cover the whole repo. Good first targets are auth, billing, permissions, data deletion, migrations, public APIs, and deployment-critical code.
+
+Create or edit one contract, map its required tests, run JUnit import, and let `vouch gate` show which evidence is still missing.
+
+### Is Vouch production-ready?
+
+No. Treat it as beta infrastructure for experimenting with contract/evidence release gates. It is not a replacement for code review, security review, incident response, or production ownership.
+
+### What does VouchBench actually validate?
+
+VouchBench validates deterministic release-gate behavior over a fixed corpus. It checks expected decisions, exit codes, coverage counts, missing obligations, invalid evidence, policy rules, and manifest/spec errors.
+
+It does not validate arbitrary product correctness.
+
+### Can I run it against my own repo without modifying it?
+
+Yes:
+
+```sh
+scripts/vouchbench-repo.sh --repo /path/to/repo --out /tmp/vouchbench-repo
+```
+
+That copies your repo into a temp snapshot and runs Vouch there.
+
+### What should I look at after bootstrap?
+
+Start with:
+
+```text
+.vouch/intents/*.yaml
+.vouch/build/obligations.ir.json
+.vouch/build/verification-plan.json
+.vouch/evidence/manifest.json
+```
+
+The intent files are the human-editable contract drafts. The IR and plan show what Vouch will require. The evidence manifest shows which test artifacts linked to which obligations.
 
 ## Test
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,172 @@
+# VouchBench
+
+VouchBench is the repo-local acceptance harness for Vouch's current release-gate claim:
+
+> Tests can pass while release obligations remain uncovered; Vouch makes that gap explicit and blocks or routes the change according to policy.
+
+It is not a benchmark for semantic code understanding. Vouch does not currently prove an implementation is correct. The harness measures whether the compiler, evidence linker, artifact validation, manifest traceability checks, and release policy make deterministic decisions over declared contracts and artifacts.
+
+## Run It
+
+From the repo root:
+
+```sh
+scripts/vouchbench.sh
+```
+
+The script builds the local CLI, runs isolated temp copies of the fixtures, asserts each scenario, and writes ignored outputs to:
+
+```text
+benchmarks/results/vouchbench.latest.json
+benchmarks/results/vouchbench.latest.md
+```
+
+Use a separate output directory if you want to archive a run:
+
+```sh
+scripts/vouchbench.sh --out /tmp/vouchbench
+```
+
+Use `--keep` when debugging a failing benchmark. The script fails at the first scenario-level assertion mismatch.
+
+## External Repo Evaluation
+
+The fixture suite is intentionally tailored to Vouch's release-gate behavior. Use it for regression and acceptance. To evaluate a real repo, use the external repo evaluator:
+
+```sh
+scripts/vouchbench-repo.sh --repo /path/to/repo --out /tmp/vouchbench-repo
+```
+
+This copies the target repo into a temporary snapshot, runs Vouch only inside that snapshot, and writes:
+
+```text
+vouchbench-repo.latest.json
+vouchbench-repo.latest.md
+```
+
+For a repo that can produce JUnit:
+
+```sh
+scripts/vouchbench-repo.sh \
+  --repo /path/to/repo \
+  --test-command "pytest --junitxml .vouch/artifacts/pytest.xml" \
+  --junit .vouch/artifacts/pytest.xml \
+  --out /tmp/vouchbench-repo
+```
+
+For a repo like `/Users/oha/skylos`, start non-destructively:
+
+```sh
+scripts/vouchbench-repo.sh --repo /Users/oha/skylos --out /tmp/vouchbench-skylos
+```
+
+That run answers different questions from the fixture acceptance suite:
+
+- can Vouch snapshot, initialize, bootstrap, and compile this repo?
+- how many draft contracts and obligations are generated?
+- if JUnit is provided, how many required-test obligations link to real test evidence?
+- if gate runs, what decision and exit code does this repo produce?
+
+It is not a stable benchmark until the scenario, contracts, evidence, and expected decision are checked into the VouchBench corpus.
+
+## Acceptance Contract
+
+The benchmark is expected to exit non-zero if any of these regress:
+
+- the required scenario corpus changes unexpectedly
+- expected Vouch decisions do not match actual decisions
+- expected gate process exit codes do not match actual exit codes
+- expected coverage counts or missing obligation IDs change
+- expected invalid evidence codes are missing
+- expected policy rules fired are different
+- manifest/spec error counts or required error text change
+- aggregate acceptance criteria are no longer met
+
+The current acceptance floor is:
+
+- 10 required scenarios
+- 114 scenario assertions
+- at least 4 tests-passed scenarios blocked by Vouch-specific checks
+- at least 2 medium/high multi-component scenarios with 25 obligations
+- canary, human escalation, and auto-merge routes all exercised
+- at least 1 invalid-evidence negative control
+- at least 1 full-coverage manifest traceability block
+
+`vouchbench.latest.json` is the machine-readable result. It includes:
+
+- `acceptance.passed`: final pass/fail status
+- `acceptance.criteria[]`: aggregate criteria such as required corpus, invalid-evidence coverage, and non-blocking route coverage
+- `scenarios[].expected`: explicit expected values for that scenario
+- `scenarios[].actual`: the compact gate result fields used by assertions
+- `scenarios[].assertions[]`: per-field assertion records with expected and actual values
+
+## Current Scenarios
+
+| Scenario | Purpose | Baseline | Expected |
+| --- | --- | --- | --- |
+| `auth_tests_only` | Passing JUnit covers required tests, but behavior, security, runtime, and rollback evidence are absent. | tests pass, would continue without Vouch | `block` |
+| `auth_partial_release_evidence` | Tests and some artifacts pass, but required test, security, and runtime obligations remain uncovered. | tests pass, would continue without Vouch | `block` |
+| `auth_manifest_traceability_block` | All obligations are covered, but a changed billing file is not owned by any touched spec. | tests pass, would continue without Vouch | `block` |
+| `auth_nonzero_test_artifact` | The test artifact command exits non-zero even though artifact files exist. | tests fail, baseline catches this | `block` |
+| `auth_full_release_evidence` | All high-risk auth obligations are covered and canary is enabled. | tests pass, no Vouch policy route | `canary` |
+| `auth_full_release_without_canary` | All high-risk auth obligations are covered, but canary is disabled. | tests pass, no Vouch policy route | `human_escalation` |
+| `platform_multi_component_partial_evidence` | A synthetic medium/high platform repo changes auth, payments, and API. Tests pass, but the payments component lacks security, runtime, and rollback evidence. | tests pass, would continue without Vouch | `block` |
+| `platform_multi_component_full_canary` | The same platform repo covers all 25 obligations across auth, payments, and API. | tests pass, no Vouch policy route | `canary` |
+| `platform_medium_api_auto_merge` | The platform repo changes only the medium-risk API contract and provides complete API evidence. | tests pass, no Vouch scope proof | `auto_merge` |
+| `docs_low_risk_full_evidence` | A low-risk docs contract has complete evidence and should not be falsely blocked. | tests pass, would continue without Vouch | `auto_merge` |
+
+## Medium/High Repo Shape
+
+The `platform_*` scenarios create a repo with three components:
+
+| Component | Risk | Obligations | Owned Paths |
+| --- | --- | ---: | --- |
+| `auth.session` | high | 9 | `internal/auth/**`, `tests/auth/**` |
+| `payments.checkout` | high | 9 | `internal/payments/**`, `tests/payments/**` |
+| `api.users` | medium | 7 | `internal/api/**`, `tests/api/**` |
+
+The multi-component platform manifest touches all three components, so the gate evaluates 25 obligations at once. The partial-evidence scenario intentionally covers 22/25 obligations and leaves only `payments.checkout` missing one security invariant, one runtime signal, and one rollback obligation. The complete-evidence scenario covers all 25 and routes to `canary`. The medium-only API scenario proves Vouch can scope the same repo down to 7 obligations and return `auto_merge`.
+
+## Baseline Accounting
+
+The benchmark separates Vouch-only catches from cases tests already catch.
+
+Tests-passed block scenarios support the narrow adoption claim: a test-only baseline would continue, while Vouch blocks due to missing release evidence or manifest traceability.
+
+The non-zero test artifact scenario is a negative control. It proves the harness validates artifact exit codes and invalid evidence, but it is not counted as a Vouch-only catch because tests already failed.
+
+The non-blocking scenarios prove Vouch is not just a blocker. Complete evidence can route to canary, high-risk evidence without canary escalates to a human, and low-risk complete evidence auto-merges.
+
+The platform scenarios add scale and scope checks: a multi-component high-risk release with 25 obligations, and a medium-risk change inside that same larger repo that should not inherit unrelated auth or payments obligations.
+
+## Validity And Limitations
+
+Valid claims from this benchmark:
+
+- Vouch links compiled obligations to evidence deterministically for the fixture corpus.
+- Missing evidence, invalid artifact exit codes, manifest traceability errors, and rollout policy routes are detected by explicit assertions.
+- The CLI gate exit code is consistent with the release decision for the tested policy behavior.
+
+Invalid claims from this benchmark:
+
+- Vouch finds all bugs.
+- Vouch understands product intent without human-owned contracts.
+- The fixtures represent every release-risk category.
+- The synthetic platform fixture is equivalent to a large production monorepo.
+- The measured runtime is a stable performance benchmark.
+
+The corpus is intentionally deterministic. Treat timing as a smoke signal only. The meaningful acceptance result is the assertion set, not the millisecond values.
+
+## Extending The Corpus
+
+Add scenarios when a real user concern appears. Good benchmark cases should state:
+
+- the contract and risk level
+- what a test-only or artifact-only baseline would do
+- the missing, invalid, or misrouted evidence Vouch should catch
+- the exact expected decision and gate exit code
+- the exact expected coverage and missing obligation IDs
+- the policy rule expected to fire
+- why the case represents a realistic release failure mode
+
+Avoid adding synthetic cases that only exercise parser branches. Unit tests are better for those. VouchBench should stay focused on adoption-facing evidence for why a contract/evidence gate is useful.

--- a/scripts/vouchbench-repo.sh
+++ b/scripts/vouchbench-repo.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/vouchbench-repo.sh --repo DIR [--out DIR] [--test-command CMD] [--junit PATH] [--keep]
+
+Runs a non-destructive Vouch evaluation against an external repository.
+
+The source repo is copied into a temporary snapshot first. Vouch writes only to
+that snapshot, never to the source repo.
+
+Options:
+  --repo DIR          External repository to evaluate.
+  --out DIR           Output directory. Default: benchmarks/results
+  --test-command CMD  Optional test command to run inside the snapshot.
+  --junit PATH        Optional JUnit XML path, relative to the snapshot, to import.
+  --keep              Keep the temporary working directory for inspection.
+EOF
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SOURCE_REPO=""
+OUT_DIR="$ROOT/benchmarks/results"
+TEST_COMMAND=""
+JUNIT_PATH=""
+KEEP=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      if [[ $# -lt 2 ]]; then
+        echo "vouchbench-repo: --repo requires a directory" >&2
+        exit 2
+      fi
+      SOURCE_REPO="$2"
+      shift 2
+      ;;
+    --out)
+      if [[ $# -lt 2 ]]; then
+        echo "vouchbench-repo: --out requires a directory" >&2
+        exit 2
+      fi
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --test-command)
+      if [[ $# -lt 2 ]]; then
+        echo "vouchbench-repo: --test-command requires a command string" >&2
+        exit 2
+      fi
+      TEST_COMMAND="$2"
+      shift 2
+      ;;
+    --junit)
+      if [[ $# -lt 2 ]]; then
+        echo "vouchbench-repo: --junit requires a path" >&2
+        exit 2
+      fi
+      JUNIT_PATH="$2"
+      shift 2
+      ;;
+    --keep)
+      KEEP=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "vouchbench-repo: unknown argument $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$SOURCE_REPO" ]]; then
+  echo "vouchbench-repo: --repo is required" >&2
+  usage >&2
+  exit 2
+fi
+if [[ ! -d "$SOURCE_REPO" ]]; then
+  echo "vouchbench-repo: repo does not exist: $SOURCE_REPO" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vouchbench-repo.XXXXXX")"
+SNAPSHOT="$RUN_DIR/repo"
+VOUCH="$RUN_DIR/vouch"
+STEPS_DIR="$RUN_DIR/steps"
+mkdir -p "$STEPS_DIR"
+
+cleanup() {
+  if [[ "$KEEP" == "1" ]]; then
+    echo "kept external repo eval workdir: $RUN_DIR" >&2
+  else
+    rm -rf "$RUN_DIR"
+  fi
+}
+trap cleanup EXIT
+
+now_ns() {
+  python3 -c 'import time; print(time.perf_counter_ns())'
+}
+
+run_step() {
+  local name="$1"
+  shift
+  local start_ns
+  local end_ns
+  local code
+  start_ns="$(now_ns)"
+  set +e
+  "$@" > "$STEPS_DIR/$name.stdout" 2> "$STEPS_DIR/$name.stderr"
+  code=$?
+  set -e
+  end_ns="$(now_ns)"
+  python3 - "$STEPS_DIR/$name.json" "$name" "$start_ns" "$end_ns" "$code" "$STEPS_DIR/$name.stdout" "$STEPS_DIR/$name.stderr" <<'PY'
+import json
+import sys
+
+path, name, start_ns, end_ns, code, stdout_path, stderr_path = sys.argv[1:]
+with open(stdout_path, encoding="utf-8", errors="replace") as f:
+    stdout = f.read()
+with open(stderr_path, encoding="utf-8", errors="replace") as f:
+    stderr = f.read()
+data = {
+    "name": name,
+    "exit_code": int(code),
+    "elapsed_ms": round((int(end_ns) - int(start_ns)) / 1_000_000, 3),
+    "stdout_path": stdout_path,
+    "stderr_path": stderr_path,
+    "stdout_tail": stdout[-4000:],
+    "stderr_tail": stderr[-4000:],
+}
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+  return 0
+}
+
+copy_snapshot() {
+  python3 - "$SOURCE_REPO" "$SNAPSHOT" "$RUN_DIR/snapshot.json" <<'PY'
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+source = Path(sys.argv[1]).resolve()
+dest = Path(sys.argv[2]).resolve()
+snapshot_path = Path(sys.argv[3])
+dest.mkdir(parents=True, exist_ok=True)
+
+def git(args):
+    return subprocess.run(
+        ["git", "-C", str(source), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+is_git = git(["rev-parse", "--is-inside-work-tree"]).returncode == 0
+files = []
+mode = "filesystem"
+branch = ""
+dirty_entries = []
+
+if is_git:
+    mode = "git-ls-files"
+    branch_proc = git(["branch", "--show-current"])
+    branch = branch_proc.stdout.strip()
+    status_proc = git(["status", "--short"])
+    dirty_entries = [line for line in status_proc.stdout.splitlines() if line.strip()]
+    tracked = git(["ls-files", "-z", "--cached", "--others", "--exclude-standard"])
+    if tracked.returncode != 0:
+        raise SystemExit(tracked.stderr)
+    files = [item for item in tracked.stdout.split("\0") if item]
+else:
+    ignored_dirs = {".git", "node_modules", ".venv", "venv", "target", "dist", "build", "__pycache__"}
+    for root, dirs, names in os.walk(source):
+        dirs[:] = [name for name in dirs if name not in ignored_dirs]
+        for name in names:
+            path = Path(root) / name
+            files.append(str(path.relative_to(source)))
+
+copied = 0
+skipped = 0
+for rel in files:
+    src = source / rel
+    dst = dest / rel
+    if not src.exists() or not src.is_file():
+        skipped += 1
+        continue
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(src, dst)
+    copied += 1
+
+data = {
+    "source": str(source),
+    "snapshot": str(dest),
+    "mode": mode,
+    "branch": branch,
+    "files_copied": copied,
+    "files_skipped": skipped,
+    "dirty_entries": dirty_entries,
+}
+with open(snapshot_path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+render_results() {
+  local json_out="$OUT_DIR/vouchbench-repo.latest.json"
+  local md_out="$OUT_DIR/vouchbench-repo.latest.md"
+  python3 - "$RUN_DIR" "$json_out" "$md_out" "$SOURCE_REPO" "$TEST_COMMAND" "$JUNIT_PATH" <<'PY'
+from __future__ import annotations
+
+import datetime as dt
+import json
+import sys
+from pathlib import Path
+
+run_dir = Path(sys.argv[1])
+json_out = Path(sys.argv[2])
+md_out = Path(sys.argv[3])
+source_repo = sys.argv[4]
+test_command = sys.argv[5]
+junit_path = sys.argv[6]
+steps_dir = run_dir / "steps"
+
+def load(path: Path, default=None):
+    if not path.exists():
+        return default
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+def parse_json_stdout(step: dict | None):
+    if not step or step.get("exit_code") != 0:
+        return None
+    stdout_path = Path(step["stdout_path"])
+    try:
+        with stdout_path.open(encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+step_order = [
+    "build_vouch",
+    "init",
+    "bootstrap_dry_run",
+    "bootstrap",
+    "compile",
+    "test_command",
+    "evidence_import",
+    "gate",
+]
+steps = [load(steps_dir / f"{name}.json") for name in step_order if (steps_dir / f"{name}.json").exists()]
+steps_by_name = {step["name"]: step for step in steps}
+snapshot = load(run_dir / "snapshot.json", {})
+compile_json = parse_json_stdout(steps_by_name.get("compile")) or {}
+bootstrap_json = parse_json_stdout(steps_by_name.get("bootstrap_dry_run")) or {}
+import_json = parse_json_stdout(steps_by_name.get("evidence_import")) or {}
+gate_json = parse_json_stdout(steps_by_name.get("gate")) or {}
+
+summary = {
+    "source_repo": source_repo,
+    "snapshot": snapshot.get("snapshot", ""),
+    "snapshot_mode": snapshot.get("mode", ""),
+    "source_branch": snapshot.get("branch", ""),
+    "source_dirty_entries": len(snapshot.get("dirty_entries", [])),
+    "files_copied": snapshot.get("files_copied", 0),
+    "bootstrap_drafts": len(bootstrap_json.get("drafts", [])) if isinstance(bootstrap_json, dict) else 0,
+    "compiled_specs": compile_json.get("specs_compiled", 0),
+    "compiled_obligations": compile_json.get("obligations_built", 0),
+    "junit_links": len(import_json.get("links", [])) if isinstance(import_json, dict) else 0,
+    "gate_decision": gate_json.get("decision", ""),
+    "gate_exit_code": steps_by_name.get("gate", {}).get("exit_code"),
+}
+status = "completed"
+if steps_by_name.get("compile", {}).get("exit_code", 1) != 0:
+    status = "compile_failed"
+elif junit_path and steps_by_name.get("evidence_import", {}).get("exit_code", 1) != 0:
+    status = "evidence_import_failed"
+elif junit_path and steps_by_name.get("gate", {}).get("exit_code") is None:
+    status = "gate_not_run"
+
+result = {
+    "version": "vouchbench.repo_eval.v0",
+    "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "status": status,
+    "summary": summary,
+    "inputs": {
+        "repo": source_repo,
+        "test_command": test_command,
+        "junit": junit_path,
+    },
+    "snapshot": snapshot,
+    "steps": steps,
+}
+
+json_out.parent.mkdir(parents=True, exist_ok=True)
+with json_out.open("w", encoding="utf-8") as f:
+    json.dump(result, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+lines = [
+    "# VouchBench External Repo Evaluation",
+    "",
+    f"Source repo: `{source_repo}`",
+    f"Status: `{status}`",
+    "",
+    "## Summary",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    f"| Snapshot mode | `{summary['snapshot_mode']}` |",
+    f"| Source branch | `{summary['source_branch']}` |",
+    f"| Source dirty entries | `{summary['source_dirty_entries']}` |",
+    f"| Files copied | `{summary['files_copied']}` |",
+    f"| Bootstrap drafts | `{summary['bootstrap_drafts']}` |",
+    f"| Compiled specs | `{summary['compiled_specs']}` |",
+    f"| Compiled obligations | `{summary['compiled_obligations']}` |",
+    f"| JUnit links | `{summary['junit_links']}` |",
+    f"| Gate decision | `{summary['gate_decision']}` |",
+    f"| Gate exit code | `{summary['gate_exit_code']}` |",
+    "",
+    "## Steps",
+    "",
+    "| Step | Exit | ms |",
+    "| --- | ---: | ---: |",
+]
+for step in steps:
+    lines.append(f"| `{step['name']}` | {step['exit_code']} | {step['elapsed_ms']} |")
+lines.extend([
+    "",
+    "## Notes",
+    "",
+    "- This is a non-destructive snapshot evaluation, not a committed benchmark fixture.",
+    "- A clean result here means Vouch can bootstrap/compile/gate the snapshot under the provided inputs.",
+    "- It does not validate product correctness, and it does not replace the deterministic fixture acceptance suite.",
+])
+md_out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+print(md_out.read_text(encoding="utf-8"))
+PY
+}
+
+echo "snapshotting external repo..."
+copy_snapshot
+
+echo "building local vouch binary..."
+run_step build_vouch bash -lc "cd '$ROOT' && GOCACHE='${GOCACHE:-$RUN_DIR/gocache}' go build -o '$VOUCH' ./cmd/vouch"
+
+echo "running vouch init/bootstrap/compile on snapshot..."
+run_step init "$VOUCH" --repo "$SNAPSHOT" --json init
+run_step bootstrap_dry_run "$VOUCH" --repo "$SNAPSHOT" --json bootstrap --dry-run
+run_step bootstrap "$VOUCH" --repo "$SNAPSHOT" --json bootstrap
+run_step compile "$VOUCH" --repo "$SNAPSHOT" --json compile
+
+if [[ -n "$TEST_COMMAND" ]]; then
+  echo "running external repo test command in snapshot..."
+  run_step test_command bash -lc "cd '$SNAPSHOT' && $TEST_COMMAND"
+fi
+
+if [[ -n "$JUNIT_PATH" ]]; then
+  echo "importing JUnit evidence and running manifestless gate..."
+  run_step evidence_import "$VOUCH" --repo "$SNAPSHOT" --json evidence import junit "$JUNIT_PATH"
+  run_step gate "$VOUCH" --repo "$SNAPSHOT" gate --json
+fi
+
+render_results
+echo "wrote:"
+echo "  $OUT_DIR/vouchbench-repo.latest.json"
+echo "  $OUT_DIR/vouchbench-repo.latest.md"

--- a/scripts/vouchbench.sh
+++ b/scripts/vouchbench.sh
@@ -1,0 +1,1435 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/vouchbench.sh [--out DIR] [--keep]
+
+Runs the local Vouch benchmark harness against reproducible fixtures.
+
+Options:
+  --out DIR   Write result JSON and Markdown to DIR.
+              Default: benchmarks/results
+  --keep      Keep the temporary working directory for inspection.
+EOF
+}
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$ROOT/benchmarks/results"
+KEEP=0
+SCENARIOS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out)
+      if [[ $# -lt 2 ]]; then
+        echo "vouchbench: --out requires a directory" >&2
+        exit 2
+      fi
+      OUT_DIR="$2"
+      shift 2
+      ;;
+    --keep)
+      KEEP=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "vouchbench: unknown argument $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p "$OUT_DIR"
+RUN_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vouchbench.XXXXXX")"
+VOUCH="$RUN_DIR/vouch"
+
+cleanup() {
+  if [[ "$KEEP" == "1" ]]; then
+    echo "kept benchmark workdir: $RUN_DIR" >&2
+  else
+    rm -rf "$RUN_DIR"
+  fi
+}
+trap cleanup EXIT
+
+now_ns() {
+  python3 -c 'import time; print(time.perf_counter_ns())'
+}
+
+write_text_file() {
+  local path="$1"
+  local content="$2"
+  mkdir -p "$(dirname "$path")"
+  printf '%s\n' "$content" > "$path"
+}
+
+write_obligation_json() {
+  local path="$1"
+  local obligations_json="$2"
+  python3 - "$path" "$obligations_json" <<'PY'
+import json
+import sys
+
+path, raw = sys.argv[1:]
+with open(path, "w", encoding="utf-8") as f:
+    json.dump({"status": "pass", "obligations": json.loads(raw)}, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+write_junit_obligations() {
+  local path="$1"
+  local obligations_json="$2"
+  python3 - "$path" "$obligations_json" <<'PY'
+import json
+import sys
+from xml.sax.saxutils import escape
+
+path, raw = sys.argv[1:]
+obligations = json.loads(raw)
+with open(path, "w", encoding="utf-8") as f:
+    f.write(f'<testsuite name="vouchbench" tests="{len(obligations)}" failures="0" errors="0" skipped="0">')
+    for obligation in obligations:
+        value = escape(obligation, {'"': '&quot;'})
+        f.write(f'<testcase classname="{value}" name="{value}"></testcase>')
+    f.write("</testsuite>\n")
+PY
+}
+
+copy_demo_repo() {
+  local scenario="$1"
+  local repo="$RUN_DIR/$scenario/repo"
+  mkdir -p "$(dirname "$repo")"
+  cp -R "$ROOT/demo_repo" "$repo"
+  printf '%s\n' "$repo"
+}
+
+write_meta_json() {
+  local dir="$1"
+  local data="$2"
+  mkdir -p "$dir"
+  python3 - "$dir/meta.json" "$data" <<'PY'
+import json
+import sys
+
+path, raw = sys.argv[1:]
+data = json.loads(raw)
+for key in ("id", "title", "baseline", "expected", "claim"):
+    if key not in data:
+        raise SystemExit(f"metadata missing required key: {key}")
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+record_timing() {
+  local dir="$1"
+  local start_ns="$2"
+  local end_ns="$3"
+  local exit_code="$4"
+  python3 - "$dir/timing.json" "$start_ns" "$end_ns" "$exit_code" <<'PY'
+import json
+import sys
+
+path, start_ns, end_ns, exit_code = sys.argv[1:]
+elapsed_ms = (int(end_ns) - int(start_ns)) / 1_000_000
+data = {
+    "gate_ms": round(elapsed_ms, 3),
+    "gate_exit_code": int(exit_code),
+}
+with open(path, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+run_gate() {
+  local dir="$1"
+  local repo="$2"
+  local manifest="${3:-}"
+  local start_ns
+  local end_ns
+  local code
+
+  start_ns="$(now_ns)"
+  set +e
+  if [[ -n "$manifest" ]]; then
+    "$VOUCH" --repo "$repo" --manifest "$manifest" gate --json > "$dir/gate.json" 2> "$dir/gate.stderr"
+  else
+    "$VOUCH" --repo "$repo" gate --json > "$dir/gate.json" 2> "$dir/gate.stderr"
+  fi
+  code=$?
+  set -e
+  end_ns="$(now_ns)"
+  record_timing "$dir" "$start_ns" "$end_ns" "$code"
+}
+
+attach_artifact() {
+  local repo="$1"
+  local manifest="$2"
+  local id="$3"
+  local kind="$4"
+  local path="$5"
+  local stdout_path="$6"
+
+  "$VOUCH" --repo "$repo" manifest attach-artifact \
+    --manifest "$manifest" \
+    --id "$id" \
+    --kind "$kind" \
+    --path "$path" \
+    --exit-code 0 \
+    --out "$manifest" > "$stdout_path"
+}
+
+assert_scenario() {
+  local dir="$1"
+  python3 - "$dir" <<'PY'
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+scenario_dir = Path(sys.argv[1])
+
+
+def load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def flatten_obligations(value: object) -> list[str]:
+    if not isinstance(value, dict):
+        return []
+    out: list[str] = []
+    for spec_id in sorted(value):
+        items = value.get(spec_id)
+        if isinstance(items, list):
+            out.extend(item for item in items if isinstance(item, str))
+    return sorted(out)
+
+
+def invalid_evidence_keys(gate: dict) -> list[str]:
+    keys: list[str] = []
+    for item in gate.get("invalid_evidence", []):
+        if isinstance(item, dict):
+            keys.append(f"{item.get('artifact', '')}:{item.get('code', '')}")
+    return sorted(keys)
+
+
+def artifact_statuses(gate: dict) -> dict[str, str]:
+    statuses: dict[str, str] = {}
+    for item in gate.get("artifact_results", []):
+        if isinstance(item, dict) and item.get("id"):
+            statuses[str(item["id"])] = str(item.get("status", ""))
+    return statuses
+
+
+def sorted_strings(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return sorted(item for item in value if isinstance(item, str))
+
+
+def same_unordered_strings(left: object, right: object) -> bool:
+    return sorted_strings(left) == sorted_strings(right)
+
+
+def add_assertion(assertions: list[dict], assertion_id: str, passed: bool, expected: object, actual: object, message: str) -> None:
+    assertions.append({
+        "id": assertion_id,
+        "passed": bool(passed),
+        "expected": expected,
+        "actual": actual,
+        "message": message,
+    })
+
+
+meta = load(scenario_dir / "meta.json")
+timing = load(scenario_dir / "timing.json")
+gate = load(scenario_dir / "gate.json")
+expected = meta["expected"]
+
+covered = flatten_obligations(gate.get("covered_obligations"))
+missing = flatten_obligations(gate.get("missing_obligations"))
+compiled_total = int(gate.get("compilation", {}).get("obligations_built", 0))
+total = max(len(covered) + len(missing), compiled_total)
+actual = {
+    "decision": gate.get("decision", "error"),
+    "gate_exit_code": timing["gate_exit_code"],
+    "covered_obligations": len(covered),
+    "total_obligations": total,
+    "missing_obligations": missing,
+    "missing_obligations_count": len(missing),
+    "invalid_evidence": invalid_evidence_keys(gate),
+    "policy_rules_fired": gate.get("policy_rules_fired", []),
+    "fired_policy_rule": gate.get("fired_policy_rule", ""),
+    "manifest_error_count": len(gate.get("manifest_errors", [])),
+    "spec_error_count": len(gate.get("spec_errors", [])),
+    "manifest_errors": gate.get("manifest_errors", []),
+    "spec_errors": gate.get("spec_errors", []),
+    "artifact_statuses": artifact_statuses(gate),
+    "reasons": gate.get("reasons", []),
+    "gate_ms": timing["gate_ms"],
+}
+
+assertions: list[dict] = []
+for key in (
+    "decision",
+    "gate_exit_code",
+    "covered_obligations",
+    "total_obligations",
+    "manifest_error_count",
+    "spec_error_count",
+):
+    if key in expected:
+        add_assertion(
+            assertions,
+            key,
+            actual[key] == expected[key],
+            expected[key],
+            actual[key],
+            f"{key} must match expected value",
+        )
+
+for key in ("missing_obligations", "invalid_evidence"):
+    if key in expected:
+        add_assertion(
+            assertions,
+            key,
+            same_unordered_strings(actual[key], expected[key]),
+            sorted_strings(expected[key]),
+            actual[key],
+            f"{key} must match expected set",
+        )
+
+if "policy_rules_fired" in expected:
+    add_assertion(
+        assertions,
+        "policy_rules_fired",
+        actual["policy_rules_fired"] == expected["policy_rules_fired"],
+        expected["policy_rules_fired"],
+        actual["policy_rules_fired"],
+        "policy rules fired must match expected order",
+    )
+
+if "artifact_statuses" in expected:
+    expected_statuses = expected["artifact_statuses"]
+    actual_subset = {
+        artifact_id: actual["artifact_statuses"].get(artifact_id)
+        for artifact_id in sorted(expected_statuses)
+    }
+    add_assertion(
+        assertions,
+        "artifact_statuses",
+        actual_subset == expected_statuses,
+        expected_statuses,
+        actual_subset,
+        "selected artifact statuses must match expected values",
+    )
+
+if "reason_substrings" in expected:
+    reasons_text = "\n".join(actual["reasons"])
+    for item in expected["reason_substrings"]:
+        add_assertion(
+            assertions,
+            f"reason_contains:{item}",
+            item in reasons_text,
+            item,
+            actual["reasons"],
+            "gate reasons must include expected text",
+        )
+
+if "manifest_error_substrings" in expected:
+    manifest_errors_text = "\n".join(actual["manifest_errors"])
+    for item in expected["manifest_error_substrings"]:
+        add_assertion(
+            assertions,
+            f"manifest_error_contains:{item}",
+            item in manifest_errors_text,
+            item,
+            actual["manifest_errors"],
+            "manifest errors must include expected text",
+        )
+
+passed = all(item["passed"] for item in assertions)
+row = {
+    "id": meta["id"],
+    "title": meta["title"],
+    "claim": meta["claim"],
+    "baseline": meta["baseline"],
+    "expected": expected,
+    "actual": actual,
+    "assertions": assertions,
+    "passed": passed,
+}
+with (scenario_dir / "row.json").open("w", encoding="utf-8") as f:
+    json.dump(row, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+if not passed:
+    print(f"vouchbench: scenario {meta['id']} failed assertions:", file=sys.stderr)
+    for item in assertions:
+        if item["passed"]:
+            continue
+        print(
+            f"- {item['id']}: expected {item['expected']!r}, got {item['actual']!r}",
+            file=sys.stderr,
+        )
+    sys.exit(1)
+PY
+}
+
+set_test_artifact_exit_code() {
+  local repo="$1"
+  local out="$2"
+  python3 - "$repo/.vouch/manifests/pass.json" "$repo/$out" <<'PY'
+import json
+import sys
+
+src, dst = sys.argv[1:]
+with open(src, encoding="utf-8") as f:
+    data = json.load(f)
+data["task"]["id"] = "issue-184-nonzero-test-artifact"
+data["task"]["summary"] = "password reset release with a failed test artifact command"
+data["agent"]["run_id"] = "demo-nonzero-test-artifact-run"
+data["verification"]["test_results"] = {"passed": 25, "failed": 1}
+for artifact in data["verification"]["artifacts"]:
+    if artifact["id"] == "test-results":
+        artifact["exit_code"] = 1
+        artifact["command"] = "npm test && npm run test:e2e"
+with open(dst, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+disable_canary_manifest() {
+  local repo="$1"
+  local out="$2"
+  python3 - "$repo/.vouch/manifests/pass.json" "$repo/$out" <<'PY'
+import json
+import sys
+
+src, dst = sys.argv[1:]
+with open(src, encoding="utf-8") as f:
+    data = json.load(f)
+data["task"]["id"] = "issue-184-no-canary"
+data["task"]["summary"] = "password reset release with complete evidence but no canary"
+data["agent"]["run_id"] = "demo-no-canary-run"
+data["runtime"]["canary"] = {"enabled": False, "initial_percent": 0}
+with open(dst, "w", encoding="utf-8") as f:
+    json.dump(data, f, indent=2, sort_keys=True)
+    f.write("\n")
+PY
+}
+
+platform_behavior_all_ids='[
+  "api.users.behavior.user_profile_response_preserves_public_schema",
+  "api.users.behavior.user_search_paginates_deterministically",
+  "auth.session.behavior.logout_invalidates_refresh_token",
+  "auth.session.behavior.refresh_session_preserves_user_identity",
+  "payments.checkout.behavior.checkout_creates_idempotent_payment_intent",
+  "payments.checkout.behavior.invoice_total_uses_server_side_price"
+]'
+
+platform_security_partial_ids='[
+  "api.users.security.email_address_is_hidden_from_public_search",
+  "auth.session.security.refresh_token_is_rotated_and_hashed",
+  "auth.session.security.session_cookie_uses_secure_attributes",
+  "payments.checkout.security.card_data_is_never_logged"
+]'
+
+platform_security_full_ids='[
+  "api.users.security.email_address_is_hidden_from_public_search",
+  "auth.session.security.refresh_token_is_rotated_and_hashed",
+  "auth.session.security.session_cookie_uses_secure_attributes",
+  "payments.checkout.security.card_data_is_never_logged",
+  "payments.checkout.security.webhook_signature_is_verified"
+]'
+
+platform_tests_all_ids='[
+  "api.users.required_test.user_profile_schema",
+  "api.users.required_test.user_search_pagination",
+  "auth.session.required_test.logout_rejects_old_token",
+  "auth.session.required_test.refresh_rotates_token",
+  "payments.checkout.required_test.checkout_idempotency",
+  "payments.checkout.required_test.invoice_total_cannot_be_client_overridden"
+]'
+
+platform_runtime_partial_ids='[
+  "api.users.runtime_signal.api_users_requests",
+  "auth.session.runtime_signal.auth_session_logout",
+  "auth.session.runtime_signal.auth_session_refresh",
+  "payments.checkout.runtime_signal.payments_checkout_created"
+]'
+
+platform_runtime_full_ids='[
+  "api.users.runtime_signal.api_users_requests",
+  "auth.session.runtime_signal.auth_session_logout",
+  "auth.session.runtime_signal.auth_session_refresh",
+  "payments.checkout.runtime_signal.payments_checkout_created",
+  "payments.checkout.runtime_signal.payments_checkout_failed"
+]'
+
+platform_rollback_partial_ids='[
+  "api.users.rollback.revert_change",
+  "auth.session.rollback.feature_flag_session_refresh_v2"
+]'
+
+platform_rollback_full_ids='[
+  "api.users.rollback.revert_change",
+  "auth.session.rollback.feature_flag_session_refresh_v2",
+  "payments.checkout.rollback.disable_feature_flag_checkout_v3"
+]'
+
+platform_partial_missing_ids='[
+  "payments.checkout.security.webhook_signature_is_verified",
+  "payments.checkout.runtime_signal.payments_checkout_failed",
+  "payments.checkout.rollback.disable_feature_flag_checkout_v3"
+]'
+
+platform_api_behavior_ids='[
+  "api.users.behavior.user_profile_response_preserves_public_schema",
+  "api.users.behavior.user_search_paginates_deterministically"
+]'
+
+platform_api_security_ids='[
+  "api.users.security.email_address_is_hidden_from_public_search"
+]'
+
+platform_api_tests_ids='[
+  "api.users.required_test.user_profile_schema",
+  "api.users.required_test.user_search_pagination"
+]'
+
+platform_api_runtime_ids='[
+  "api.users.runtime_signal.api_users_requests"
+]'
+
+platform_api_rollback_ids='[
+  "api.users.rollback.revert_change"
+]'
+
+auth_test_missing_ids='[
+  "auth.password_reset.required_test.rate_limit_triggers",
+  "auth.password_reset.required_test.token_cannot_be_reused",
+  "auth.password_reset.required_test.token_expires",
+  "auth.password_reset.required_test.unknown_email_receives_same_response_shape"
+]'
+
+auth_tests_only_missing_ids='[
+  "auth.password_reset.behavior.reset_token_expires_after_30_minutes",
+  "auth.password_reset.behavior.reset_token_is_single_use",
+  "auth.password_reset.behavior.response_does_not_reveal_whether_account_exists",
+  "auth.password_reset.behavior.user_can_request_password_reset_by_email",
+  "auth.password_reset.security.no_account_enumeration",
+  "auth.password_reset.security.reset_endpoint_is_rate_limited_by_ip_and_account",
+  "auth.password_reset.security.reset_token_is_never_logged",
+  "auth.password_reset.security.reset_token_is_stored_hashed",
+  "auth.password_reset.runtime_signal.password_reset_completed",
+  "auth.password_reset.runtime_signal.password_reset_failed",
+  "auth.password_reset.runtime_signal.password_reset_requested",
+  "auth.password_reset.rollback.feature_flag_password_reset_v2"
+]'
+
+auth_partial_missing_ids='[
+  "auth.password_reset.required_test.rate_limit_triggers",
+  "auth.password_reset.required_test.token_cannot_be_reused",
+  "auth.password_reset.security.reset_endpoint_is_rate_limited_by_ip_and_account",
+  "auth.password_reset.security.reset_token_is_never_logged",
+  "auth.password_reset.runtime_signal.password_reset_completed",
+  "auth.password_reset.runtime_signal.password_reset_requested"
+]'
+
+create_platform_repo() {
+  local scenario="$1"
+  local dir="$RUN_DIR/$scenario"
+  local repo="$dir/repo"
+  mkdir -p "$repo/internal/auth" "$repo/internal/payments" "$repo/internal/api" "$repo/tests/auth" "$repo/tests/payments" "$repo/tests/api"
+  write_text_file "$repo/internal/auth/session.py" 'def refresh_session(user_id): return user_id'
+  write_text_file "$repo/internal/payments/checkout.py" 'def create_checkout(cart): return cart'
+  write_text_file "$repo/internal/api/users.py" 'def public_user(user): return user'
+  write_text_file "$repo/tests/auth/test_session.py" 'def test_refresh_rotates_token(): pass'
+  write_text_file "$repo/tests/payments/test_checkout.py" 'def test_checkout_idempotency(): pass'
+  write_text_file "$repo/tests/api/test_users.py" 'def test_user_profile_schema(): pass'
+  write_text_file "$repo/CODEOWNERS" '/internal/auth/ @security
+/internal/payments/ @payments
+/internal/api/ @platform'
+
+  "$VOUCH" --repo "$repo" init > "$dir/init.stdout"
+  "$VOUCH" --repo "$repo" contract create \
+    --name auth.session \
+    --owner security \
+    --risk high \
+    --paths "internal/auth/**,tests/auth/**" \
+    --behavior "refresh session preserves user identity" \
+    --behavior "logout invalidates refresh token" \
+    --security "refresh token is rotated and hashed" \
+    --security "session cookie uses secure attributes" \
+    --required-test "refresh rotates token" \
+    --required-test "logout rejects old token" \
+    --metric "auth.session.refresh" \
+    --metric "auth.session.logout" \
+    --rollback-strategy "feature_flag" \
+    --rollback-flag "session_refresh_v2" > "$dir/contract-auth.stdout"
+  "$VOUCH" --repo "$repo" contract create \
+    --name payments.checkout \
+    --owner payments \
+    --risk high \
+    --paths "internal/payments/**,tests/payments/**" \
+    --behavior "checkout creates idempotent payment intent" \
+    --behavior "invoice total uses server side price" \
+    --security "webhook signature is verified" \
+    --security "card data is never logged" \
+    --required-test "checkout idempotency" \
+    --required-test "invoice total cannot be client overridden" \
+    --metric "payments.checkout.created" \
+    --metric "payments.checkout.failed" \
+    --rollback-strategy "disable_feature_flag" \
+    --rollback-flag "checkout_v3" > "$dir/contract-payments.stdout"
+  "$VOUCH" --repo "$repo" contract create \
+    --name api.users \
+    --owner platform \
+    --risk medium \
+    --paths "internal/api/**,tests/api/**" \
+    --behavior "user profile response preserves public schema" \
+    --behavior "user search paginates deterministically" \
+    --security "email address is hidden from public search" \
+    --required-test "user profile schema" \
+    --required-test "user search pagination" \
+    --metric "api.users.requests" \
+    --rollback-strategy "revert_change" > "$dir/contract-api.stdout"
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  printf '%s\n' "$repo"
+}
+
+write_platform_artifacts() {
+  local repo="$1"
+  local behavior_ids="$2"
+  local security_ids="$3"
+  local test_ids="$4"
+  local runtime_ids="$5"
+  local rollback_ids="$6"
+
+  mkdir -p "$repo/.vouch/artifacts"
+  write_obligation_json "$repo/.vouch/artifacts/platform-behavior.json" "$behavior_ids"
+  write_obligation_json "$repo/.vouch/artifacts/platform-security.json" "$security_ids"
+  write_junit_obligations "$repo/.vouch/artifacts/platform-tests.xml" "$test_ids"
+  write_obligation_json "$repo/.vouch/artifacts/platform-runtime.json" "$runtime_ids"
+  write_obligation_json "$repo/.vouch/artifacts/platform-rollback.json" "$rollback_ids"
+}
+
+attach_platform_artifacts() {
+  local repo="$1"
+  local manifest="$2"
+  local dir="$3"
+
+  attach_artifact "$repo" "$manifest" platform-behavior behavior_trace .vouch/artifacts/platform-behavior.json "$dir/attach-platform-behavior.stdout"
+  attach_artifact "$repo" "$manifest" platform-security security_check .vouch/artifacts/platform-security.json "$dir/attach-platform-security.stdout"
+  attach_artifact "$repo" "$manifest" platform-tests test_coverage .vouch/artifacts/platform-tests.xml "$dir/attach-platform-tests.stdout"
+  attach_artifact "$repo" "$manifest" platform-runtime runtime_metric .vouch/artifacts/platform-runtime.json "$dir/attach-platform-runtime.stdout"
+  attach_artifact "$repo" "$manifest" platform-rollback rollback_plan .vouch/artifacts/platform-rollback.json "$dir/attach-platform-rollback.stdout"
+}
+
+add_auth_tests_only() {
+  local scenario="auth_tests_only"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(copy_demo_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"High-risk auth change with passing JUnit only\",
+    \"claim\": \"JUnit tests pass, but behavior, security, runtime, and rollback evidence is missing.\",
+    \"baseline\": {
+      \"id\": \"tests_only\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees a passing JUnit artifact and no release-obligation coverage model.\"
+    },
+    \"expected\": {
+      \"decision\": \"block\",
+      \"gate_exit_code\": 1,
+      \"covered_obligations\": 4,
+      \"total_obligations\": 16,
+      \"missing_obligations\": $auth_tests_only_missing_ids,
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"block_verifier_findings\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"artifact_statuses\": {\"junit\": \"valid\"},
+      \"reason_substrings\": [
+        \"uncovered behavior obligations\",
+        \"uncovered security invariants\",
+        \"uncovered rollback obligations\",
+        \"uncovered runtime signal obligations\"
+      ]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  "$VOUCH" --repo "$repo" evidence import junit artifacts/junit-pass.xml > "$dir/import.stdout"
+  run_gate "$dir" "$repo" ""
+  assert_scenario "$dir"
+}
+
+add_auth_partial_release_evidence() {
+  local scenario="auth_partial_release_evidence"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(copy_demo_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"High-risk auth change with partial release evidence\",
+    \"claim\": \"Tests pass and some artifacts exist, but required test, security, and runtime obligations remain uncovered.\",
+    \"baseline\": {
+      \"id\": \"tests_plus_partial_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees passing tests and partial artifacts, but does not require every compiled release obligation to be covered.\"
+    },
+    \"expected\": {
+      \"decision\": \"block\",
+      \"gate_exit_code\": 1,
+      \"covered_obligations\": 10,
+      \"total_obligations\": 16,
+      \"missing_obligations\": $auth_partial_missing_ids,
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"block_verifier_findings\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"artifact_statuses\": {\"test-results\": \"valid\", \"security-results\": \"valid\", \"runtime-signals\": \"valid\"},
+      \"reason_substrings\": [
+        \"uncovered required tests\",
+        \"uncovered security invariants\",
+        \"uncovered runtime signal obligations\"
+      ]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  run_gate "$dir" "$repo" ".vouch/manifests/blocked.json"
+  assert_scenario "$dir"
+}
+
+add_auth_manifest_traceability_block() {
+  local scenario="auth_manifest_traceability_block"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(copy_demo_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"High-risk auth change with full evidence but an unrouted changed file\",
+    \"claim\": \"Complete auth evidence is not enough when the manifest omits ownership for a changed billing file.\",
+    \"baseline\": {
+      \"id\": \"tests_plus_complete_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees the full passing artifact set but does not check changed-file ownership against contract scope.\"
+    },
+    \"expected\": {
+      \"decision\": \"block\",
+      \"gate_exit_code\": 1,
+      \"covered_obligations\": 16,
+      \"total_obligations\": 16,
+      \"missing_obligations\": [],
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"block_invalid_spec_or_manifest\"],
+      \"manifest_error_count\": 1,
+      \"spec_error_count\": 0,
+      \"reason_substrings\": [\"invalid specs or manifest\"],
+      \"manifest_error_substrings\": [\"src/billing/invoice.ts\"]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  run_gate "$dir" "$repo" ".vouch/manifests/traceability-blocked.json"
+  assert_scenario "$dir"
+}
+
+add_auth_nonzero_test_artifact() {
+  local scenario="auth_nonzero_test_artifact"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(copy_demo_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"High-risk auth change with complete evidence but a non-zero test artifact exit\",
+    \"claim\": \"The harness must treat artifact command exit codes as release evidence, not just artifact file presence.\",
+    \"baseline\": {
+      \"id\": \"tests_failed\",
+      \"tests_passed\": false,
+      \"caught_by_tests\": true,
+      \"would_continue_without_vouch\": false,
+      \"description\": \"The test runner already failed, so this is a negative-control scenario rather than a Vouch-only catch.\"
+    },
+    \"expected\": {
+      \"decision\": \"block\",
+      \"gate_exit_code\": 1,
+      \"covered_obligations\": 12,
+      \"total_obligations\": 16,
+      \"missing_obligations\": $auth_test_missing_ids,
+      \"invalid_evidence\": [\"test-results:non_zero_exit\"],
+      \"policy_rules_fired\": [\"block_verifier_findings\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"artifact_statuses\": {\"test-results\": \"invalid\"},
+      \"reason_substrings\": [
+        \"evidence artifact test-results is invalid\",
+        \"test suite failed\",
+        \"uncovered required tests\"
+      ]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  set_test_artifact_exit_code "$repo" ".vouch/manifests/nonzero-test-artifact.json"
+  run_gate "$dir" "$repo" ".vouch/manifests/nonzero-test-artifact.json"
+  assert_scenario "$dir"
+}
+
+add_auth_full_release_evidence() {
+  local scenario="auth_full_release_evidence"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(copy_demo_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"High-risk auth change with complete release evidence\",
+    \"claim\": \"All obligations are covered; policy still routes high-risk auth through canary instead of auto-merge.\",
+    \"baseline\": {
+      \"id\": \"tests_plus_complete_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees complete passing artifacts but does not express the canary release route.\"
+    },
+    \"expected\": {
+      \"decision\": \"canary\",
+      \"gate_exit_code\": 0,
+      \"covered_obligations\": 16,
+      \"total_obligations\": 16,
+      \"missing_obligations\": [],
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"high_risk_canary\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"reason_substrings\": [\"high-risk change has passing evidence and canary enabled\"]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  run_gate "$dir" "$repo" ".vouch/manifests/pass.json"
+  assert_scenario "$dir"
+}
+
+add_auth_full_release_without_canary() {
+  local scenario="auth_full_release_without_canary"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(copy_demo_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"High-risk auth change with complete evidence but no canary\",
+    \"claim\": \"Complete evidence without a canary should escalate high-risk auth instead of auto-merging.\",
+    \"baseline\": {
+      \"id\": \"tests_plus_complete_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees passing tests and complete artifacts, but does not encode high-risk rollout policy.\"
+    },
+    \"expected\": {
+      \"decision\": \"human_escalation\",
+      \"gate_exit_code\": 0,
+      \"covered_obligations\": 16,
+      \"total_obligations\": 16,
+      \"missing_obligations\": [],
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"high_risk_without_canary\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"reason_substrings\": [\"high-risk change passed checks but has no canary\"]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  disable_canary_manifest "$repo" ".vouch/manifests/no-canary.json"
+  run_gate "$dir" "$repo" ".vouch/manifests/no-canary.json"
+  assert_scenario "$dir"
+}
+
+add_platform_multi_component_partial_evidence() {
+  local scenario="platform_multi_component_partial_evidence"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(create_platform_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"Medium/high platform change with partial multi-component evidence\",
+    \"claim\": \"A realistic multi-component release can pass tests and still block because one high-risk component lacks security, runtime, and rollback evidence.\",
+    \"baseline\": {
+      \"id\": \"multi_component_tests_plus_partial_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees passing tests across auth, payments, and API, but does not require complete evidence per compiled obligation and component.\"
+    },
+    \"expected\": {
+      \"decision\": \"block\",
+      \"gate_exit_code\": 1,
+      \"covered_obligations\": 22,
+      \"total_obligations\": 25,
+      \"missing_obligations\": $platform_partial_missing_ids,
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"block_verifier_findings\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"artifact_statuses\": {
+        \"platform-behavior\": \"valid\",
+        \"platform-security\": \"valid\",
+        \"platform-tests\": \"valid\",
+        \"platform-runtime\": \"valid\",
+        \"platform-rollback\": \"valid\"
+      },
+      \"reason_substrings\": [
+        \"payments.checkout has uncovered security invariants\",
+        \"payments.checkout has uncovered runtime signal obligations\",
+        \"payments.checkout has uncovered rollback obligations\"
+      ]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" manifest create \
+    --task-id platform-204 \
+    --summary "agent updates session refresh, checkout, and users API" \
+    --agent codex \
+    --run-id platform-partial \
+    --changed-file internal/auth/session.py \
+    --changed-file internal/payments/checkout.py \
+    --changed-file internal/api/users.py \
+    --external-effect charges_card \
+    --external-effect sends_email \
+    --out .vouch/manifests/platform-partial.json > "$dir/manifest.stdout"
+  write_platform_artifacts "$repo" \
+    "$platform_behavior_all_ids" \
+    "$platform_security_partial_ids" \
+    "$platform_tests_all_ids" \
+    "$platform_runtime_partial_ids" \
+    "$platform_rollback_partial_ids"
+  attach_platform_artifacts "$repo" ".vouch/manifests/platform-partial.json" "$dir"
+  run_gate "$dir" "$repo" ".vouch/manifests/platform-partial.json"
+  assert_scenario "$dir"
+}
+
+add_platform_multi_component_full_canary() {
+  local scenario="platform_multi_component_full_canary"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(create_platform_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"Medium/high platform change with complete multi-component evidence\",
+    \"claim\": \"A multi-component high-risk release with complete evidence should pass to canary instead of being treated like a tiny toy repo.\",
+    \"baseline\": {
+      \"id\": \"multi_component_tests_plus_complete_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees all component tests and artifacts passing but does not encode the high-risk canary release posture.\"
+    },
+    \"expected\": {
+      \"decision\": \"canary\",
+      \"gate_exit_code\": 0,
+      \"covered_obligations\": 25,
+      \"total_obligations\": 25,
+      \"missing_obligations\": [],
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"high_risk_canary\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"reason_substrings\": [\"high-risk change has passing evidence and canary enabled\"]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" manifest create \
+    --task-id platform-205 \
+    --summary "agent updates session refresh, checkout, and users API with complete release evidence" \
+    --agent codex \
+    --run-id platform-full \
+    --changed-file internal/auth/session.py \
+    --changed-file internal/payments/checkout.py \
+    --changed-file internal/api/users.py \
+    --external-effect charges_card \
+    --external-effect sends_email \
+    --out .vouch/manifests/platform-full.json > "$dir/manifest.stdout"
+  write_platform_artifacts "$repo" \
+    "$platform_behavior_all_ids" \
+    "$platform_security_full_ids" \
+    "$platform_tests_all_ids" \
+    "$platform_runtime_full_ids" \
+    "$platform_rollback_full_ids"
+  attach_platform_artifacts "$repo" ".vouch/manifests/platform-full.json" "$dir"
+  run_gate "$dir" "$repo" ".vouch/manifests/platform-full.json"
+  assert_scenario "$dir"
+}
+
+add_platform_medium_api_auto_merge() {
+  local scenario="platform_medium_api_auto_merge"
+  local dir="$RUN_DIR/$scenario"
+  local repo
+  repo="$(create_platform_repo "$scenario")"
+  SCENARIOS+=("$dir")
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"Medium-risk API-only change in a multi-component repo\",
+    \"claim\": \"The benchmark should prove Vouch can isolate a medium-risk component inside a larger repo and auto-merge it when evidence is complete.\",
+    \"baseline\": {
+      \"id\": \"api_tests_plus_complete_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees passing API tests but does not prove the gate scoped obligations to only the touched medium-risk contract.\"
+    },
+    \"expected\": {
+      \"decision\": \"auto_merge\",
+      \"gate_exit_code\": 0,
+      \"covered_obligations\": 7,
+      \"total_obligations\": 7,
+      \"missing_obligations\": [],
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"low_medium_auto_merge\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"reason_substrings\": [\"low/medium risk change passed required evidence\"]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" manifest create \
+    --task-id platform-206 \
+    --summary "agent updates users API only" \
+    --agent codex \
+    --run-id platform-api \
+    --changed-file internal/api/users.py \
+    --out .vouch/manifests/platform-api.json > "$dir/manifest.stdout"
+  write_platform_artifacts "$repo" \
+    "$platform_api_behavior_ids" \
+    "$platform_api_security_ids" \
+    "$platform_api_tests_ids" \
+    "$platform_api_runtime_ids" \
+    "$platform_api_rollback_ids"
+  attach_platform_artifacts "$repo" ".vouch/manifests/platform-api.json" "$dir"
+  run_gate "$dir" "$repo" ".vouch/manifests/platform-api.json"
+  assert_scenario "$dir"
+}
+
+add_docs_low_risk_full_evidence() {
+  local scenario="docs_low_risk_full_evidence"
+  local dir="$RUN_DIR/$scenario"
+  local repo="$dir/repo"
+  SCENARIOS+=("$dir")
+
+  mkdir -p "$repo"
+  printf '# Docs\n' > "$repo/README.md"
+
+  write_meta_json "$dir" "{
+    \"id\": \"$scenario\",
+    \"title\": \"Low-risk docs change with complete evidence\",
+    \"claim\": \"A low-risk fully evidenced change should not be falsely blocked.\",
+    \"baseline\": {
+      \"id\": \"tests_plus_complete_artifacts\",
+      \"tests_passed\": true,
+      \"caught_by_tests\": false,
+      \"would_continue_without_vouch\": true,
+      \"description\": \"The baseline sees passing documentation checks and all declared docs obligations are covered.\"
+    },
+    \"expected\": {
+      \"decision\": \"auto_merge\",
+      \"gate_exit_code\": 0,
+      \"covered_obligations\": 5,
+      \"total_obligations\": 5,
+      \"missing_obligations\": [],
+      \"invalid_evidence\": [],
+      \"policy_rules_fired\": [\"low_medium_auto_merge\"],
+      \"manifest_error_count\": 0,
+      \"spec_error_count\": 0,
+      \"reason_substrings\": [\"low/medium risk change passed required evidence\"]
+    }
+  }"
+
+  "$VOUCH" --repo "$repo" init > "$dir/init.stdout"
+  "$VOUCH" --repo "$repo" contract create \
+    --name docs.readme \
+    --owner docs \
+    --risk low \
+    --paths README.md \
+    --behavior "readme documents usage" \
+    --security "no secrets introduced" \
+    --required-test "documentation smoke check" \
+    --metric "vouch.gate.decision" \
+    --rollback-strategy "revert_change" > "$dir/contract.stdout"
+  "$VOUCH" --repo "$repo" compile > "$dir/compile.stdout"
+  "$VOUCH" --repo "$repo" manifest create \
+    --task-id docs-safe \
+    --summary "docs update" \
+    --agent codex \
+    --run-id bench-docs \
+    --changed-file README.md \
+    --out .vouch/manifests/docs.json > "$dir/manifest.stdout"
+
+  mkdir -p "$repo/.vouch/artifacts"
+  write_text_file "$repo/.vouch/artifacts/behavior.json" '{"status":"pass","obligations":["docs.readme.behavior.readme_documents_usage"]}'
+  write_text_file "$repo/.vouch/artifacts/security.json" '{"status":"pass","obligations":["docs.readme.security.no_secrets_introduced"]}'
+  write_text_file "$repo/.vouch/artifacts/runtime.json" '{"status":"pass","obligations":["docs.readme.runtime_signal.vouch_gate_decision"]}'
+  write_text_file "$repo/.vouch/artifacts/rollback.json" '{"status":"pass","obligations":["docs.readme.rollback.revert_change"]}'
+  write_text_file "$repo/.vouch/test-map.json" '{"version":"vouch.test_map.v0","mappings":{"docs.readme.required_test.documentation_smoke_check":["tests/docs/test_readme.py::test_documentation_smoke_check"]}}'
+  write_text_file "$repo/.vouch/artifacts/tests.xml" '<testsuite name="docs" tests="1" failures="0" errors="0" skipped="0"><testcase classname="tests.docs.test_readme" name="test_documentation_smoke_check" file="tests/docs/test_readme.py"></testcase></testsuite>'
+
+  "$VOUCH" --repo "$repo" manifest attach-artifact \
+    --manifest .vouch/manifests/docs.json \
+    --id behavior \
+    --kind behavior_trace \
+    --path .vouch/artifacts/behavior.json \
+    --exit-code 0 \
+    --out .vouch/manifests/docs.json > "$dir/attach-behavior.stdout"
+  "$VOUCH" --repo "$repo" manifest attach-artifact \
+    --manifest .vouch/manifests/docs.json \
+    --id security \
+    --kind security_check \
+    --path .vouch/artifacts/security.json \
+    --exit-code 0 \
+    --out .vouch/manifests/docs.json > "$dir/attach-security.stdout"
+  "$VOUCH" --repo "$repo" manifest attach-artifact \
+    --manifest .vouch/manifests/docs.json \
+    --id tests \
+    --kind test_coverage \
+    --path .vouch/artifacts/tests.xml \
+    --test-map .vouch/test-map.json \
+    --exit-code 0 \
+    --out .vouch/manifests/docs.json > "$dir/attach-tests.stdout"
+  "$VOUCH" --repo "$repo" manifest attach-artifact \
+    --manifest .vouch/manifests/docs.json \
+    --id runtime \
+    --kind runtime_metric \
+    --path .vouch/artifacts/runtime.json \
+    --exit-code 0 \
+    --out .vouch/manifests/docs.json > "$dir/attach-runtime.stdout"
+  "$VOUCH" --repo "$repo" manifest attach-artifact \
+    --manifest .vouch/manifests/docs.json \
+    --id rollback \
+    --kind rollback_plan \
+    --path .vouch/artifacts/rollback.json \
+    --exit-code 0 \
+    --out .vouch/manifests/docs.json > "$dir/attach-rollback.stdout"
+
+  run_gate "$dir" "$repo" ".vouch/manifests/docs.json"
+  assert_scenario "$dir"
+}
+
+render_results() {
+  local json_out="$OUT_DIR/vouchbench.latest.json"
+  local md_out="$OUT_DIR/vouchbench.latest.md"
+
+  python3 - "$json_out" "$md_out" "${SCENARIOS[@]}" <<'PY'
+from __future__ import annotations
+
+import datetime as dt
+import json
+import statistics
+import sys
+from pathlib import Path
+
+json_out = Path(sys.argv[1])
+md_out = Path(sys.argv[2])
+scenario_dirs = [Path(p) for p in sys.argv[3:]]
+
+required_scenarios = [
+    "auth_tests_only",
+    "auth_partial_release_evidence",
+    "auth_manifest_traceability_block",
+    "auth_nonzero_test_artifact",
+    "auth_full_release_evidence",
+    "auth_full_release_without_canary",
+    "platform_multi_component_partial_evidence",
+    "platform_multi_component_full_canary",
+    "platform_medium_api_auto_merge",
+    "docs_low_risk_full_evidence",
+]
+
+
+def load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def criterion(criteria: list[dict], criterion_id: str, passed: bool, expected: object, actual: object, description: str) -> None:
+    criteria.append({
+        "id": criterion_id,
+        "passed": bool(passed),
+        "expected": expected,
+        "actual": actual,
+        "description": description,
+    })
+
+
+rows = [load(path / "row.json") for path in scenario_dirs]
+rows_by_id = {row["id"]: row for row in rows}
+assertion_count = sum(len(row["assertions"]) for row in rows)
+assertions_passed = sum(
+    1
+    for row in rows
+    for item in row["assertions"]
+    if item["passed"]
+)
+gate_times = [row["actual"]["gate_ms"] for row in rows]
+tests_passed_rows = [row for row in rows if row["baseline"]["tests_passed"]]
+tests_failed_rows = [row for row in rows if not row["baseline"]["tests_passed"]]
+tests_passed_block_rows = [
+    row for row in rows
+    if row["baseline"]["tests_passed"]
+    and row["expected"]["decision"] == "block"
+    and row["actual"]["decision"] == "block"
+]
+nonblocking_rows = [row for row in rows if row["expected"]["decision"] != "block"]
+full_coverage_block_rows = [
+    row for row in rows
+    if row["actual"]["decision"] == "block"
+    and row["actual"]["covered_obligations"] == row["actual"]["total_obligations"]
+]
+medium_high_scale_rows = [
+    row for row in rows
+    if row["actual"]["total_obligations"] >= 25
+]
+invalid_evidence_rows = [
+    row for row in rows
+    if len(row["actual"]["invalid_evidence"]) > 0
+]
+manifest_traceability_rows = [
+    row for row in rows
+    if row["actual"]["decision"] == "block"
+    and row["actual"]["manifest_error_count"] > 0
+]
+
+summary = {
+    "scenario_count": len(rows),
+    "assertions_passed": assertions_passed,
+    "assertion_count": assertion_count,
+    "expected_decisions_met": sum(1 for row in rows if row["actual"]["decision"] == row["expected"]["decision"]),
+    "expected_gate_exit_codes_met": sum(1 for row in rows if row["actual"]["gate_exit_code"] == row["expected"]["gate_exit_code"]),
+    "tests_passed_scenarios": len(tests_passed_rows),
+    "tests_failed_scenarios": len(tests_failed_rows),
+    "tests_passed_expected_block_scenarios": len([row for row in rows if row["baseline"]["tests_passed"] and row["expected"]["decision"] == "block"]),
+    "tests_passed_scenarios_vouch_blocked": len(tests_passed_block_rows),
+    "tests_failed_scenarios_vouch_blocked": len([row for row in tests_failed_rows if row["actual"]["decision"] == "block"]),
+    "nonblocking_policy_routes": len(nonblocking_rows),
+    "nonblocking_policy_routes_met": sum(1 for row in nonblocking_rows if row["actual"]["decision"] == row["expected"]["decision"]),
+    "full_coverage_block_scenarios": len(full_coverage_block_rows),
+    "medium_high_scale_scenarios": len(medium_high_scale_rows),
+    "max_obligations_in_scenario": max([row["actual"]["total_obligations"] for row in rows], default=0),
+    "invalid_evidence_scenarios": len(invalid_evidence_rows),
+    "manifest_traceability_block_scenarios": len(manifest_traceability_rows),
+    "median_gate_ms": round(statistics.median(gate_times), 3) if gate_times else 0,
+    "max_gate_ms": round(max(gate_times), 3) if gate_times else 0,
+}
+
+criteria: list[dict] = []
+criterion(
+    criteria,
+    "required_scenario_corpus",
+    sorted(rows_by_id) == sorted(required_scenarios),
+    sorted(required_scenarios),
+    sorted(rows_by_id),
+    "the benchmark must keep the required scenario corpus intact",
+)
+criterion(
+    criteria,
+    "all_scenario_assertions_passed",
+    assertions_passed == assertion_count and assertion_count > 0,
+    f"{assertion_count}/{assertion_count}",
+    f"{assertions_passed}/{assertion_count}",
+    "every scenario-level machine-readable assertion must pass",
+)
+criterion(
+    criteria,
+    "tests_passed_blocks_preserved",
+    len(tests_passed_block_rows) >= 4,
+    ">=4",
+    len(tests_passed_block_rows),
+    "at least four tests-passed scenarios must still be blocked by Vouch-specific checks",
+)
+criterion(
+    criteria,
+    "nonblocking_routes_preserved",
+    summary["nonblocking_policy_routes_met"] >= 3,
+    ">=3",
+    summary["nonblocking_policy_routes_met"],
+    "canary, human escalation, and auto-merge non-blocking routes must all be exercised",
+)
+criterion(
+    criteria,
+    "medium_high_repo_scale_preserved",
+    len(medium_high_scale_rows) >= 2 and summary["max_obligations_in_scenario"] >= 25,
+    {
+        "min_scenarios_with_25_obligations": 2,
+        "min_max_obligations": 25,
+    },
+    {
+        "scenarios_with_25_obligations": len(medium_high_scale_rows),
+        "max_obligations": summary["max_obligations_in_scenario"],
+    },
+    "the corpus must include medium/high multi-component repo scenarios with at least 25 obligations",
+)
+criterion(
+    criteria,
+    "invalid_evidence_detection_preserved",
+    len(invalid_evidence_rows) >= 1,
+    ">=1",
+    len(invalid_evidence_rows),
+    "the corpus must include at least one invalid artifact evidence block",
+)
+criterion(
+    criteria,
+    "full_coverage_manifest_block_preserved",
+    len(full_coverage_block_rows) >= 1 and len(manifest_traceability_rows) >= 1,
+    ">=1 full-coverage manifest block",
+    {
+        "full_coverage_block_scenarios": len(full_coverage_block_rows),
+        "manifest_traceability_block_scenarios": len(manifest_traceability_rows),
+    },
+    "the corpus must prove full coverage can still block on manifest traceability",
+)
+
+acceptance = {
+    "passed": all(item["passed"] for item in criteria),
+    "criteria": criteria,
+}
+result = {
+    "version": "vouchbench.v1",
+    "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+    "acceptance": acceptance,
+    "summary": summary,
+    "scenarios": rows,
+}
+json_out.parent.mkdir(parents=True, exist_ok=True)
+with json_out.open("w", encoding="utf-8") as f:
+    json.dump(result, f, indent=2, sort_keys=True)
+    f.write("\n")
+
+status = "pass" if acceptance["passed"] else "fail"
+lines = [
+    "# VouchBench Latest",
+    "",
+    f"Generated: `{result['generated_at']}`",
+    "",
+    "## Acceptance",
+    "",
+    f"- Status: `{status}`",
+    f"- Assertions passed: {assertions_passed}/{assertion_count}",
+    f"- Required scenarios present: {len(rows_by_id)}/{len(required_scenarios)}",
+    "",
+    "| Criterion | Result | Actual | Expected |",
+    "| --- | --- | --- | --- |",
+]
+for item in criteria:
+    result_word = "pass" if item["passed"] else "fail"
+    actual = json.dumps(item["actual"], sort_keys=True) if isinstance(item["actual"], (dict, list)) else str(item["actual"])
+    expected = json.dumps(item["expected"], sort_keys=True) if isinstance(item["expected"], (dict, list)) else str(item["expected"])
+    lines.append(f"| `{item['id']}` | `{result_word}` | `{actual}` | `{expected}` |")
+
+lines.extend([
+    "",
+    "## Baseline Accounting",
+    "",
+    f"- Tests-passed scenarios: {summary['tests_passed_scenarios']}/{summary['scenario_count']}",
+    f"- Tests-failed negative controls: {summary['tests_failed_scenarios']}/{summary['scenario_count']}",
+    f"- Tests-passed scenarios expected to block: {summary['tests_passed_expected_block_scenarios']}",
+    f"- Tests-passed scenarios Vouch blocked: {summary['tests_passed_scenarios_vouch_blocked']}/{summary['tests_passed_expected_block_scenarios']}",
+    f"- Non-blocking policy routes matched: {summary['nonblocking_policy_routes_met']}/{summary['nonblocking_policy_routes']}",
+    f"- Full-coverage block scenarios: {summary['full_coverage_block_scenarios']}",
+    f"- Medium/high scale scenarios: {summary['medium_high_scale_scenarios']} with max {summary['max_obligations_in_scenario']} obligations",
+    f"- Invalid-evidence scenarios: {summary['invalid_evidence_scenarios']}",
+    f"- Median gate runtime: {summary['median_gate_ms']} ms",
+    f"- Max gate runtime: {summary['max_gate_ms']} ms",
+    "",
+    "## Scenarios",
+    "",
+    "| Scenario | Baseline | Tests | Expected | Vouch | Exit | Coverage | Assertions |",
+    "| --- | --- | --- | --- | --- | ---: | --- | --- |",
+])
+for row in rows:
+    tests = "pass" if row["baseline"]["tests_passed"] else "fail"
+    assertions_met = sum(1 for item in row["assertions"] if item["passed"])
+    assertions_total = len(row["assertions"])
+    coverage = f"{row['actual']['covered_obligations']}/{row['actual']['total_obligations']}"
+    lines.append(
+        f"| `{row['id']}` | `{row['baseline']['id']}` | `{tests}` | "
+        f"`{row['expected']['decision']}` | `{row['actual']['decision']}` | "
+        f"{row['actual']['gate_exit_code']} | `{coverage}` | {assertions_met}/{assertions_total} |"
+    )
+lines.extend([
+    "",
+    "## Claims Exercised",
+    "",
+])
+for row in rows:
+    lines.append(f"- `{row['id']}`: {row['claim']}")
+
+md_out.parent.mkdir(parents=True, exist_ok=True)
+md_out.write_text("\n".join(lines) + "\n", encoding="utf-8")
+print(md_out.read_text(encoding="utf-8"))
+
+if not acceptance["passed"]:
+    print("vouchbench: acceptance failed", file=sys.stderr)
+    for item in criteria:
+        if not item["passed"]:
+            print(f"- {item['id']}: expected {item['expected']!r}, got {item['actual']!r}", file=sys.stderr)
+    sys.exit(1)
+PY
+}
+
+echo "building local vouch binary..."
+(cd "$ROOT" && GOCACHE="${GOCACHE:-$RUN_DIR/gocache}" go build -o "$VOUCH" ./cmd/vouch)
+
+echo "running benchmark scenarios..."
+add_auth_tests_only
+add_auth_partial_release_evidence
+add_auth_manifest_traceability_block
+add_auth_nonzero_test_artifact
+add_auth_full_release_evidence
+add_auth_full_release_without_canary
+add_platform_multi_component_partial_evidence
+add_platform_multi_component_full_canary
+add_platform_medium_api_auto_merge
+add_docs_low_risk_full_evidence
+
+render_results
+echo "wrote:"
+echo "  $OUT_DIR/vouchbench.latest.json"
+echo "  $OUT_DIR/vouchbench.latest.md"


### PR DESCRIPTION
## Summary

  - Add `scripts/vouchbench.sh` for fixed Vouch benchmark scenarios.
  - Add 10 benchmark scenarios for missing evidence, partial evidence, bad manifests, failed test artifacts, canary, human review, auto-merge, and multi-component repos.
  - Add `scripts/vouchbench-repo.sh` to test Vouch on a copied real repo without modifying the original.

  ## Validation

  - `bash -n scripts/vouchbench.sh`
  - `bash -n scripts/vouchbench-repo.sh`
  - `git diff --check`
  - `scripts/vouchbench.sh --out /private/tmp/vouchbench-final-after-repo-mode`
  - `scripts/vouchbench-repo.sh --repo /Users/oha/skylos --out /private/tmp/vouchbench-skylos`
  - `scripts/vouchbench-repo.sh --repo /Users/oha/sago --out /private/tmp/vouchbench-sago`
  - `GOCACHE=/private/tmp/vouch-gocache go test ./...`