### PR TITLE
docs: package shadow-mode pr workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,9 @@ vouch evidence import junit .vouch/artifacts/pytest.xml
 vouch gate
 ```
 
-JUnit covers required-test obligations only. Behavior, security, runtime, and
-rollback obligations need their own evidence.
+JUnit covers required-test obligations only. `security_check` artifacts can use
+SARIF 2.1.0 when scanner rules or results reference exact obligation IDs.
+Behavior, runtime, and rollback obligations need their own evidence.
 
 ## Install
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -60,6 +60,7 @@ Implemented today:
 - Manifest creation from changed files and owned paths.
 - Artifact attachment with obligation inference.
 - JUnit test-map adapter for raw pytest-style JUnit evidence.
+- SARIF 2.1.0 import for `security_check` evidence with exact obligation-ID mapping.
 - Machine-readable gate result artifact output for status checks.
 - Release policy files loaded from `.vouch/policy/release-policy.json`.
 - Policy simulation command with structured policy input/output.
@@ -200,7 +201,6 @@ Planned work:
 - Typed API/signature obligation suggestions.
 - Coverage report import.
 - Static analysis import.
-- SARIF import.
 - Secret scanning import.
 - Logging and PII scanner import.
 - Migration and external-effect detectors.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,6 +66,8 @@ Implemented today:
 - Policy simulation command with structured policy input/output.
 - Structured verifier output artifacts imported into findings and policy input.
 - Release decisions: `block`, `human_escalation`, `canary`, `auto_merge`.
+- Manifest-backed shadow-mode GitHub Actions reference workflow with gate summary
+  and artifact upload conventions.
 - Demo repo with blocked and passing manifests.
 - Unit tests for the current pipeline.
 
@@ -96,11 +98,11 @@ roadmap by themselves.
 
 Near-term execution order:
 
-1. Shadow-mode pull-request pilot package.
+1. Run the shadow-mode pull-request pilot package against real repositories.
 2. Evidence connector wedge: SARIF/Semgrep import and coverage import.
 3. Reproducible case study where tests pass but Vouch blocks or routes because
    release obligations are missing, invalid, or out of scope.
-4. Artifact upload conventions and auditable gate output for PR workflows.
+4. GitHub Checks/status integration over the auditable gate result.
 5. Trust hardening that supports evidence workflows: required high-risk hashes,
    commit/runner provenance, scoped signers, and signed specs or manifests.
 6. JSON schemas and compatibility tests for public artifacts.
@@ -248,7 +250,7 @@ The next useful contributions are:
 
 - Static-analysis/SARIF importer for security and quality evidence.
 - Coverage XML importer for required-test and behavior evidence.
-- Shadow-mode GitHub PR workflow with artifact upload conventions.
+- Shadow-mode GitHub PR pilot results from real repositories.
 - Real-world case study showing a plausible bad agent change blocked by an obligation.
 - Reference workflow for `try -> write -> manifest -> attach evidence -> gate`.
 - Test-map discovery to reduce manual required-test mapping.

--- a/docs/COMPILER.md
+++ b/docs/COMPILER.md
@@ -165,6 +165,11 @@ vouch --repo DIR gate
 JUnit covers `required_test` obligations only. Missing behavior, security,
 runtime, or rollback evidence can still block.
 
+`security_check` artifacts can also be SARIF 2.1.0 logs. Vouch treats SARIF as
+scanner evidence only when rules or result properties reference exact compiled
+obligation IDs. High or critical mapped SARIF results become blocking findings;
+unmapped scanner output is not treated as contract evidence.
+
 ## What Is Proven
 
 The repo-local benchmark is VouchBench:

--- a/docs/GITHUB_ACTIONS.md
+++ b/docs/GITHUB_ACTIONS.md
@@ -65,8 +65,10 @@ The relevant code paths are:
 
 ### Shadow Mode
 
-Use this first. It shows Vouch's decision in the job summary but does not block
-the pull request.
+Use this first. It creates a manifest for the pull request diff, attaches
+evidence artifacts, writes the gate result to the job summary, and uploads the
+manifest/build/evidence bundle for audit. The job is advisory because
+`continue-on-error: true` is set at the job level.
 
 ```yaml
 name: Vouch
@@ -74,11 +76,22 @@ name: Vouch
 on:
   pull_request:
 
+permissions:
+  contents: read
+
+env:
+  VOUCH_MANIFEST: .vouch/manifests/pr-${{ github.event.pull_request.number }}-${{ github.run_attempt }}.json
+  VOUCH_GATE_RESULT: .vouch/build/gate-result.json
+  VOUCH_JUNIT: .vouch/artifacts/pytest.xml
+
 jobs:
   vouch:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -90,37 +103,82 @@ jobs:
       - name: Compile Vouch contracts
         run: vouch compile
 
-      - name: Run tests
-        run: pytest --junitxml .vouch/artifacts/pytest.xml
+      - name: Create PR manifest
+        env:
+          VOUCH_TASK_ID: pr-${{ github.event.pull_request.number }}
+          VOUCH_TASK_SUMMARY: ${{ github.event.pull_request.title }}
+          VOUCH_RUN_ID: ${{ github.run_id }}.${{ github.run_attempt }}
+          VOUCH_RUNNER_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/vouch.yml@${{ github.ref }}
+        run: |
+          vouch manifest create \
+            --task-id "$VOUCH_TASK_ID" \
+            --summary "$VOUCH_TASK_SUMMARY" \
+            --agent github-actions \
+            --run-id "$VOUCH_RUN_ID" \
+            --runner-identity "$VOUCH_RUNNER_IDENTITY" \
+            --runner-oidc-issuer https://token.actions.githubusercontent.com \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --out "$VOUCH_MANIFEST"
 
-      - name: Import JUnit evidence
-        run: vouch evidence import junit .vouch/artifacts/pytest.xml
+      - name: Run tests for evidence
+        id: tests
+        run: |
+          mkdir -p .vouch/artifacts
+          set +e
+          pytest --junitxml "$VOUCH_JUNIT"
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Attach JUnit evidence
+        if: steps.tests.outputs.exit_code == '0'
+        run: |
+          vouch manifest attach-artifact \
+            --manifest "$VOUCH_MANIFEST" \
+            --id pytest \
+            --kind test_coverage \
+            --path "$VOUCH_JUNIT" \
+            --producer github-actions \
+            --command "pytest --junitxml $VOUCH_JUNIT" \
+            --exit-code "${{ steps.tests.outputs.exit_code }}" \
+            --out "$VOUCH_MANIFEST"
 
       - name: Gate PR
-        continue-on-error: true
-        run: vouch gate --github-summary --out .vouch/build/gate-result.json
+        run: vouch --manifest "$VOUCH_MANIFEST" gate --github-summary --out "$VOUCH_GATE_RESULT"
 
-      - name: Upload Vouch result
+      - name: Upload Vouch artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vouch-gate-result
-          path: .vouch/build/gate-result.json
+          name: vouch-shadow-pr-${{ github.event.pull_request.number }}
+          path: |
+            .vouch/manifests/
+            .vouch/build/
+            .vouch/artifacts/
+          if-no-files-found: ignore
 ```
 
 Use shadow mode until reviewers agree that Vouch is catching real
-release-readiness gaps and the false-block rate is acceptable.
+release-readiness gaps and the false-block rate is acceptable. Keep normal CI
+test jobs in place during this phase; this job is measuring the release
+contract workflow.
 
 ### Enforced Mode
 
-After a shadow-mode pilot, remove `continue-on-error: true` from the gate step:
+After a shadow-mode pilot, remove job-level `continue-on-error: true`:
 
 ```yaml
-      - name: Gate PR
-        run: vouch gate --github-summary --out .vouch/build/gate-result.json
+jobs:
+  vouch:
+    runs-on: ubuntu-latest
 ```
 
 `vouch gate` exits non-zero only when the release decision is `block`.
 `human_escalation`, `canary`, and `auto_merge` are non-blocking process exits.
+If the test evidence step records a non-zero exit, the workflow does not attach
+the JUnit artifact, so the gate reports missing required-test evidence instead
+of treating failed tests as passing evidence.
 
 ### What The Summary Shows
 
@@ -132,10 +190,23 @@ The report includes:
 - obligation coverage
 - policy path
 - reasons
+- invalid evidence artifacts
 - component-level covered and missing obligations
 - verifier findings and required fixes
 
 The renderer is [`RenderGitHubSummary`](../internal/vouch/render.go).
+
+### Artifact Convention
+
+Upload the whole Vouch bundle for each shadow run:
+
+- `.vouch/manifests/`: PR manifest and attached artifact references.
+- `.vouch/build/`: compiler outputs and `gate-result.json`.
+- `.vouch/artifacts/`: raw evidence such as JUnit XML or SARIF.
+
+The compact gate result should be written to `.vouch/build/gate-result.json`.
+That file uses `vouch.gate_result.v0` and is the stable input for future status
+checks or GitHub Checks integrations.
 
 ### Contracts In CI
 

--- a/docs/github-action-example.yml
+++ b/docs/github-action-example.yml
@@ -3,11 +3,22 @@ name: Vouch
 on:
   pull_request:
 
+permissions:
+  contents: read
+
+env:
+  VOUCH_MANIFEST: .vouch/manifests/pr-${{ github.event.pull_request.number }}-${{ github.run_attempt }}.json
+  VOUCH_GATE_RESULT: .vouch/build/gate-result.json
+  VOUCH_JUNIT: .vouch/artifacts/pytest.xml
+
 jobs:
   vouch:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -19,18 +30,57 @@ jobs:
       - name: Compile Vouch obligations
         run: vouch compile
 
-      - name: Run tests
-        run: pytest --junitxml .vouch/artifacts/pytest.xml
+      - name: Create PR manifest
+        env:
+          VOUCH_TASK_ID: pr-${{ github.event.pull_request.number }}
+          VOUCH_TASK_SUMMARY: ${{ github.event.pull_request.title }}
+          VOUCH_RUN_ID: ${{ github.run_id }}.${{ github.run_attempt }}
+          VOUCH_RUNNER_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/vouch.yml@${{ github.ref }}
+        run: |
+          vouch manifest create \
+            --task-id "$VOUCH_TASK_ID" \
+            --summary "$VOUCH_TASK_SUMMARY" \
+            --agent github-actions \
+            --run-id "$VOUCH_RUN_ID" \
+            --runner-identity "$VOUCH_RUNNER_IDENTITY" \
+            --runner-oidc-issuer https://token.actions.githubusercontent.com \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --out "$VOUCH_MANIFEST"
 
-      - name: Import JUnit evidence
-        run: vouch evidence import junit .vouch/artifacts/pytest.xml
+      - name: Run tests for evidence
+        id: tests
+        run: |
+          mkdir -p .vouch/artifacts
+          set +e
+          pytest --junitxml "$VOUCH_JUNIT"
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Attach JUnit evidence
+        if: steps.tests.outputs.exit_code == '0'
+        run: |
+          vouch manifest attach-artifact \
+            --manifest "$VOUCH_MANIFEST" \
+            --id pytest \
+            --kind test_coverage \
+            --path "$VOUCH_JUNIT" \
+            --producer github-actions \
+            --command "pytest --junitxml $VOUCH_JUNIT" \
+            --exit-code "${{ steps.tests.outputs.exit_code }}" \
+            --out "$VOUCH_MANIFEST"
 
       - name: Gate PR
-        continue-on-error: true
-        run: vouch gate --github-summary --out .vouch/build/gate-result.json
+        run: vouch --manifest "$VOUCH_MANIFEST" gate --github-summary --out "$VOUCH_GATE_RESULT"
 
-      - name: Upload Vouch result
+      - name: Upload Vouch artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vouch-gate-result
-          path: .vouch/build/gate-result.json
+          name: vouch-shadow-pr-${{ github.event.pull_request.number }}
+          path: |
+            .vouch/manifests/
+            .vouch/build/
+            .vouch/artifacts/
+          if-no-files-found: ignore

--- a/docs/site/compiler.md
+++ b/docs/site/compiler.md
@@ -110,3 +110,11 @@ The current decisions are:
 - `auto_merge`
 
 `gate` exits non-zero only when the final decision is `block`.
+
+## Evidence Model
+
+Manifest-backed `security_check` artifacts can be generic exact-ID JSON or
+SARIF 2.1.0 scanner logs. SARIF rules and result properties must reference exact
+compiled obligation IDs. High or critical mapped SARIF results enter the normal
+blocking finding and policy path; unmapped scanner output does not satisfy a
+contract obligation.

--- a/docs/site/github-actions.md
+++ b/docs/site/github-actions.md
@@ -47,8 +47,9 @@ Official references:
 
 ## Vouch PR Workflow
 
-The current Vouch PR workflow should start in shadow mode. It appends a job
-summary and uploads `.vouch/build/gate-result.json` without blocking the PR.
+The current Vouch PR workflow should start in shadow mode. It creates a PR
+manifest from the diff, attaches evidence artifacts, appends a job summary, and
+uploads the manifest/build/evidence bundle without blocking the PR.
 
 ```yaml
 name: Vouch
@@ -56,11 +57,22 @@ name: Vouch
 on:
   pull_request:
 
+permissions:
+  contents: read
+
+env:
+  VOUCH_MANIFEST: .vouch/manifests/pr-${{ github.event.pull_request.number }}-${{ github.run_attempt }}.json
+  VOUCH_GATE_RESULT: .vouch/build/gate-result.json
+  VOUCH_JUNIT: .vouch/artifacts/pytest.xml
+
 jobs:
   vouch:
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v5
         with:
@@ -72,22 +84,71 @@ jobs:
       - name: Compile Vouch contracts
         run: vouch compile
 
-      - name: Run tests
-        run: pytest --junitxml .vouch/artifacts/pytest.xml
+      - name: Create PR manifest
+        env:
+          VOUCH_TASK_ID: pr-${{ github.event.pull_request.number }}
+          VOUCH_TASK_SUMMARY: ${{ github.event.pull_request.title }}
+          VOUCH_RUN_ID: ${{ github.run_id }}.${{ github.run_attempt }}
+          VOUCH_RUNNER_IDENTITY: https://github.com/${{ github.repository }}/.github/workflows/vouch.yml@${{ github.ref }}
+        run: |
+          vouch manifest create \
+            --task-id "$VOUCH_TASK_ID" \
+            --summary "$VOUCH_TASK_SUMMARY" \
+            --agent github-actions \
+            --run-id "$VOUCH_RUN_ID" \
+            --runner-identity "$VOUCH_RUNNER_IDENTITY" \
+            --runner-oidc-issuer https://token.actions.githubusercontent.com \
+            --base "origin/${{ github.base_ref }}" \
+            --head HEAD \
+            --out "$VOUCH_MANIFEST"
 
-      - name: Import JUnit evidence
-        run: vouch evidence import junit .vouch/artifacts/pytest.xml
+      - name: Run tests for evidence
+        id: tests
+        run: |
+          mkdir -p .vouch/artifacts
+          set +e
+          pytest --junitxml "$VOUCH_JUNIT"
+          exit_code=$?
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Attach JUnit evidence
+        if: steps.tests.outputs.exit_code == '0'
+        run: |
+          vouch manifest attach-artifact \
+            --manifest "$VOUCH_MANIFEST" \
+            --id pytest \
+            --kind test_coverage \
+            --path "$VOUCH_JUNIT" \
+            --producer github-actions \
+            --command "pytest --junitxml $VOUCH_JUNIT" \
+            --exit-code "${{ steps.tests.outputs.exit_code }}" \
+            --out "$VOUCH_MANIFEST"
 
       - name: Gate PR
-        continue-on-error: true
-        run: vouch gate --github-summary --out .vouch/build/gate-result.json
+        run: vouch --manifest "$VOUCH_MANIFEST" gate --github-summary --out "$VOUCH_GATE_RESULT"
 
-      - name: Upload Vouch result
+      - name: Upload Vouch artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: vouch-gate-result
-          path: .vouch/build/gate-result.json
+          name: vouch-shadow-pr-${{ github.event.pull_request.number }}
+          path: |
+            .vouch/manifests/
+            .vouch/build/
+            .vouch/artifacts/
+          if-no-files-found: ignore
 ```
+
+Keep normal CI test jobs in place during shadow mode. This workflow measures
+release-contract coverage; it should not be the only test enforcement path until
+the team switches to enforced mode.
+
+Upload these paths for every shadow run:
+
+- `.vouch/manifests/`: PR manifest and attached artifact references.
+- `.vouch/build/`: compiler outputs and `gate-result.json`.
+- `.vouch/artifacts/`: raw evidence such as JUnit XML or SARIF.
 
 ## Code References
 
@@ -104,5 +165,8 @@ jobs:
 
 ## Enforced Mode
 
-After a shadow-mode pilot, remove `continue-on-error: true` from the gate step.
-The CLI exits non-zero only when the final decision is `block`.
+After a shadow-mode pilot, remove job-level `continue-on-error: true`. The CLI
+exits non-zero only when the final decision is `block`. If the test evidence
+step records a non-zero exit, the workflow does not attach the JUnit artifact,
+so the gate reports missing required-test evidence instead of treating failed
+tests as passing evidence.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -42,8 +42,9 @@ vouch evidence import junit .vouch/artifacts/pytest.xml
 vouch gate
 ```
 
-JUnit covers required-test obligations only. Behavior, security, runtime, and
-rollback obligations need their own evidence.
+JUnit covers required-test obligations only. `security_check` artifacts can use
+SARIF 2.1.0 when scanner rules or results reference exact obligation IDs.
+Behavior, runtime, and rollback obligations need their own evidence.
 
 ## Status
 

--- a/internal/vouch/evidence.go
+++ b/internal/vouch/evidence.go
@@ -162,10 +162,9 @@ func artifactCoverageByKind(artifacts []ArtifactResult) map[EvidenceKind]map[str
 
 func importVerifierFindings(evidence *Evidence) {
 	for _, result := range evidence.ArtifactResults {
-		if result.VerifierOutput == nil {
-			continue
+		if result.VerifierOutput != nil {
+			evidence.VerifierOutputs = append(evidence.VerifierOutputs, *result.VerifierOutput)
 		}
-		evidence.VerifierOutputs = append(evidence.VerifierOutputs, *result.VerifierOutput)
 		evidence.Findings = append(evidence.Findings, result.VerifierFindings...)
 	}
 }

--- a/internal/vouch/evidence_artifacts.go
+++ b/internal/vouch/evidence_artifacts.go
@@ -113,6 +113,13 @@ func LinkEvidenceArtifacts(repo string, manifest Manifest, artifacts []EvidenceA
 					result.addIssue("junit_import", issue)
 				}
 			}
+		} else if artifact.Kind == EvidenceSecurityCheck && len(data) > 0 && sarifLooksLike(data) {
+			covered, findings, issues := importSARIFEvidence(data, artifact.Obligations, index)
+			result.CoveredObligations = covered
+			result.VerifierFindings = findings
+			for _, issue := range issues {
+				result.addIssue("sarif_import", issue)
+			}
 		} else if len(data) > 0 {
 			covered, issues := importGenericEvidence(data, artifact.Obligations)
 			result.CoveredObligations = covered

--- a/internal/vouch/evidence_test.go
+++ b/internal/vouch/evidence_test.go
@@ -1026,6 +1026,86 @@ func TestGenericArtifactRequiresExactObligationTokens(t *testing.T) {
 	}
 }
 
+func TestSARIFSecurityEvidenceCoversReferencedObligation(t *testing.T) {
+	repo, manifestPath, ids := writeFullyCoveredUIScenario(t, nil)
+	securityID := ids[ObligationSecurity]
+	manifest := mustLoadManifest(t, manifestPath)
+	setArtifactPath(t, &manifest, "security", "artifacts/security.sarif")
+	writeJSON(t, manifestPath, manifest)
+	writeSARIFArtifact(t, repo, "artifacts/security.sarif", sarifSecurityLog(securityID, nil))
+
+	evidence, err := CollectEvidence(repo, manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "auto_merge" {
+		t.Fatalf("expected SARIF security evidence to pass, got %s: findings=%#v invalid=%#v", evidence.Decision, evidence.Findings, evidence.InvalidEvidence)
+	}
+	if !artifactCovered(evidence, "security", securityID) {
+		t.Fatalf("expected SARIF artifact to cover security obligation: %#v", evidence.ArtifactResults)
+	}
+	if hasInvalidEvidence(evidence, "security", "sarif_import") {
+		t.Fatalf("expected SARIF artifact to import cleanly: %#v", evidence.InvalidEvidence)
+	}
+}
+
+func TestSARIFHighSecurityFindingBlocks(t *testing.T) {
+	repo, manifestPath, ids := writeFullyCoveredUIScenario(t, nil)
+	securityID := ids[ObligationSecurity]
+	manifest := mustLoadManifest(t, manifestPath)
+	setArtifactPath(t, &manifest, "security", "artifacts/security.sarif")
+	writeJSON(t, manifestPath, manifest)
+	writeSARIFArtifact(t, repo, "artifacts/security.sarif", sarifSecurityLog(
+		"rules.no-hardcoded-secret",
+		map[string]any{
+			"severity":          "warning",
+			"tags":              []string{securityID},
+			"security-severity": "8.2",
+		},
+		sarifFindingResult("rules.no-hardcoded-secret", "warning", "hardcoded secret in changed file"),
+	))
+
+	evidence, err := CollectEvidence(repo, manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if evidence.Decision != "block" {
+		t.Fatalf("expected high SARIF finding to block, got %s", evidence.Decision)
+	}
+	if artifactCovered(evidence, "security", securityID) {
+		t.Fatalf("expected blocked SARIF obligation to remain uncovered: %#v", evidence.ArtifactResults)
+	}
+	if !hasFinding(evidence, "sarif", "semgrep reported high-severity finding rules.no-hardcoded-secret") {
+		t.Fatalf("expected imported SARIF finding: %#v", evidence.Findings)
+	}
+	if !contains(evidence.PolicyResult.RulesFired, "block_verifier_findings") {
+		t.Fatalf("expected policy to block on SARIF finding: %#v", evidence.PolicyResult)
+	}
+}
+
+func TestSARIFRequiresExactObligationIDs(t *testing.T) {
+	data, err := json.Marshal(sarifSecurityLog("rules.near-match", map[string]any{
+		"tags": []string{"obligation.one_extra"},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	covered, findings, issues := importSARIFEvidence(data, []string{"obligation.one"}, ObligationIndex{
+		ByID: map[string]Obligation{
+			"obligation.one": {ID: "obligation.one"},
+		},
+	})
+	if len(covered) != 0 {
+		t.Fatalf("expected near-match SARIF reference not to cover, got %#v", covered)
+	}
+	if len(findings) != 0 {
+		t.Fatalf("expected no finding for unmapped SARIF result, got %#v", findings)
+	}
+	if !containsSubstring(issues, "SARIF does not reference obligation obligation.one") {
+		t.Fatalf("expected exact-ID issue, got %#v", issues)
+	}
+}
+
 func TestJUnitErrorsAndSkipsInvalidateArtifact(t *testing.T) {
 	covered, failed, issues := importJUnitEvidence([]byte(`<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="suite" tests="3" failures="0" errors="1" skipped="1">
@@ -2289,6 +2369,44 @@ func writeVerifierOutputArtifact(t *testing.T, repo string, relPath string, outp
 		t.Fatal(err)
 	}
 	writeArtifact(t, repo, relPath, string(append(data, '\n')))
+}
+
+func writeSARIFArtifact(t *testing.T, repo string, relPath string, log map[string]any) {
+	t.Helper()
+	data, err := json.MarshalIndent(log, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeArtifact(t, repo, relPath, string(append(data, '\n')))
+}
+
+func sarifSecurityLog(ruleID string, properties map[string]any, results ...map[string]any) map[string]any {
+	rule := map[string]any{"id": ruleID}
+	if len(properties) > 0 {
+		rule["properties"] = properties
+	}
+	return map[string]any{
+		"version": sarifVersion,
+		"runs": []any{map[string]any{
+			"tool": map[string]any{
+				"driver": map[string]any{
+					"name":  "semgrep",
+					"rules": []any{rule},
+				},
+			},
+			"results": results,
+		}},
+	}
+}
+
+func sarifFindingResult(ruleID string, level string, message string) map[string]any {
+	return map[string]any{
+		"ruleId": ruleID,
+		"level":  level,
+		"message": map[string]any{
+			"text": message,
+		},
+	}
 }
 
 func writeEvidenceBundle(t *testing.T, repo string, relPath string, manifest Manifest, artifact EvidenceArtifact, mutate func(EvidenceArtifact, *EvidenceBundle)) {

--- a/internal/vouch/onboarding.go
+++ b/internal/vouch/onboarding.go
@@ -1012,6 +1012,9 @@ func importArtifactCoverage(data []byte, kind EvidenceKind, candidateObligations
 		covered, _, issues := importJUnitEvidence(data, candidateObligations)
 		return covered, issues
 	}
+	if kind == EvidenceSecurityCheck && sarifLooksLike(data) {
+		return importSARIFReferences(data, candidateObligations)
+	}
 	return importGenericEvidence(data, candidateObligations)
 }
 

--- a/internal/vouch/onboarding_test.go
+++ b/internal/vouch/onboarding_test.go
@@ -235,6 +235,40 @@ func TestAttachArtifactInfersCoveredObligations(t *testing.T) {
 	}
 }
 
+func TestAttachArtifactInfersSARIFSecurityObligations(t *testing.T) {
+	repo := initializedRepo(t)
+	spec := createSampleContract(t, repo, RiskMedium)
+	_, err := CreateManifest(repo, ManifestCreateOptions{
+		TaskID:       "agent-1",
+		Summary:      "change app service",
+		Agent:        "codex",
+		RunID:        "run-1",
+		ChangedFiles: []string{"src/app/service.py"},
+		Out:          ".vouch/manifests/agent-1.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	securityID := obligationID(t, spec, ObligationSecurity, "project paths stay inside repo")
+	writeSARIFArtifact(t, repo, ".vouch/artifacts/security.sarif", sarifSecurityLog(securityID, nil))
+
+	_, artifact, err := AttachArtifact(repo, AttachArtifactOptions{
+		ManifestPath: ".vouch/manifests/agent-1.json",
+		ID:           "security",
+		Kind:         EvidenceSecurityCheck,
+		Path:         ".vouch/artifacts/security.sarif",
+		Command:      "semgrep scan --sarif",
+		ExitCode:     0,
+		Out:          ".vouch/manifests/agent-1.with-security.json",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !contains(artifact.Obligations, securityID) {
+		t.Fatalf("expected inferred SARIF obligation %s, got %#v", securityID, artifact.Obligations)
+	}
+}
+
 func TestAttachArtifactRejectsNonZeroExitAndPathEscape(t *testing.T) {
 	repo := initializedRepo(t)
 	createSampleContract(t, repo, RiskMedium)

--- a/internal/vouch/sarif.go
+++ b/internal/vouch/sarif.go
@@ -1,0 +1,357 @@
+package vouch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+)
+
+const sarifVersion = "2.1.0"
+
+type sarifLog struct {
+	Version string     `json:"version"`
+	Runs    []sarifRun `json:"runs"`
+}
+
+type sarifRun struct {
+	Tool    sarifTool     `json:"tool"`
+	Results []sarifResult `json:"results"`
+}
+
+type sarifTool struct {
+	Driver sarifDriver `json:"driver"`
+}
+
+type sarifDriver struct {
+	Name  string      `json:"name"`
+	Rules []sarifRule `json:"rules"`
+}
+
+type sarifRule struct {
+	ID                   string          `json:"id"`
+	Name                 string          `json:"name"`
+	ShortDescription     sarifMessage    `json:"shortDescription"`
+	FullDescription      sarifMessage    `json:"fullDescription"`
+	DefaultConfiguration sarifDefault    `json:"defaultConfiguration"`
+	Properties           sarifProperties `json:"properties"`
+}
+
+type sarifDefault struct {
+	Level string `json:"level"`
+}
+
+type sarifResult struct {
+	RuleID     string          `json:"ruleId"`
+	Level      string          `json:"level"`
+	Message    sarifMessage    `json:"message"`
+	Properties sarifProperties `json:"properties"`
+}
+
+type sarifMessage struct {
+	Text string `json:"text"`
+}
+
+type sarifProperties map[string]any
+
+func sarifLooksLike(data []byte) bool {
+	var header struct {
+		Version string `json:"version"`
+		Runs    []any  `json:"runs"`
+	}
+	if err := json.Unmarshal(data, &header); err != nil {
+		return false
+	}
+	return header.Version != "" && header.Runs != nil
+}
+
+func importSARIFReferences(data []byte, obligationIDs []string) ([]string, []string) {
+	log, issues := parseSARIF(data)
+	if len(issues) > 0 {
+		return nil, issues
+	}
+	refs := sarifReferencedObligations(log, stringSet(obligationIDs))
+	var covered []string
+	for _, obligationID := range obligationIDs {
+		if refs[obligationID] {
+			covered = append(covered, obligationID)
+		}
+	}
+	if len(covered) == 0 {
+		issues = append(issues, "SARIF does not reference any expected obligation IDs")
+	}
+	return covered, issues
+}
+
+func importSARIFEvidence(data []byte, obligationIDs []string, index ObligationIndex) ([]string, []Finding, []string) {
+	log, issues := parseSARIF(data)
+	if len(issues) > 0 {
+		return nil, nil, issues
+	}
+
+	obligations := make(map[string]bool, len(obligationIDs))
+	for _, obligationID := range obligationIDs {
+		if _, ok := index.ByID[obligationID]; !ok {
+			issues = append(issues, fmt.Sprintf("unknown obligation %q", obligationID))
+			continue
+		}
+		obligations[obligationID] = true
+	}
+	refs := sarifReferencedObligations(log, obligations)
+	blocked := map[string]bool{}
+	var findings []Finding
+
+	for _, run := range log.Runs {
+		rules := sarifRulesByID(run)
+		ruleRefs := sarifRunRuleRefs(run, obligations)
+		tool := run.Tool.Driver.Name
+		if strings.TrimSpace(tool) == "" {
+			tool = "sarif"
+		}
+		for _, result := range run.Results {
+			resultRefs := sarifResultRefs(result, ruleRefs, obligations)
+			if len(resultRefs) == 0 {
+				continue
+			}
+			rule := rules[result.RuleID]
+			severity := sarifSeverity(result, rule)
+			if sarifSeverityRank(severity) < sarifSeverityRank("high") {
+				continue
+			}
+			for _, obligationID := range resultRefs {
+				blocked[obligationID] = true
+			}
+			findings = append(findings, Finding{
+				Verifier:    "sarif",
+				Severity:    severity,
+				Decision:    "block",
+				Claim:       sarifClaim(tool, result),
+				Evidence:    sarifEvidence(result, resultRefs),
+				RequiredFix: "fix the SARIF finding or attach passing security evidence",
+				Obligations: resultRefs,
+			})
+		}
+	}
+
+	var covered []string
+	for _, obligationID := range obligationIDs {
+		if !obligations[obligationID] {
+			continue
+		}
+		if !refs[obligationID] {
+			issues = append(issues, fmt.Sprintf("SARIF does not reference obligation %s", obligationID))
+			continue
+		}
+		if !blocked[obligationID] {
+			covered = append(covered, obligationID)
+		}
+	}
+	return covered, findings, issues
+}
+
+func parseSARIF(data []byte) (sarifLog, []string) {
+	var log sarifLog
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	if err := decoder.Decode(&log); err != nil {
+		return log, []string{fmt.Sprintf("cannot parse SARIF JSON: %v", err)}
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		return log, []string{"trailing JSON content after SARIF log"}
+	}
+	if log.Version != sarifVersion {
+		return log, []string{fmt.Sprintf("SARIF version must be %s", sarifVersion)}
+	}
+	if len(log.Runs) == 0 {
+		return log, []string{"SARIF log contains no runs"}
+	}
+	return log, nil
+}
+
+func sarifReferencedObligations(log sarifLog, obligations map[string]bool) map[string]bool {
+	refs := map[string]bool{}
+	for _, run := range log.Runs {
+		ruleRefs := sarifRunRuleRefs(run, obligations)
+		for _, ids := range ruleRefs {
+			for id := range ids {
+				refs[id] = true
+			}
+		}
+		for _, result := range run.Results {
+			for _, id := range sarifResultRefs(result, ruleRefs, obligations) {
+				refs[id] = true
+			}
+		}
+	}
+	return refs
+}
+
+func sarifRunRuleRefs(run sarifRun, obligations map[string]bool) map[string]map[string]bool {
+	refs := map[string]map[string]bool{}
+	for _, rule := range run.Tool.Driver.Rules {
+		ruleSet := sarifRuleRefs(rule, obligations)
+		if len(ruleSet) > 0 {
+			refs[rule.ID] = ruleSet
+		}
+	}
+	return refs
+}
+
+func sarifRulesByID(run sarifRun) map[string]sarifRule {
+	rules := make(map[string]sarifRule, len(run.Tool.Driver.Rules))
+	for _, rule := range run.Tool.Driver.Rules {
+		rules[rule.ID] = rule
+	}
+	return rules
+}
+
+func sarifRuleRefs(rule sarifRule, obligations map[string]bool) map[string]bool {
+	refs := map[string]bool{}
+	if obligations[rule.ID] {
+		refs[rule.ID] = true
+	}
+	addSARIFPropertyRefs(refs, rule.Properties, obligations)
+	return refs
+}
+
+func sarifResultRefs(result sarifResult, ruleRefs map[string]map[string]bool, obligations map[string]bool) []string {
+	refs := map[string]bool{}
+	if obligations[result.RuleID] {
+		refs[result.RuleID] = true
+	}
+	for id := range ruleRefs[result.RuleID] {
+		refs[id] = true
+	}
+	addSARIFPropertyRefs(refs, result.Properties, obligations)
+	return sortedStringKeys(refs)
+}
+
+func addSARIFPropertyRefs(refs map[string]bool, value any, obligations map[string]bool) {
+	switch typed := value.(type) {
+	case string:
+		if obligations[typed] {
+			refs[typed] = true
+		}
+	case []any:
+		for _, item := range typed {
+			addSARIFPropertyRefs(refs, item, obligations)
+		}
+	case map[string]any:
+		for _, item := range typed {
+			addSARIFPropertyRefs(refs, item, obligations)
+		}
+	case sarifProperties:
+		for _, item := range typed {
+			addSARIFPropertyRefs(refs, item, obligations)
+		}
+	}
+}
+
+func sarifSeverity(result sarifResult, rule sarifRule) string {
+	if severity := severityFromProperties(result.Properties); severity != "" {
+		return severity
+	}
+	if severity := severityFromProperties(rule.Properties); severity != "" {
+		return severity
+	}
+	level := strings.TrimSpace(result.Level)
+	if level == "" {
+		level = strings.TrimSpace(rule.DefaultConfiguration.Level)
+	}
+	switch level {
+	case "error":
+		return "high"
+	case "warning":
+		return "medium"
+	case "note", "none":
+		return "low"
+	default:
+		return "low"
+	}
+}
+
+func severityFromProperties(properties sarifProperties) string {
+	if severity := securitySeverity(properties["security-severity"]); severity != "" {
+		return severity
+	}
+	for _, key := range []string{"severity", "problem.severity"} {
+		if severity := normalizeSeverity(properties[key]); severity != "" {
+			return severity
+		}
+	}
+	return ""
+}
+
+func normalizeSeverity(value any) string {
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	switch strings.ToLower(strings.TrimSpace(text)) {
+	case "critical":
+		return "critical"
+	case "high", "error":
+		return "high"
+	case "medium", "warning":
+		return "medium"
+	case "low", "note", "none":
+		return "low"
+	default:
+		return ""
+	}
+}
+
+func securitySeverity(value any) string {
+	var score float64
+	switch typed := value.(type) {
+	case float64:
+		score = typed
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		if err != nil {
+			return ""
+		}
+		score = parsed
+	default:
+		return ""
+	}
+	switch {
+	case score >= 9:
+		return "critical"
+	case score >= 7:
+		return "high"
+	case score >= 4:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+func sarifClaim(tool string, result sarifResult) string {
+	if strings.TrimSpace(result.RuleID) == "" {
+		return tool + " reported a high-severity security finding"
+	}
+	return fmt.Sprintf("%s reported high-severity finding %s", tool, result.RuleID)
+}
+
+func sarifEvidence(result sarifResult, obligations []string) string {
+	message := strings.TrimSpace(result.Message.Text)
+	if message == "" {
+		message = "SARIF result did not include a message"
+	}
+	return fmt.Sprintf("%s; obligations: %s", message, strings.Join(obligations, ", "))
+}
+
+func sarifSeverityRank(severity string) int {
+	switch severity {
+	case "critical":
+		return 3
+	case "high":
+		return 2
+	case "medium":
+		return 1
+	default:
+		return 0
+	}
+}


### PR DESCRIPTION
## Summary

  - Package the shadow-mode PR workflow around manifest-backed evidence.
  - Update GitHub Actions docs and published docs with PR manifest creation, JUnit attachment, gate summary output,
  and artifact upload conventions.
  - Update the roadmap to mark the reference workflow as implemented and move next workflow work toward real pilot
  results and status integration.

## Tests

  - `go test ./...`
