### PR TITLE
chore: harden release evidence workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Good contributions make that pipeline more explicit, deterministic, testable, an
 Run the tests:
 
 ```sh
-GOCACHE=/private/tmp/vouch-gocache go test ./...
+go test ./...
 ```
 
 Install the CLI locally:

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The site is deployed from `.github/workflows/pages.yml` after changes land on
 - [Benchmarks](docs/BENCHMARKS.md)
 - [Comparison](COMPARISON.md)
 - [Roadmap](ROADMAP.md)
+- [Agent/product operating brief](skills.md)
 - [Contributing](CONTRIBUTING.md)
 
 ## Status
@@ -93,7 +94,7 @@ scripts/vouchbench.sh
 ## Development
 
 ```sh
-GOCACHE=/private/tmp/vouch-gocache go test ./...
+go test ./...
 ```
 
 ## License

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -84,18 +84,29 @@ It does not yet prove that Vouch understands arbitrary product intent. The contr
 
 ## Execution Order
 
-The trust and policy work should move earlier than the original phase order.
-Until evidence is provenance-bound and policy is inspectable, workflow polish and
-AI verifier layers are easy to bypass or hard to reason about.
+Use [`skills.md`](skills.md) as the operating brief for choosing work. The
+direction is compiler/evidence control plane, not AI code review.
+
+The next product risk is adoption proof: teams need to see Vouch catch
+release-readiness gaps in a normal pull-request workflow without pretending to
+judge arbitrary implementation correctness. Trust and policy hardening still
+matter, but they should support real evidence workflows rather than lead the
+roadmap by themselves.
 
 Near-term execution order:
 
-1. Tamper-evident evidence and runner identity.
-2. Policy files and policy simulation.
-3. Positioning and comparison artifacts.
-4. Contract-generation paths that reduce authoring cost.
-5. Reproducible case studies that show Vouch catching realistic regressions.
-6. AI evidence verifiers only after signed evidence and policy semantics exist.
+1. Shadow-mode pull-request pilot package.
+2. Evidence connector wedge: SARIF/Semgrep import and coverage import.
+3. Reproducible case study where tests pass but Vouch blocks or routes because
+   release obligations are missing, invalid, or out of scope.
+4. Artifact upload conventions and auditable gate output for PR workflows.
+5. Trust hardening that supports evidence workflows: required high-risk hashes,
+   commit/runner provenance, scoped signers, and signed specs or manifests.
+6. JSON schemas and compatibility tests for public artifacts.
+7. Policy profile expansion or Rego adapter once the policy input shape proves
+   stable.
+8. AI evidence verifiers only after evidence provenance and policy semantics are
+   solid.
 
 ## Roadmap Phases
 
@@ -235,18 +246,21 @@ Remaining work:
 
 The next useful contributions are:
 
+- Static-analysis/SARIF importer for security and quality evidence.
+- Coverage XML importer for required-test and behavior evidence.
+- Shadow-mode GitHub PR workflow with artifact upload conventions.
+- Real-world case study showing a plausible bad agent change blocked by an obligation.
+- Reference workflow for `try -> write -> manifest -> attach evidence -> gate`.
+- Test-map discovery to reduce manual required-test mapping.
+- Required hashes for high-risk evidence artifacts.
+- Commit SHA and runner provenance binding for evidence artifacts.
 - Contract- or path-scoped allowed signer policy.
 - Canonical JSON serialization rules for evidence bundles.
 - Signed specs and manifests.
-- Rego policy adapter decision spike.
-- Reference workflow for `init -> manifest -> pytest -> junit map -> attach -> gate`.
-- Real-world case study showing a plausible bad agent change blocked by an obligation.
-- Test-map discovery to reduce manual required-test mapping.
-- OpenAPI-to-contract stub generation.
-- Coverage XML importer for required-test and behavior evidence.
-- Static-analysis/SARIF importer for security and quality evidence.
 - JSON schemas plus compatibility tests for AST, spec, IR, plan, manifest, and evidence.
 - Golden diagnostics for parser and compiler failures.
+- OpenAPI-to-contract stub generation.
+- Rego policy adapter decision spike.
 - More demo scenarios beyond password reset, including ordinary library changes.
 
 ## Productionization Track

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -54,10 +54,10 @@ scripts/vouchbench-repo.sh \
   --out /tmp/vouchbench-repo
 ```
 
-For a repo like `/Users/oha/skylos`, start non-destructively:
+For an external repo, start non-destructively:
 
 ```sh
-scripts/vouchbench-repo.sh --repo /Users/oha/skylos --out /tmp/vouchbench-skylos
+scripts/vouchbench-repo.sh --repo /path/to/repo --out /tmp/vouchbench-repo
 ```
 
 That run answers different questions from the fixture acceptance suite:

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -330,7 +330,7 @@ func manifestCreate(repo string, args []string, jsonOut bool, stdout io.Writer, 
 	model := flags.String("model", "", "agent model")
 	runnerIdentity := flags.String("runner-identity", "", "expected runner identity for signed evidence")
 	runnerOIDCIssuer := flags.String("runner-oidc-issuer", "", "expected runner OIDC issuer for signed evidence")
-	base := flags.String("base", "main", "git base ref")
+	base := flags.String("base", "", "git base ref; auto-detected when omitted")
 	head := flags.String("head", "HEAD", "git head ref")
 	risk := flags.String("risk", "", "risk override")
 	outPath := flags.String("out", "", "manifest output path")

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -460,6 +460,10 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 	if len(covered) == 0 {
 		return Manifest{}, EvidenceArtifact{}, fmt.Errorf("artifact covers no %q obligations: %s", opts.Kind, strings.Join(issues, "; "))
 	}
+	artifactSHA256 := opts.SHA256
+	if artifactSHA256 == "" {
+		artifactSHA256 = sha256Hex(data)
+	}
 	producer := opts.Producer
 	if producer == "" {
 		producer = manifest.Agent.Name
@@ -473,7 +477,7 @@ func AttachArtifact(repo string, opts AttachArtifactOptions) (Manifest, Evidence
 		Producer:         producer,
 		Command:          opts.Command,
 		Path:             artifactPath,
-		SHA256:           opts.SHA256,
+		SHA256:           artifactSHA256,
 		EvidenceBundle:   opts.EvidenceBundle,
 		SignatureBundle:  opts.SignatureBundle,
 		SignerIdentity:   opts.SignerIdentity,
@@ -846,7 +850,11 @@ func writeYAMLList(b *bytes.Buffer, key string, values []string) {
 
 func gitChangedFiles(repo string, base string, head string) ([]string, error) {
 	if base == "" {
-		base = "main"
+		var err error
+		base, err = defaultGitBaseRef(repo)
+		if err != nil {
+			return nil, err
+		}
 	}
 	if head == "" {
 		head = "HEAD"
@@ -868,6 +876,35 @@ func gitChangedFiles(repo string, base string, head string) ([]string, error) {
 		}
 	}
 	return files, nil
+}
+
+func defaultGitBaseRef(repo string) (string, error) {
+	if base := strings.TrimSpace(os.Getenv("VOUCH_BASE_REF")); base != "" {
+		return base, nil
+	}
+	if base := strings.TrimSpace(os.Getenv("GITHUB_BASE_REF")); base != "" {
+		return base, nil
+	}
+	if base, ok := gitOutput(repo, "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"); ok {
+		return base, nil
+	}
+	if base, ok := gitOutput(repo, "symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"); ok {
+		return base, nil
+	}
+	return "", errors.New("cannot auto-detect git base ref; pass --base or --changed-file explicitly")
+}
+
+func gitOutput(repo string, args ...string) (string, bool) {
+	gitArgs := append([]string{"-C", repo}, args...)
+	out, err := exec.Command("git", gitArgs...).Output()
+	if err != nil {
+		return "", false
+	}
+	value := strings.TrimSpace(string(out))
+	if value == "" {
+		return "", false
+	}
+	return value, true
 }
 
 func normalizeChangedFiles(files []string) []string {

--- a/internal/vouch/onboarding_test.go
+++ b/internal/vouch/onboarding_test.go
@@ -3,6 +3,7 @@ package vouch
 import (
 	"bytes"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -159,6 +160,38 @@ func TestManifestCreateAllowsUnownedFilesForCompilerTraceabilityBlock(t *testing
 	}
 }
 
+func TestManifestCreateUsesConfiguredBaseRef(t *testing.T) {
+	repo := initializedRepo(t)
+	createSampleContract(t, repo, RiskMedium)
+	writeText(t, filepath.Join(repo, "src", "app", "service.py"), "def service():\n    return 'old'\n")
+	runGit(t, repo, "init")
+	runGit(t, repo, "checkout", "-b", "trunk")
+	runGit(t, repo, "add", ".")
+	runGit(t, repo, "-c", "user.email=vouch@example.invalid", "-c", "user.name=Vouch Test", "commit", "-m", "initial")
+	runGit(t, repo, "checkout", "-b", "feature")
+	writeText(t, filepath.Join(repo, "src", "app", "service.py"), "def service():\n    return 'new'\n")
+	runGit(t, repo, "add", "src/app/service.py")
+	runGit(t, repo, "-c", "user.email=vouch@example.invalid", "-c", "user.name=Vouch Test", "commit", "-m", "change service")
+	t.Setenv("VOUCH_BASE_REF", "trunk")
+
+	manifest, err := CreateManifest(repo, ManifestCreateOptions{
+		TaskID:  "agent-1",
+		Summary: "change app service",
+		Agent:   "codex",
+		RunID:   "run-1",
+		Out:     ".vouch/manifests/agent-1.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(manifest.Change.ChangedFiles, "src/app/service.py") {
+		t.Fatalf("expected changed file from trunk...HEAD, got %#v", manifest.Change.ChangedFiles)
+	}
+	if got := strings.Join(manifest.Change.SpecsTouched, ","); got != "app.service" {
+		t.Fatalf("expected app.service from auto-detected base ref, got %s", got)
+	}
+}
+
 func TestAttachArtifactInfersCoveredObligations(t *testing.T) {
 	repo := initializedRepo(t)
 	spec := createSampleContract(t, repo, RiskMedium)
@@ -193,6 +226,9 @@ func TestAttachArtifactInfersCoveredObligations(t *testing.T) {
 	}
 	if !contains(artifact.Obligations, behaviorID) {
 		t.Fatalf("expected inferred obligation %s, got %#v", behaviorID, artifact.Obligations)
+	}
+	if artifact.SHA256 != sha256Hex([]byte(`{"status":"pass","obligations":["`+behaviorID+`"]}`)) {
+		t.Fatalf("expected artifact sha256 to be recorded, got %q", artifact.SHA256)
 	}
 	if len(updated.Verification.Artifacts) != 1 {
 		t.Fatalf("expected one artifact, got %#v", updated.Verification.Artifacts)
@@ -348,6 +384,16 @@ func writeText(t *testing.T, path string, value string) {
 	}
 	if err := os.WriteFile(path, []byte(value), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func runGit(t *testing.T, repo string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = repo
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(output))
 	}
 }
 

--- a/skills.md
+++ b/skills.md
@@ -1,0 +1,145 @@
+# Vouch Operating Brief
+
+Use this before choosing roadmap work, designing features, writing docs, or
+describing Vouch.
+
+## Identity
+
+Vouch is a compiler for release contracts.
+
+Its job is to turn human-owned release intent into typed obligations, link those
+obligations to evidence artifacts, and produce an auditable release decision:
+
+```text
+human-owned intent
+  -> typed AST and diagnostics
+  -> spec JSON
+  -> obligation IR
+  -> verification plan and runner artifacts
+  -> evidence and policy input
+  -> block | human_escalation | canary | auto_merge
+```
+
+The release gate is a runtime target for the compiler output. It is not the
+whole product.
+
+## Boundary
+
+Vouch is not an AI code reviewer.
+
+Do not position Vouch as a tool that reads a diff and decides whether the
+implementation is good. It should not compete with AI pull-request review tools
+by producing generic review comments, style suggestions, or line-by-line bug
+claims.
+
+Vouch should answer a different question:
+
+```text
+For the contracts this change touched, which compiled obligations are required,
+which evidence artifacts satisfy them, and what release posture follows?
+```
+
+## Good Work
+
+Prefer work that strengthens at least one of these surfaces:
+
+- Contract language and source diagnostics.
+- Typed AST, semantic analysis, and stable compiler stages.
+- Obligation IR and stable semantic obligation IDs.
+- Spec-to-file traceability for routing changed files to contracts.
+- Evidence artifact import, validation, linking, and coverage.
+- Policy input, policy simulation, policy semantics, and fired-rule reporting.
+- Auditable gate results for CI and pull-request workflows.
+- Evidence provenance, runner identity, signatures, and tamper evidence.
+- Shadow-mode pilot workflows that prove Vouch catches release-readiness gaps.
+
+The best next work makes existing CI artifacts more meaningful to Vouch:
+
+- SARIF or Semgrep import for `security_check` evidence.
+- Coverage import for `test_coverage` or behavior-adjacent evidence.
+- Deployment, metric, alert, and rollback evidence importers.
+- GitHub summary/check output that explains obligations, evidence, and policy.
+- Case studies where tests pass but release obligations remain uncovered.
+
+## Wrong Turns
+
+Avoid work whose main value is generic code review:
+
+- Inline comments about arbitrary diff quality.
+- General bug-finding agents that are not tied to compiled obligations.
+- Style, lint, readability, naming, or refactor suggestions as product output.
+- "Approve this PR" or "this code is correct" claims.
+- Chat-based code review workflows without artifact-backed evidence.
+- AI verifier layers that are not bound to runner identity, evidence artifacts,
+  and release policy.
+
+Avoid work that turns Vouch into only a CI wrapper:
+
+- Running test commands without improving obligation coverage.
+- Duplicating existing scanner dashboards without mapping results to obligations.
+- Blocking on tool output without explaining the touched contract and evidence
+  requirement.
+
+## Positioning
+
+Use these phrases:
+
+- "compiler for release contracts"
+- "release-contract compiler and evidence gate"
+- "the layer between CI passed and ship it"
+- "obligation-oriented control plane"
+- "auditable release decision for agent-written code"
+
+Avoid these phrases as primary positioning:
+
+- "AI code reviewer"
+- "automated PR reviewer"
+- "bug finder"
+- "lint bot"
+- "CI wrapper"
+- "general coding agent"
+
+## Decision Test
+
+Before implementing a feature, answer these questions:
+
+1. Which human-owned contract or typed source artifact does this strengthen?
+2. Which compiled obligation, evidence kind, or policy fact does this improve?
+3. Does the output remain deterministic and auditable?
+4. Can the result be represented in compiler artifacts, evidence manifests, or
+   gate results?
+5. Would this still matter if all generic AI code reviewers already existed?
+6. Are we inspecting implementation correctness, or are we linking evidence to
+   declared obligations?
+
+If the answer to question 6 is "inspecting implementation correctness," stop and
+redesign the work around contracts, obligations, evidence, or policy.
+
+## Near-Term Work
+
+The current product direction is:
+
+1. Ship a strong shadow-mode pull-request pilot path.
+2. Add evidence connector importers, starting with SARIF/Semgrep and coverage.
+3. Produce realistic case studies where tests pass but Vouch blocks or routes
+   the change because release evidence is missing, invalid, or out of scope.
+4. Continue trust hardening where it supports real evidence workflows: required
+   high-risk hashes, commit/runner provenance, scoped signers, and signed specs
+   or manifests.
+
+Do not lead with AI review features. AI verifiers can come later only as
+evidence verifiers that are tied to obligations, artifacts, provenance, and
+policy.
+
+## Integration Posture
+
+Vouch should compose with existing tools instead of replacing them:
+
+- Sigstore/cosign proves evidence signer identity.
+- SLSA and in-toto-style metadata describe provenance and authorized steps.
+- OPA/Rego can evaluate policy over structured inputs.
+- SARIF, Semgrep, coverage, test reports, deployment plans, metrics, and
+  rollback plans are evidence inputs.
+
+Vouch supplies the missing semantic layer: contract language, obligation IR,
+evidence mapping, and release result.


### PR DESCRIPTION
## Summary

  - Harden manifest/evidence workflow by removing a hardcoded `main` base ref and recording attached artifact hashes.

## What Changed

  - If no base can be detected, Vouch asks for `--base` or `--changed-file`.
  - `manifest attach-artifact` now records `sha256` automatically when one is not supplied.

  ## Validation

  - `go test ./...`