### PR TITLE
docs: align Agent OS architecture and roadmap

### DIFF
--- a/AGENT_OS_EXECUTION_PLAN.md
+++ b/AGENT_OS_EXECUTION_PLAN.md
@@ -3,13 +3,17 @@
 > This document records the kernel foundation implemented on 2026-07-23. Its
 > original identity-and-control-plane product framing is superseded by
 > [`AGENT_TRANSACTION_EXECUTION_PLAN.md`](./AGENT_TRANSACTION_EXECUTION_PLAN.md).
-> The run lifecycle, durable event store, capability broker, and resource-driver
+> The canonical hierarchy is now defined by [`README.md`](./README.md) and
+> [`ROADMAP.md`](./ROADMAP.md): Vouch Agent OS is the complete architecture,
+> Vouch Runtime is the customer-side enforcement product, `vouchd` is its
+> kernel, and Vouch Control Plane manages Runtime fleets. The run lifecycle,
+> durable event store, capability broker, and connector-driver
 > boundary remain required substrate for the transaction product.
 
 ## Purpose
 
-Evolve Vouch from a release-contract compiler and evidence gate into the trusted
-control plane for software agents.
+Evolve Vouch from a release-contract compiler and evidence gate into the
+trusted `vouchd` authority kernel inside Vouch Runtime.
 
 The intended system is not another reasoning framework. Existing agents and
 frameworks should continue to own prompting, planning, model calls, and their
@@ -41,14 +45,14 @@ Implementation status as of 2026-07-23:
   decision/execution/result events, denied path-escape tests, and ambiguous
   action recovery to `unknown` without retry.
 - The rest of Milestone 2 and later milestones remain planned. In particular,
-  process and external-service drivers, authenticated approvals, revocation,
-  runtime adapters, scheduling, identity, and distributed operation are not yet
-  complete.
+  process and external-service connector drivers, authenticated approvals,
+  revocation, agent adapters, scheduling, identity and distributed operation
+  are not yet complete.
 
 ## Product Definition
 
-Vouch will be ready to call an agent operating system when it can make the
-following guarantees:
+This historical plan defined kernel-readiness through the following
+guarantees:
 
 1. Every agent run has a stable identity, owner, parent lineage, lifecycle,
    budget, contract, and isolated state.
@@ -66,8 +70,9 @@ following guarantees:
 9. Agents, memory, credentials, and workspaces are isolated by default.
 10. An operator can inspect, approve, pause, resume, cancel, and recover runs.
 
-Until those guarantees hold, describe Vouch as an agent control plane or agent
-kernel rather than a complete agent OS.
+Under the current hierarchy, these guarantees produce a credible Vouch Runtime
+kernel. The complete Vouch Agent OS additionally requires the Vouch Control
+Plane to manage a Runtime fleet.
 
 ## North-Star Demonstration
 
@@ -75,7 +80,7 @@ The first complete demonstration should govern one real coding-agent run:
 
 ```text
 1. A human creates a run from a reviewed execution contract.
-2. Vouch admits the run and launches an agent through a runtime adapter.
+2. Vouch admits the run and launches an agent through an agent adapter.
 3. The agent requests a permitted workspace write; Vouch authorizes and logs it.
 4. The agent requests an out-of-scope write; Vouch denies it before execution.
 5. The agent requests a protected action such as push or deployment.
@@ -99,7 +104,7 @@ infrastructure.
                          Vouch Control API
                                |
           +--------------------+--------------------+
-          |                 Vouch Kernel             |
+          |                 vouchd kernel             |
           |                                           |
           |  Run supervisor      Contract compiler   |
           |  Admission/scheduler Policy evaluator    |
@@ -110,21 +115,21 @@ infrastructure.
                 State + event log     Action broker
                         |                  |
          +--------------+------+    +------+------------+
-         | Runtime adapters    |    | Resource drivers   |
+         | Agent adapters      |    | Connector drivers  |
          | CLI / Codex /       |    | filesystem / shell |
          | Claude / SDKs       |    | MCP / GitHub /     |
          | LangGraph / custom  |    | cloud / databases  |
          +---------------------+    +--------------------+
 ```
 
-### Control plane and data plane
+### `vouchd` authority and Runtime workload subsystems
 
 Keep these boundaries explicit:
 
-- The control plane stores contracts, runs, capabilities, policy, approvals,
+- The `vouchd` authority subsystem stores contracts, runs, capabilities, policy, approvals,
   checkpoints, and decisions.
-- The data plane executes model and tool operations through runtime adapters and
-  resource drivers.
+- The Runtime workload subsystem executes model operations through agent
+  adapters; connector drivers perform authorized downstream operations.
 - Adapters and agents are untrusted clients of the kernel. They may propose an
   action but may not authorize it.
 - The policy evaluator is deterministic. Model output may be evidence or input,
@@ -139,7 +144,7 @@ JSON Schemas before adding multiple wire formats.
 
 An immutable, content-addressed definition of an agent:
 
-- Runtime adapter and entrypoint.
+- Agent adapter and entrypoint.
 - Model requirements and permitted providers.
 - Instructions, skills, and tool declarations.
 - Contract references.
@@ -247,7 +252,7 @@ These invariants take priority over feature count:
 5. Never expose raw long-lived credentials to the model or agent workspace.
 6. A child run cannot receive more authority than its parent can delegate.
 7. Revocation applies at the next broker boundary and blocks new effects.
-8. Runtime adapters cannot write authoritative run or decision state directly.
+8. Agent adapters cannot write authoritative run or decision state directly.
 9. Every public resource is schema-versioned and rejects unknown fields.
 10. The event history is sufficient to explain the current run state.
 
@@ -270,7 +275,7 @@ requested
 - Policy inputs, decisions, explanations, and enforcement points.
 - Action and event schemas.
 - Evidence linkage and release decisions.
-- Runtime adapter and resource-driver interfaces.
+- Agent-adapter and connector-driver interfaces.
 - Audit history and operator-facing explanation.
 
 ### Vouch should integrate
@@ -297,7 +302,8 @@ Goal: define the public semantics before writing a daemon.
 
 Deliverables:
 
-- Architecture decision record for control plane versus data plane.
+- Architecture decision record for `vouchd` authority versus Runtime workload
+  and connector subsystems.
 - Threat model covering malicious prompts, agents, tools, adapters, evidence,
   and operators.
 - JSON Schemas for the eight core resources.
@@ -372,7 +378,7 @@ Exit criteria:
   process driver.
 - Every attempted action appears in the event history, including denials.
 
-### Milestone 3: Runtime adapter protocol
+### Milestone 3: Agent adapter protocol
 
 Goal: govern agents without owning their reasoning loop.
 
@@ -480,7 +486,7 @@ Exit criteria:
 - Remote actions retain human, parent-agent, and child-agent attribution.
 - Cross-protocol traces correlate to the same Vouch run and event sequence.
 
-### Milestone 8: Distributed production control plane
+### Milestone 8: Distributed production Runtime
 
 Goal: make the proven kernel operable by teams.
 
@@ -496,7 +502,7 @@ Deliverables:
 
 Exit criteria:
 
-- Control-plane failover does not lose acknowledged events or duplicate known
+- Runtime failover does not lose acknowledged events or duplicate known
   committed effects.
 - Tenant isolation is covered by automated authorization tests.
 - An operator can diagnose and recover a stuck run without database surgery.
@@ -542,7 +548,7 @@ internal/kernel/reducer/   lifecycle and action state reducers
 internal/kernel/store/     event/run store interfaces and SQLite adapter
 internal/kernel/policy/    admission and action policy boundary
 internal/kernel/broker/    action mediation and driver dispatch
-internal/kernel/runtime/   runtime adapter protocol and supervision
+internal/kernel/runtime/   agent adapter protocol and supervision
 internal/kernel/drivers/   filesystem/process, later MCP and remote drivers
 schemas/                   versioned JSON Schemas and compatibility fixtures
 ```
@@ -608,12 +614,13 @@ Keep two separate claims:
 - `VouchKernelBench`: run durability, action mediation, delegation, budgets,
   approvals, and recovery.
 
-Do not claim agent-task quality from either harness. They validate control-plane
-behavior, not model intelligence.
+Do not claim agent-task quality from either harness. They validate kernel
+authority behavior, not model intelligence.
 
 ## Metrics
 
-Track metrics that reveal whether Vouch is functioning as a control plane:
+Track metrics that reveal whether `vouchd` is functioning as an authority
+kernel:
 
 - Percentage of privileged actions mediated by the broker.
 - Unauthorized actions prevented before side effects.
@@ -656,14 +663,14 @@ At the end of each milestone, answer:
 7. Did the existing compiler/evidence/release behavior remain compatible?
 
 If a milestone adds orchestration features without strengthening an authority,
-durability, isolation, or audit boundary, it is not moving Vouch toward an
-agent OS.
+durability, isolation or audit boundary, it is not moving Vouch Runtime toward
+the complete Vouch Agent OS architecture.
 
 ## Immediate Next Actions
 
 1. Review and approve the product definition and ten OS guarantees in this
    document.
-2. Write the control-plane/data-plane architecture decision record.
+2. Write the kernel-authority/Runtime-workload architecture decision record.
 3. Write the threat model before choosing daemon or adapter APIs.
 4. Specify the eight versioned resources and their lifecycle invariants.
 5. Create golden fixtures for the north-star run.

--- a/AGENT_TRANSACTION_EXECUTION_PLAN.md
+++ b/AGENT_TRANSACTION_EXECUTION_PLAN.md
@@ -13,15 +13,14 @@ Vouch is the transaction and verification layer for autonomous agents:
 > necessary approval, commits the effects, and coordinates recovery when the
 > outcome fails.
 
-The immediate category is **Agent Transaction Control**. The product is not an
-identity directory, another agent framework, an MCP-only gateway, or a generic
-allow/deny policy proxy. Identity providers and cloud policy engines remain
-integrations beneath or beside Vouch.
+This historical plan used **Agent Transaction Control** as a working technical
+category. The canonical current name for the first product is **Vouch
+Runtime**. It is not an identity directory, another agent framework, an
+MCP-only gateway or a generic allow/deny policy proxy.
 
-The long-term “agent OS” claim becomes credible when the system provides a
-non-bypassable transaction boundary across the important resources in an
-agent's workflow. Until then, call the implementation a transaction runtime or
-transaction kernel.
+Under the current hierarchy, **Vouch Agent OS** is the complete Control Plane
+plus Runtime-fleet architecture. See the current README and roadmap for the
+claim boundary.
 
 ## Current foundation
 
@@ -233,22 +232,22 @@ Exit criteria:
   partially-committed, or manual-recovery outcome.
 - No unknown non-idempotent action is automatically repeated.
 
-### Phase T4: Enterprise control plane
+### Phase T4: Vouch Control Plane
 
 Deliver:
 
-- Self-hosted data plane and highly available central control plane.
+- Customer-side Vouch Runtime fleet and highly available Vouch Control Plane.
 - Entra/Okta/IAM identity adapters, SSO, RBAC, and approval delegation.
 - Policy versioning/simulation, SIEM export, evidence retention, and audit
   bundles.
 - Credential brokering, restricted egress, emergency revocation, and data
   residency controls.
-- Multiple coding-agent and runtime adapters.
+- Multiple coding-agent and agent adapters.
 
 Exit criteria:
 
 - Production paths are non-bypassable under the documented deployment model.
-- Control-plane failover neither loses acknowledged receipts nor duplicates
+- Vouch Control Plane failover neither loses acknowledged receipts nor duplicates
   known effects.
 - Operators can recover stuck transactions without database surgery.
 

--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -22,7 +22,7 @@ One-sentence version:
 | Supply-chain tooling | Sign artifacts and describe provenance | Establishes identity and provenance inputs used by Vouch authority |
 | Vouch Contracts | Compile release intent into obligations and map evidence | Optional module that strengthens Vouch Runtime verification |
 | Vouch Runtime | Govern the complete task from isolated execution through commit/recovery | Current product |
-| Vouch Control Plane | Manage runtime fleets, organization policy, approval UX and audit | Future commercial layer |
+| Vouch Control Plane | Manage Runtime fleets, organization policy, approval UX, audit and connector configuration | Future commercial layer; it does not execute connector actions |
 
 ## Why a per-tool gateway is not enough
 
@@ -127,10 +127,11 @@ atomically update an allowed local ref.
 It does not yet provide remote GitHub merge, deployment or database connectors,
 a network multi-tenant service, HA or fleet management.
 
-The future Vouch Control Plane will manage multiple self-hosted runtime data
-planes, organization policy, approvals, audit and enterprise connectors. The
-long-term Agent OS description becomes appropriate only when those important
-resource paths are non-bypassable.
+The future Vouch Control Plane will manage multiple customer-side Vouch
+Runtimes, organization policy, approvals, audit and connector configuration.
+Connector drivers will continue to execute inside each Runtime. The complete
+Vouch Agent OS external claim requires both non-bypassable multi-system Runtime
+enforcement and demonstrated Control Plane operation across a Runtime fleet.
 
 ## Non-goals
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,17 +4,22 @@ Thanks for helping build Vouch Runtime.
 
 ## Product first principle
 
-Vouch Runtime is the transaction runtime for autonomous agents. A contribution
-should strengthen the controlled path from task intent to isolated execution,
-staged effects, exact-state verification, authority, commit and recovery.
+Vouch Runtime provides transaction and outcome control for autonomous-agent
+actions. A contribution should strengthen the controlled path from task intent
+to isolated execution, staged effects, exact-state verification, authority,
+commit and recovery.
 
 Keep the hierarchy clear:
 
-- Vouch Runtime is the current product.
-- `vouchd` is the trusted transaction kernel.
+- Vouch is the company and product name.
+- Vouch Agent OS is the complete architecture: Control Plane plus Runtime
+  fleet, transaction protocol and connector model.
+- Vouch Runtime is the first sellable product and customer-side enforcement
+  boundary.
+- `vouchd` is the trusted transaction kernel inside each Runtime.
 - Vouch Contracts is an optional verification module.
-- Vouch Control Plane is a future commercial fleet-management layer.
-- Agent OS is the long-term north star.
+- Vouch Control Plane is the future central fleet, policy, approval and audit
+  manager; it does not execute downstream agent actions.
 
 Vouch is not a coding agent, generic AI code reviewer, identity provider or
 universal rollback system.
@@ -97,7 +102,7 @@ Useful work includes:
 - Immutable staging and exact verifier inputs.
 - Idempotent commit, receipts and reconciliation.
 - Honest partial-commit and manual-recovery semantics.
-- Deep resource drivers with tested failure boundaries.
+- Deep connector drivers with tested failure boundaries.
 
 Unknown non-idempotent effects must be reconciled, never blindly retried.
 
@@ -185,7 +190,7 @@ Avoid changes that:
 - Depend on nondeterministic model output for authority.
 - Add a connector without reconciliation semantics.
 - Present Vouch Contracts as the whole product.
-- Call the current implementation a complete Agent OS.
+- Call the current implementation a complete Vouch Agent OS.
 
 The project should be ambitious about enforcement and conservative about its
 claims.

--- a/README.md
+++ b/README.md
@@ -2,40 +2,95 @@
   <img src="assets/vouch.png" alt="Vouch logo" width="220">
 </p>
 
-# Vouch Runtime
+# Vouch
 
-Vouch Runtime is the transaction runtime for autonomous software agents. It
-runs an agent inside an isolated task boundary, records the resulting effects,
-verifies the exact proposed state, obtains any required independent authority,
-and publishes an approved outcome atomically.
+Vouch is the transaction operating layer between autonomous agents and
+enterprise systems. Agents may propose work, but a deterministic enforcement
+runtime controls which exact effects may become real.
+
+Vouch does not replace an agent framework, model provider, identity provider,
+container runtime, Kubernetes or the host operating system. It controls the
+authority and transaction boundary around agent work.
+
+## Architecture: where the OS, Runtime and kernel sit
+
+**Vouch Agent OS** names the complete target system; it is not another process
+or deployment. The enforcement function lives in one or more customer-side
+**Vouch Runtime** installations. Each Runtime contains a trusted **`vouchd`
+kernel**. The planned **Vouch Control Plane** manages a fleet of Runtimes.
 
 ```text
-task intent
-  -> isolated agent execution
-  -> normalized effect ledger
-  -> immutable staged state
-  -> policy and independent verification
-  -> approval when required
-  -> commit | block | revise | recover
+                         administrators / approvers
+                                   |
+       +---------------- Vouch Agent OS ------------------+
+       |          the complete target Vouch system       |
+       |                                                  |
+       |  Vouch Control Plane [planned]                   |
+       |  fleet | organization policy | approval routing |
+       |  audit | incident response | fleet revocation   |
+       |                 |                 ^              |
+       |      signed policy/authority      | receipts     |
+       |                 v                 |              |
+task   |  +------- Vouch Runtime [customer-side] ------+  |
+------>|  | customer-side enforcement boundary         |  |
+       |  |                                             |  |
+       |  |              vouchd kernel                  |  |
+       |  |  admission | identity and lineage          |  |
+       |  |  lifecycle | capabilities | budgets        |  |
+       |  |  action broker | sequence policy           |  |
+       |  |  transaction journal | verification        |  |
+       |  |  approvals | commit | reconciliation       |  |
+       |  |       | launches          ^        |        |  |
+       |  |       v                   |        v        |  |
+       |  |  agent sandbox ------ ActionRequest ------  |  |
+       |  |  + agent adapter          |   connector     |  |
+       |  |  untrusted; no            +-> driver        |  |
+       |  |  downstream credentials       scoped creds  |  |
+       |  +--------------------------------------|------+  |
+       +-----------------------------------------|---------+
+                                                 v
+                    GitHub | Kubernetes | PostgreSQL
+                    SAP | Salesforce | cloud | email
 ```
 
-Vouch does not decide how an agent reasons or writes code. It controls the
-boundary between an agent's proposal and a real effect.
+The operating-system analogy is precise:
 
-## Product hierarchy
+| Name | Meaning | Status |
+| --- | --- | --- |
+| **Vouch Agent OS** | The complete target architecture: Control Plane, Runtime fleet, transaction protocol and connector model. It is an umbrella, not a process. | Product direction |
+| **Vouch Control Plane** | Organization-wide fleet, policy, approval, audit and incident management. It manages Runtimes but does not execute agent actions. | Planned |
+| **Vouch Runtime** | The deployable enforcement boundary installed in a customer environment. It contains `vouchd`, agent sandboxes, local durable state and connector drivers. | Narrow single-node local-Git profile implemented |
+| **`vouchd` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Foundation implemented; production authority paths are not yet unified |
+| **Agent sandbox** | The isolated, untrusted environment in which an agent loop executes. It receives no downstream production credentials. | OCI implementation available |
+| **Agent adapter** | Connects an existing agent framework or command to the kernel. It may request work and actions but cannot authorize itself or create receipts. | Command/profile and lower-level integration exist; supported broker API planned |
+| **Connector driver** | Performs typed operations against one downstream system after kernel authorization and reconciles external state. `vouchd` records authoritative receipts and coordinates recovery. | Rooted filesystem and local Git exist; common interface and remote connectors planned |
+| **Vouch Contracts** | Optional verification module that turns human-owned intent into evidence obligations used by Runtime policy. | Beta |
 
-- **Vouch Runtime** is the current product and developer surface.
-- **`vouchd`** is its trusted local kernel. It owns execution, durable state,
-  policy, verification, approval and commit.
-- **Vouch Contracts** is an optional verification module. It compiles
-  human-owned release intent into obligations and maps evidence to those
-  obligations. It strengthens a runtime policy; it is not the primary product.
-- **Vouch Control Plane** is the future commercial management layer for runner
-  fleets, organization policy, approval UX, audit retention, connectors and
-  enterprise operations. It is not implemented in this repository today.
-- **Agent OS** is the long-term north star. Vouch should use that description
-  only after it provides a non-bypassable transaction boundary across the
-  important resources in an agent workflow.
+The diagram states the intended ownership boundary, not a completion claim.
+Today the supported transaction path and the lower-level
+run/capability/action path are adjacent but not yet one authoritative
+lifecycle. Converging them is the first implementation milestone.
+
+Every consequential action must follow one authority path:
+
+```text
+agent proposes an action
+  -> vouchd authenticates the run and delegated authority
+  -> vouchd evaluates the action and complete transaction sequence
+  -> deny | request approval | authorize
+  -> connector driver stages or executes with scoped credentials
+  -> vouchd records the receipt and verifies the outcome
+  -> commit | compensate | reconcile | require manual recovery
+```
+
+An agent with direct downstream credentials can bypass Vouch. A deployment is
+therefore enforcement-grade only when production credentials and network paths
+are available exclusively through Vouch connector drivers.
+
+The current local-Git transaction is the first kernel and connector slice. A
+complete Vouch Agent OS external claim requires both non-bypassable,
+multi-system Runtime enforcement and a Vouch Control Plane managing a fleet of
+those Runtimes.
 
 ## Runtime quick start
 
@@ -173,6 +228,7 @@ code correct and are not a generic AI code reviewer.
 - [Production runtime operations](docs/PRODUCTION.md)
 - [Kernel internals](docs/KERNEL.md)
 - [Runtime and product roadmap](ROADMAP.md)
+- [Product validation and competitive assessment](docs/PRODUCT_VALIDATION.md)
 - [Transaction-control decision](docs/architecture/ADR-002-agent-transaction-control.md)
 - [Threat model](docs/architecture/TRANSACTION_THREAT_MODEL.md)
 - [Vouch Contracts](docs/COMPILER.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,257 +1,320 @@
-# Vouch Runtime Roadmap
+# Vouch Agent OS Roadmap
 
-## Product direction
+## Direction
 
-Vouch Runtime is the transaction runtime for autonomous agents. The current
-product is not the older release-contract compiler, and it is not yet a complete
-Agent OS.
+**Vouch Agent OS** is the complete architecture: the organization-wide Control
+Plane, a fleet of customer-side Vouch Runtimes, the transaction protocol and
+connector model. It is not a separate daemon.
 
-The product hierarchy is:
+**Vouch Runtime** is the deployable enforcement boundary. The trusted
+**`vouchd` kernel** lives inside each Runtime and owns authority, durable
+transaction state, policy decisions, approvals and commit coordination.
 
-| Layer | Role | Status |
-| --- | --- | --- |
-| Vouch Runtime | Isolate, stage, verify, authorize, commit and recover an agent task | Current product |
-| `vouchd` | Trusted transaction kernel and local enforcement point | Implemented |
-| Vouch Contracts | Optional contract-to-obligation verification module | Implemented beta module |
-| Vouch Control Plane | Fleet, policy, approvals, audit, connectors and enterprise administration | Future commercial layer |
-| Agent OS | Non-bypassable transaction boundary across the important resources in an agent workflow | Long-term north star |
+The current external product message is:
 
-The immediate technical category remains **Agent Transaction Control**. Vouch
-should earn the Agent OS description through enforcement coverage rather than
-adopt it as a premature marketing claim.
+> **Vouch Runtime — stateful transaction and outcome integrity for actions
+> proposed by autonomous agents.**
+
+The market problem is real, but generic identity, policy gateways, durable
+agent runtimes, workflow orchestration and fleet control planes are already
+crowded categories. The reasoning and competitive evidence are recorded in
+[Product Validation](docs/PRODUCT_VALIDATION.md).
 
 ## Product thesis
 
-Agents will receive useful authority only when organizations can control the
-complete task, not merely approve isolated tool calls after the fact.
+An agent should be able to propose useful work without possessing ambient
+production authority.
 
 ```text
-human intent
-  -> admitted agent execution
-  -> staged, normalized effects
-  -> exact-state verification
-  -> outcome-oriented approval
-  -> ordered commit and receipts
-  -> postconditions and recovery
+admit exact intent and delegated authority
+  -> execute an untrusted agent inside a bounded Runtime
+  -> turn attempted actions into typed proposed effects
+  -> evaluate individual actions and the composed task
+  -> stage or hold effects where possible
+  -> verify exact preconditions, invariants and postconditions
+  -> obtain approval for the frozen outcome when required
+  -> commit in dependency order
+  -> reconcile, compensate or require manual recovery
 ```
 
-Vouch succeeds when a team grants an agent permission to complete work it
-previously allowed the agent only to suggest.
+Vouch succeeds when a customer safely grants an agent authority to complete a
+task it previously allowed the agent only to suggest.
 
-## Implemented foundation
+## Current state
 
-The repository already contains:
+The repository contains a substantial foundation:
 
-- Strict versioned resources for agent images, execution contracts, runs,
-  capabilities, actions, transactions, effects, verifications, approvals,
-  commit plans, checkpoints and events.
-- Deterministic reducers and append-only hash-chained histories.
-- SQLite event/projection persistence, optimistic concurrency and restart
-  recovery.
-- `vouchd` over a mode-`0600` Unix socket.
-- Daemon-owned OCI execution with non-root identities, read-only roots,
-  resource limits and bounded output.
-- Transaction-specific model brokering with provider credential isolation,
-  model/tool policy, token budgets and durable receipts.
-- Detached Git worktrees, bounded raw staging, immutable tree revisions and
-  exact read-only verifier materializations.
-- Normalized effect ledgers and initial sequence/separation policy.
-- OIDC role and namespace enforcement.
-- Immutable approval packages, signed independent approvals and a distinct
-  release identity.
-- Compare-and-swap publication to allowed local Git refs and crash
+- strict resources for tasks, images, contracts, runs, capabilities, actions,
+  transactions, effects, verifications, approvals and commit plans;
+- deterministic reducers and hash-chained event histories;
+- SQLite persistence, optimistic concurrency and restart recovery;
+- daemon-owned OCI agent and verifier execution;
+- isolated Git worktrees, immutable tree staging and exact verifier
+  materialization;
+- model credential isolation, token limits and receipts;
+- OIDC operator identity and signed, independent approvals;
+- sequence findings, compare-and-swap local Git publication and crash
   reconciliation.
-- Readiness checks and separate kernel, transaction, runtime, Contracts and
-  production acceptance harnesses.
-- The optional Vouch Contracts compiler, obligation IR, evidence import and
-  release-policy module.
 
-## Current supported profile
+The supported profile remains one node, one security tenant and publication to
+an allowed local Git ref. It does not yet control a remote enterprise system.
 
-The supported runtime profile is deliberately narrow:
+### Critical architecture gap
 
-- One node, one security tenant and one trusted host/VM.
-- One non-root daemon boundary using SQLite and local storage.
-- Preloaded digest-pinned agent, verifier and broker images.
-- Daemon-owned mandatory verifiers.
-- OIDC operator identity, signed approvals and separation of duties.
-- Publication to an allowed local Git branch ref.
+The repository currently has two adjacent authority paths:
 
-The profile does not include remote push or pull-request merge, deployment,
-database effects, submodules, multi-tenancy, a network control API, distributed
-scheduling or HA. Stable versioned binary packaging and upgrade compatibility
-are still pending. The complete requirements remain in
-[docs/PRODUCTION.md](docs/PRODUCTION.md).
+1. The production `vouch run` path creates an `AgentTask` and
+   `AgentTransaction`, executes an OCI workload and stages Git effects.
+2. The older kernel path owns `AgentRun`, `ExecutionContract`, capability
+   grants and brokered `ActionRequest` resources, but those endpoints are
+   disabled by the production profile.
 
-## Execution order
+The production transaction therefore does not yet bind a real kernel run,
+contract, capabilities, lineage and task budgets into one authoritative
+lifecycle. Adding remote connectors before converging these paths would create
+connector-specific product logic around the wrong kernel boundary.
 
-### Phase 0: Coherent developer surface
+## Execution principles
 
-Make the implemented runtime understandable and usable without exposing its
-internal state-machine choreography.
+1. **One authority path.** Task, run, contract, capabilities, transaction and
+   release scope are admitted atomically.
+2. **Kernel before driver.** Connector behavior is implemented behind one
+   conformance-tested interface, not inside GitHub-specific API handlers.
+3. **No ambient credentials.** Agents never receive downstream production
+   credentials or unrestricted egress.
+4. **External truth before retry.** An ambiguous non-idempotent action is
+   reconciled; it is never retried blindly.
+5. **Exact approval.** Any material change to authority, effects, verification,
+   policy or release target invalidates approval.
+6. **Connector-specific recovery.** Reversible, compensatable and irreversible
+   effects remain distinct.
+7. **Integrate standards.** Use existing identity, policy and orchestration
+   systems rather than rebuilding them.
+8. **Commercial evidence gates breadth.** A merged feature is not product
+   validation.
 
-- Implemented: task execution is the primary top-level `vouch run` workflow;
-  `status`, `approve` and `release` are product-facing commands; the older run
-  kernel is under `vouch kernel`; and the compiler/evidence surface is grouped
-  under `vouch contracts`.
-- Add `watch`, product-level `effects`, `events`, `cancel` and
-  `doctor` experiences around one transaction ID.
-- Add a strict versioned runtime configuration file.
-- Ship stable binary/container installation and a service definition.
-- Publish an explicit CLI and schema compatibility policy.
+## Next mergeable changes
 
-Exit criteria:
+Each item is a bounded workstream. Deliver it through short, independently
+reviewable pull requests; do not bundle an entire row into one pull request.
 
-- A developer can install Vouch, start a local runtime, run a supported coding
-  agent and understand the next required action from one quick start.
-- Normal use does not require manually authoring event envelopes, digests or
-  sequence cursors.
+| Change | Deliverable | Required acceptance |
+| --- | --- | --- |
+| **OS-0: architecture truth** | README architecture and glossary; evidence-backed product validation; this executable roadmap; terminology cleanup in kernel docs. | Every architecture box maps to implemented code or is clearly marked planned or external. Documentation makes no unsupported production claim. |
+| **OS-1: focused validation lanes** | At most three required PR lanes: Go checks, affected acceptance and documentation when changed. Run the full race, vulnerability and benchmark collections on `main`, nightly and release. Retain production OCI acceptance for security-critical Runtime changes. | Normal PR gate completes in a bounded target such as 12 minutes. Path rules cannot skip production acceptance when kernel, sandbox, identity, approval, release or connector code changes. |
+| **OS-2: atomic task admission** | One daemon-owned, idempotent endpoint persists the exact task, `ExecutionContract`, real `AgentRun`, initial capability grants and `AgentTransaction` in one database transaction. The server authors authoritative events and digests. | Fault injection after every persistence step creates no orphan resources. Identical idempotency retry returns the same admission; a changed retry conflicts. Every transaction references a digest-matching run and contract. |
+| **OS-3: bind execution authority and data boundaries** | OCI execution transitions the admitted `AgentRun`. Identity, sponsor and parent lineage, contract, capabilities, deadline, allowed resources, data classes, model egress and budgets become authoritative. Task limits may narrow daemon ceilings but never widen them. | Run and transaction state cannot diverge after success, failure or injected crash. Expired authority prevents start. Time, model, tool and cost limits fail closed and are durably charged across restart. Denied mounts, connector reads, resource classes and model-egress destinations are inaccessible rather than merely recorded. |
+| **OS-4: durable supervisor and circuit breaker** | Asynchronous workload start, durable desired state and execution lease; functional `watch`, `cancel`, kill and revocation. “Pause” means stop at a declared safe boundary, not arbitrary process snapshotting. | Repeated start creates one workload. Cancel terminates the agent and broker within a bounded interval and prevents release. No new effect executes after revocation. Restart produces one reconciled outcome. |
+| **OS-5: connector interface and transaction coordinator** | Introduce `Plan → Stage/Hold → Inspect → Verify → Commit → Reconcile → Compensate`; add a connector registry plus a durable dependency-ordered coordinator. Each connector persists preparation state, commit state and receipts. Unknown results stop dependent work; restart performs reconciliation before retry or compensation. Move local Git behind the interface only after the generic harness passes. | Two fake connectors prove dependency-ordered prepare/commit, stop-on-unknown, restart recovery, reverse compensation and manual-recovery escalation. Faults are injected before dispatch, during dispatch and after an external effect but before its receipt. Connectors cannot mint authority. Existing local-Git production acceptance remains behaviorally unchanged. |
+| **OS-6: versioned Runtime action protocol and broker** | Replace or converge the legacy broker behind a supported `ActionRequest → decision/approval → receipt` protocol. A transaction-scoped workload credential binds sandbox transport, task, run, transaction, delegated identity, capability, deadline and idempotency key. Publish stable status/event cursors, error semantics and one maintained Go client. Direct private-worktree mutation remains an explicitly contained, stageable boundary. | Local transport rejects forged, cross-run, expired and replayed credentials. Approval resumes only the exact immutable request after restart. A fake connector proves allow, deny, approval, expiry and revocation without exposing its credential. N/N-1 protocol and adapter-conformance fixtures pass; every attempted external effect is attributable. |
+| **OS-7: lineage-aware temporal policy** | Persist immutable identity, delegation, action and effect facts across runs and transactions. Evaluate bounded temporal and separation-of-duties rules across sessions, systems, child agents and a shared sponsor lineage. Ordinary stateless decisions may use an ACS/Cedar/OPA adapter, but Vouch remains authoritative for history and commit. | An AP-style fixture spanning separate sessions and delegated identities is denied for the composed sequence while individually valid actions remain allowed. Restart yields the same decision. Retention and query bounds are explicit, and the policy adapter cannot authorize or commit an effect outside the Runtime transaction. |
+| **GH-1: GitHub ref driver** | After OS-7, add daemon-owned GitHub App authentication, installation/repository allowlist, exact-base branch publication and reconciliation. No pull request or merge yet. | Credentials never enter the task, sandbox, events or logs. Retry is idempotent, stale base fails, and a simulated timeout after remote mutation reconciles to the exact commit without another mutation. |
+| **GH-2: protected PR driver** | Idempotent create/update, transaction marker, exact head/base binding and a concise reviewer summary. Material updates invalidate prepared authority. | Retry creates no duplicate PR. Foreign or stale heads fail closed. Summary explains intent, material effects, verification, risk and required authority without dumping the internal ledger. |
+| **GH-3: exact-SHA merge** | Recheck head SHA, required checks, review policy, approval package and releaser separation immediately before merge; reconcile ambiguous outcomes. | Mutated head, failed check, expired approval and approver-as-releaser fail. Injected timeout yields at most one merge. Receipt identifies the exact reviewed and merged SHA. |
+| **OPS-1: install, API and evidence** | Versioned Runtime configuration and local API contract, binary/container release, service definition, `doctor`, `watch`, audit-bundle export and compatibility/upgrade policy. | A clean supported VM completes the documented transaction. N/N-1 API/config compatibility, restart, backup and restore pass. JSON and Markdown evidence replay to the authoritative projection. |
+| **CP-1: pilot Vouch Control Plane** | Runtime enrollment and health, signed policy distribution, approval routing, central receipt collection and fleet kill/revocation. Build only after paid-pilot evidence. | Vouch Control Plane loss cannot duplicate effects or erase local receipts. Cached-policy behavior is explicit and fails safely. One partner operates multiple Runtimes. |
 
-### Phase 1: Public runtime API and agent protocol
+## Product milestones
 
-Turn the internal foundation into an embeddable product.
+### Milestone A: Vouch Runtime developer preview
 
-- Publish public versioned API resource packages and an OpenAPI document.
-- Publish a supported Go client; add another SDK only after the API stabilizes.
-- Add idempotent task creation and mutation requests.
-- Add bounded event/status streaming and pagination.
-- Implemented locally: strict named profiles make `AgentImage` executable with
-  a pinned OCI reference and fixed entrypoint.
-- Implemented locally: `vouch.agent_task.v0` durably retains and digest-binds
-  exact intent, transaction/run/profile/image/command identity and is mounted
-  read-only at `/vouch/task.json`. External encrypted artifact storage remains
-  control-plane work.
-- Wire execution contracts, budgets, verifier profiles and release targets into
-  transaction creation.
-- Provide a generic command adapter and one polished coding-agent adapter.
-
-Exit criteria:
-
-- An external application can submit and observe a transaction without
-  importing `internal/` packages or reproducing CLI orchestration.
-- The exact task, agent image, runtime policy and verifier set are immutable and
-  attributable.
-
-### Phase 2: Deep remote-Git workflow
-
-Build the first complete customer workflow rather than many shallow connectors.
-
-- GitHub App installation and short-lived credential brokering.
-- Staged branch and pull-request creation/update with idempotency and receipts.
-- Exact commit/status/check bindings.
-- Reviewer-facing approval package and decision UX.
-- Merge/reconciliation semantics that expose conflicts and unknown outcomes.
-- Audit bundle export for one transaction.
+Complete **OS-0 through OS-7**.
 
 Exit criteria:
 
-- A design partner lets an agent open or update a protected change through
-  Vouch that it would not let the agent publish directly.
-- No GitHub effect becomes real outside the frozen policy, verification and
-  approval package.
+- one task creates one durable, authoritative chain from sponsor and contract
+  through run, actions, effects, verification, approval and outcome;
+- an agent cannot exercise connector authority outside that chain;
+- budgets, expiry, cancel and revocation affect the real production workload;
+- a second connector can implement the interface without changing kernel
+  transaction semantics;
+- the supported action protocol authenticates the sandbox and preserves exact
+  approval and receipt scope;
+- lineage-aware policy produces the same bounded decision across restart.
 
-### Phase 3: Vouch Control Plane
+At this point Vouch may describe the deliverable as a **Vouch Runtime developer
+preview**, not a complete Vouch Agent OS.
 
-Build the future commercial layer around self-hosted runtime data planes.
+### Milestone B: Vouch Runtime GitHub pilot
 
-- Runtime registration, health and fleet inventory.
-- Organization policy distribution and versioning.
-- SSO/RBAC, approval routing and delegation.
-- Audit retention, search, export and SIEM integration.
-- Usage, model-cost and budget visibility.
-- Connector and verifier profile management.
-- Remote revocation and incident controls.
-- Managed or enterprise-supported deployment options.
+Complete **GH-1 through GH-3** and **OPS-1**.
 
-The commercial boundary is management and assurance at organization scale.
-The local runtime should remain useful on its own. Likely charging units are
-controlled agent transactions or active agents, with infrastructure/model
-compute accounted for separately; pricing must be validated with paid pilots.
+GitHub is a technical proving ground, not an assumed standalone market. Native
+GitHub agent controls already provide isolated execution, safe write outputs,
+protected branches and human merge. The proof must demonstrate Vouch-specific
+properties: task authority, exact outcome binding, connector receipts and
+ambiguous-effect reconciliation.
 
 Exit criteria:
 
-- One paid design partner manages multiple runtime workers through the control
-  plane.
-- Control-plane loss does not cause acknowledged effects to be duplicated or
-  authoritative local receipts to disappear.
+- every GitHub mutation belongs to an admitted Vouch transaction;
+- the agent receives no GitHub write credential;
+- mutation after approval invalidates release;
+- restart and injected timeouts create no duplicate branch, PR or merge;
+- one operator can install and complete the supported transaction without
+  database surgery.
 
-### Phase 4: Multi-system transaction packs
+### Milestone C: Vouch Runtime multi-system production pilot
 
-Expand only through connectors with explicit stage, commit, reconciliation and
-recovery semantics.
+Add deep connectors in this order:
 
-Priority order:
+1. Kubernetes deployment, canary health, traffic progression and rollback.
+2. PostgreSQL migration dry-run, invariants, native transaction where possible
+   and compensation/recovery metadata otherwise.
+3. One combined GitHub + Kubernetes + PostgreSQL transaction.
 
-1. Kubernetes deployment, canary health and rollback.
-2. PostgreSQL migration staging, invariants and compensation metadata.
-3. A combined GitHub + Kubernetes + PostgreSQL transaction.
+Exit criteria:
 
-Every connector must classify effects as read-only, stageable, reversible,
-compensatable or irreversible. Unknown non-idempotent effects are reconciled,
-never retried blindly.
+- connector credentials and network paths are non-bypassable;
+- commit dependencies and receipts span all three systems;
+- fault injection after every release boundary produces `committed`,
+  `rolled_back`, `partially_committed` or `manual_recovery_required` truthfully;
+- unknown non-idempotent work is never duplicated.
 
-### Phase 5: Distributed runtime
+This milestone validates the Runtime enforcement layer. It does not by itself
+complete the Vouch Agent OS architecture.
 
-Broaden the deployment claim only after the single-node semantics remain stable.
+### Milestone D: Vouch Control Plane pilot
 
-- PostgreSQL and object-storage persistence.
-- Leases, scheduling, quotas, priorities and admission control.
-- Multi-tenant network API and data-plane authentication.
-- HA, failover, upgrade and disaster-recovery procedures.
-- Data-residency and retention controls.
-- Multiple runtime and agent adapters.
+Build **CP-1** only after the commercial gates pass. Expand it incrementally
+with organization policy simulation, SSO/RBAC, approval delegation, audit
+retention/search/SIEM, connector configuration and usage/cost visibility.
 
-Only after these paths are non-bypassable should Vouch describe the deployed
-system as an Agent OS.
+The local Runtime remains authoritative for effects and receipts. A Control
+Plane outage may stop new authority according to policy, but must never cause a
+known effect to be duplicated or an acknowledged receipt to disappear.
 
-## Vouch Contracts roadmap
+Exit criteria:
 
-Vouch Contracts remains an optional verification module, not a parallel product
-identity. Its priorities should support runtime authority:
+- one paid partner manages at least two Runtimes through the Control Plane;
+- signed policy and revocation reach each enrolled Runtime;
+- approval routing and central receipt collection preserve local authority;
+- Control Plane loss follows the declared cached-policy behavior without
+  duplicating an effect.
 
-- Compile obligations into daemon-owned verifier requirements.
-- Bind obligation coverage and evidence provenance into approval packages.
-- Import SARIF, coverage, deployment, metrics and rollback evidence.
-- Publish schemas and compatibility tests for compiler artifacts.
-- Add scoped signer and exception policy.
-- Improve source diagnostics and authoring only where real runtime pilots show
-  contract-maintenance cost.
+After this exit, the complete system may be presented as a **Vouch Agent OS
+private preview**. Production enterprise claims still require the distributed
+operations in Milestone E.
 
-The Contracts module does not inspect arbitrary diffs and pronounce code
-correct. AI verifiers may contribute evidence but cannot be the sole authority
-for high-impact effects.
+### Milestone E: distributed Runtime and vertical packs
+
+After single-node semantics and paid usage are stable:
+
+- PostgreSQL and object-storage persistence;
+- leases, scheduling, quotas, priorities and admission control;
+- multi-tenant network API and Runtime workload authentication;
+- HA, failover, upgrades, disaster recovery, residency and retention;
+- finance/ERP, cloud operations and customer-operations transaction packs.
+
+Finance packs should interoperate with existing ERP segregation-of-duties
+controls and payment standards such as AP2. They must prove a cross-system or
+delegation-lineage gap rather than duplicate native SAP controls.
 
 ## Commercial validation
 
-Find teams considering coding or operations agents with write access and ask
-for the last workflow they refused to automate. Do not broaden the product
-until:
+Engineering and customer discovery run in parallel.
 
-- Three organizations provide a real workflow and its policy constraints.
-- Two permit monitor-mode or local-runtime integration.
-- One agrees to a paid control-plane or enterprise pilot.
-- The buyer values task-level control beyond logs and raw tool approvals.
-- Vouch produces measurable permission expansion.
+### Problem gate
 
-Primary metrics:
+- Interview 20 enterprises with live agent pilots.
+- Pass only if at least 8 describe consequential write authority as a top-three
+  blocker, 5 provide a recent refused workflow and 3 accept a scoped pilot.
 
-- Transactions and material effects mediated before release.
-- Permission-expansion events.
-- Automatic, focused-approval, revise and block rates.
-- False-block rate and approval latency.
-- Verification coverage of declared postconditions.
-- Unknown, partial-commit, compensation-failure and manual-recovery rates.
-- Duplicate non-idempotent effects; target zero.
-- Replay mismatch or unattributed effect; target zero.
+### Existing-controls gate
 
-## Non-goals
+For each workflow, model the strongest solution using the customer's existing
+identity provider, cloud/API gateway, native application controls and
+Camunda/Temporal or equivalent workflow engine.
 
-Vouch should not claim to:
+Continue only when customers identify a material composed-effect,
+exact-outcome or recovery gap that existing controls cannot cover acceptably.
 
-- Be a general-purpose coding agent or reasoning framework.
-- Be an identity provider or credential vault.
-- Be only an MCP gateway or per-call policy proxy.
-- Prove arbitrary code correct.
-- Replace production security review or incident response.
-- Offer universal rollback or fictional cross-system ACID semantics.
-- Provide production multi-tenancy or HA before those paths exist.
+### Non-bypassability gate
+
+At least 3 pilot customers must be willing to remove scoped credentials from
+the agent and route every relevant write through a Vouch Runtime. Otherwise the
+product is advisory middleware.
+
+### Permission-expansion and recovery gate
+
+Each pilot must complete at least 20 real transactions, including 5 tasks the
+customer previously restricted to humans, with:
+
+- zero unauthorized, duplicate or unattributed material effects;
+- zero replay mismatches;
+- explicit reconciliation for every ambiguous external result;
+- measured false-block rate and approval latency.
+
+### Commercial gate
+
+Obtain two paid pilots, not only free design partnerships, before building the
+Vouch Control Plane.
+
+Stop or reposition if customers are satisfied by native controls, refuse
+non-bypassable mediation, cannot name a material cross-action gap or value
+receipts and recovery only as optional compliance evidence.
+
+## Validation strategy
+
+Required pull-request validation should stay proportionate:
+
+1. **Go checks:** formatting, module consistency, vet and unit tests.
+2. **Affected acceptance:** the smallest kernel, Runtime, connector or
+   Contracts scenario that proves the changed invariant.
+3. **Documentation:** strict documentation build only when documentation or
+   public schemas change.
+
+Full race, vulnerability, all-benchmark and production matrices run on
+`main`, nightly and releases, with path-sensitive production acceptance still
+required for security-critical changes. A new feature should add one focused
+acceptance scenario rather than another overlapping benchmark family.
+
+## Vouch Contracts
+
+Vouch Contracts remains an optional verification module. Its Runtime priorities
+are:
+
+- bind obligation and evidence requirements into atomic task admission;
+- run required verification under daemon-owned profiles;
+- bind exact coverage and evidence provenance into approval packages;
+- add formats only when a real connector or pilot requires them.
+
+Do not expand Contracts into a parallel product, generic AI reviewer or
+unbounded authoring project.
+
+## Explicit deferrals
+
+- A new identity provider, credential vault or agent directory.
+- A new generic policy language or competing guardrail standard.
+- A general workflow/process orchestration engine.
+- Broad MCP passthrough without typed effects and recovery semantics.
+- SAP, Salesforce, email and broad cloud connectors before the heterogeneous
+  software transaction works.
+- Cross-session finance policies before identity lineage and effect history are
+  authoritative.
+- Universal rollback or fictional cross-system ACID guarantees.
+- Arbitrary process snapshot/resume.
+- Multi-node scheduling, production multi-tenancy and HA before paid evidence.
+- A large dashboard, marketplace or multiple SDKs before the public API and
+  connector contract stabilize.
+- Further generic observability and evaluation features.
+
+## Metrics
+
+Technical invariants:
+
+- duplicate non-idempotent effects: **zero**;
+- unattributed material effects: **zero**;
+- replay/projection mismatch: **zero**;
+- authority exercised after expiry or revocation: **zero**;
+- unknown outcome automatically retried: **zero**.
+
+Product metrics:
+
+- permission-expansion events;
+- transactions and material effects mediated;
+- automatic, approval, revise and block rates;
+- false-block rate and approval latency;
+- postcondition verification coverage;
+- unknown, partial-commit, compensation-failure and manual-recovery rates;
+- pilot conversion and paid renewal.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,8 +13,9 @@ should be treated as unsupported.
 The only supported production deployment profile is the mandatory-gate-tested,
 single-node, single-tenant Vouch Runtime that publishes to allowed local Git
 refs. Vouch Contracts is an optional verification module. The future Vouch
-Control Plane, enterprise connectors, multi-tenancy, and HA are not implemented
-production claims. There is no production push, merge, or deployment connector.
+Control Plane, enterprise connector drivers, multi-tenancy and HA are not
+implemented production claims. There is no production push, merge or deployment
+connector driver.
 Mandatory gates include reachable Go vulnerability scanning and
 VouchRuntimeBench in addition to test, vet, race, compiler/kernel/transaction
 benchmarks, and production OCI acceptance.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -13,7 +13,7 @@ event recovery across a real daemon restart. Keeping the harnesses separate
 prevents the new kernel claim from weakening or silently changing the existing
 114-assertion release-gate acceptance floor.
 
-Agent Transaction Control has a third, independent acceptance harness:
+The Vouch Runtime transaction path has a third, independent acceptance harness:
 
 ```sh
 scripts/vouchtransactionbench.sh

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -1,13 +1,11 @@
 # Local Agent Kernel
 
-Vouch includes a single-machine agent control plane. This document describes
-the lower-level run/action kernel; the production transaction runtime adds the
-OCI sandbox, OIDC authorization, signed approvals, model broker, verification,
-and Git commit coordinator described in
-[Production Runtime Operations](PRODUCTION.md). The kernel is the durable
-process and authority substrate beneath
-[Agent Transaction Control](../AGENT_TRANSACTION_EXECUTION_PLAN.md), not a
-claim that the full operating system is finished.
+Vouch Runtime includes a single-machine `vouchd` authority kernel. This
+document describes its lower-level run/action substrate; the supported
+production Runtime path adds the OCI sandbox, OIDC authorization, signed
+approvals, model broker, verification and Git commit coordinator described in
+[Production Runtime Operations](PRODUCTION.md). This subsystem is not a claim
+that the complete Vouch Agent OS is finished.
 
 The implemented path is:
 
@@ -16,7 +14,7 @@ ExecutionContract
   -> time-bounded CapabilityGrant
   -> ActionRequest
   -> durable request and authorization events
-  -> rooted filesystem driver
+  -> rooted filesystem connector driver
   -> committed | failed | unknown receipt
 ```
 
@@ -31,8 +29,10 @@ their existing CLI behavior.
 - SQLite transactions, optimistic event cursors, namespace predicates, and
   restart recovery.
 - `vouchd` over a mode-`0600` Unix socket and `vouch daemon` as a convenience.
-- Run create, inspect, list, event, pause, resume, cancel, and capability
-  installation commands.
+- Run create, inspect, list, event, pause, resume, cancel and capability
+  installation commands. Pause, resume and cancel currently transition only
+  the lower-level run record; they do not control a running production OCI
+  workload.
 - Execution-contract compilation into stable, expiring capability grants.
 - Typed filesystem read/write actions with output limits and workspace
   containment.
@@ -43,7 +43,8 @@ their existing CLI behavior.
 
 Filesystem access uses Go's [`os.Root`](https://pkg.go.dev/os#Root) API. Operations are resolved beneath an
 already-open repository and workspace root, including symlink traversal checks.
-The driver writes through a synced temporary file and an in-root atomic rename.
+The connector driver writes through a synced temporary file and an in-root
+atomic rename.
 
 ## Local walkthrough
 
@@ -110,15 +111,15 @@ projection and event history before and after restart.
 
 This lower-level run/action slice mediates only actions submitted to its
 filesystem broker. It cannot stop a process that also has direct host
-filesystem access. Use the production transaction runtime for untrusted agent
-execution: it launches the agent in the daemon-owned OCI boundary, authenticates
-operator requests, and removes direct model credentials.
+filesystem access. Use the production Vouch Runtime path for untrusted agent
+execution: it launches the agent in the daemon-owned OCI boundary,
+authenticates operator requests and removes direct model credentials.
 
 Not yet implemented:
 
-- MCP, GitHub API, database, or cloud action drivers.
+- MCP, GitHub API, database or cloud connector drivers.
 - OIDC discovery/JWKS refresh, identity lifecycle provisioning, or a
-  multi-tenant network control plane.
+  multi-tenant Runtime API.
 - Capability revocation events.
 - Leases, schedulers, or distributed stores.
 - Portable canonical JSON signatures; the current event digest is a local v0

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -1,13 +1,13 @@
 # Production Runtime Operations
 
-Vouch's production profile is a single-node transaction runtime for autonomous
-software changes released through local Git refs. It enforces the runtime
+Vouch's production profile is a single-node Vouch Runtime for autonomous
+software changes released through local Git refs. It enforces the Runtime
 boundary; it does not turn the current implementation into a multi-tenant or
-highly available control plane. This narrow, single-tenant Git profile is
+highly available Vouch Control Plane. This narrow, single-tenant Git profile is
 supported only for revisions that pass the mandatory Go formatting,
 module, test, vet, and `govulncheck` checks; kernel race tests; VouchBench,
 VouchKernelBench, VouchTransactionBench, VouchRuntimeBench; and production OCI
-acceptance. Vouch Contracts, enterprise connectors, multi-tenancy, and HA
+acceptance. Vouch Contracts, enterprise connector drivers, multi-tenancy and HA
 architecture remain beta.
 
 ## Enforced production boundary
@@ -401,7 +401,7 @@ The production profile is suitable only when all of these constraints are
 acceptable:
 
 - One daemon, one security tenant, and one local SQLite ledger on a dedicated
-  trusted host or VM; no HA, failover, or remote control plane.
+  trusted host or VM; no HA, failover or Vouch Control Plane.
 - A trusted dedicated daemon account and same-UID container boundary. Vouch
   does not protect against a malicious host administrator, OCI-engine operator,
   or identity able to replace configured parent paths.

--- a/docs/PRODUCT_VALIDATION.md
+++ b/docs/PRODUCT_VALIDATION.md
@@ -1,0 +1,225 @@
+# Product Validation: Is Vouch Solving a Real Problem?
+
+Checked against public evidence and competing products on **2026-07-26**.
+
+## Verdict
+
+The problem is real. The broad category is also crowded, and the product thesis
+is not yet commercially validated.
+
+| Question | Assessment |
+| --- | --- |
+| Do enterprises face security, reliability and governance barriers when deploying autonomous agents? | **Strong evidence: yes.** |
+| Is withheld consequential write authority a top-three buying blocker? | **Unproven.** That is the customer-discovery hypothesis H1 below, not a conclusion from public research. |
+| Are identity, per-call authorization, observability and generic agent control planes still open categories? | **No.** Large vendors and open-source projects already cover them. |
+| Is task-scoped transaction and outcome control a plausible remaining gap? | **Yes, but unproven as a standalone market.** Independent research has converged on nearly the same abstraction. |
+| Does the current Vouch implementation solve the enterprise problem? | **Only in a narrow local-Git boundary.** It proves several mechanisms, but it does not yet control an external production workflow. |
+| Should development continue? | **Conditionally.** Converge the kernel, prove deep connector semantics and obtain paid design-partner evidence before building the Vouch Control Plane. |
+
+The strongest current positioning is:
+
+> **Vouch Runtime provides stateful transaction and outcome integrity for
+> actions proposed by autonomous agents.**
+
+“Vouch Agent OS” describes the complete architecture. It is not a
+differentiated market category by itself and should not be the primary external
+claim yet.
+
+## The customer problem
+
+An enterprise can give an agent:
+
+- no write authority, which confines it to recommendations and human
+  copy-and-paste;
+- a conventional identity and coarse API permissions, which allows individual
+  calls but may not constrain the composed task;
+- a gateway or policy hook, which can allow or deny each request;
+- a workflow engine, which can enforce a process that was modeled in advance;
+- observability, which explains behavior after it occurred.
+
+The remaining problem is narrower:
+
+> Can an organization delegate a bounded outcome to a nondeterministic actor,
+> inspect the exact proposed effects before release, enforce rules over their
+> composition, and recover truthfully when an external result is ambiguous or
+> only partly reversible?
+
+Vouch must provide four properties together:
+
+1. **Complete mediation.** The agent has no ambient path or credential that
+   bypasses the Runtime.
+2. **Task-level authority.** Identity, delegation, budgets, data scope,
+   actions, effects, verifications and approvals are bound to one durable
+   transaction.
+3. **Outcome integrity.** Approval and release bind to the exact effect set and
+   verified state, not merely to a tool name or natural-language plan.
+4. **Honest recovery.** The Runtime stages where possible, uses idempotency and
+   compare-and-swap, reconciles ambiguous effects, compensates where safe and
+   exposes partial or manual recovery when reversal is impossible.
+
+## Evidence that the problem exists
+
+- NIST's May 2026 analysis of public responses on AI-agent security reports
+  broad agreement that agents introduce novel security threats and that those
+  concerns are a barrier to adoption. NIST also says established cybersecurity
+  practices need adaptation for agents. See
+  [NIST Trustworthy and Responsible AI 800-5](https://www.nist.gov/publications/summary-analysis-responses-request-information-regarding-security-considerations-ai).
+- The NIST NCCoE concept paper on agent identity and authorization asks how to
+  establish task-dependent identity and least privilege, prove authority and
+  intent, manage delegation, and provide audit and non-repudiation. See
+  [Identity and Authority of Software Agents](https://www.nccoe.nist.gov/news-insights/new-concept-paper-identity-and-authority-software-agents).
+- McKinsey's 2025 global survey reports that 62% of respondents' organizations
+  were at least experimenting with agents, while only 23% reported scaling an
+  agentic system somewhere in the enterprise. Nearly two-thirds had not begun
+  scaling AI enterprise-wide. See
+  [The state of AI in 2025](https://www.mckinsey.com/capabilities/quantumblack/our-insights/the-state-of-ai).
+- The 2026 *Measuring Agents in Production* study collected 306 valid
+  responses and filtered its primary analysis to 86 production or pilot
+  systems. Reliability was the leading challenge; reported dependence on
+  short runs and human evaluation supports the need for controllable
+  execution. The headline percentages use smaller, question-specific samples,
+  so they are directional rather than population estimates. See
+  [Pan et al.](https://arxiv.org/abs/2512.04123).
+- Gartner forecasts that an average global Fortune 500 enterprise could have
+  more than 150,000 agents in use by 2028 and reports that only 13% of
+  organizations believe they have appropriate agent governance. A separate
+  forecast says 40% of enterprises will demote or decommission autonomous
+  agents by 2027 because governance gaps are discovered after incidents. These
+  are analyst forecasts, not observed outcomes. See
+  [April 2026](https://www.gartner.com/en/newsroom/press-releases/2026-04-28-gartner-identifies-six-steps-to-manage-artificial-intelligence-agent-sprawl)
+  and
+  [May 2026](https://www.gartner.com/en/newsroom/press-releases/2026-05-26-gartner-says-applying-uniform-governance-across-ai-agents-will-lead-to-enterprise-ai-agent-failure).
+
+The conclusion supported by these sources is not “Vouch will win.” It is that
+organizations need stronger authority and recovery mechanisms before granting
+agents consequential autonomy.
+
+## The competitive reality
+
+The 2026 market has moved beyond an observability-only comparison.
+
+| Category | Examples | What already exists | Implication for Vouch |
+| --- | --- | --- | --- |
+| Agent identity and lifecycle | [Microsoft Entra Agent ID](https://learn.microsoft.com/en-us/entra/agent-id/), [Okta for AI Agents](https://www.okta.com/newsroom/press-releases/okta-for-ai-agents-core-brings-lifecycle-governance-to-regulated-environments/) | Agent registry, owners and sponsors, lifecycle, Conditional Access, short-lived access and revocation | Integrate these identities; do not build an identity directory. |
+| Inline tool and API policy | [AWS AgentCore Policy](https://docs.aws.amazon.com/bedrock-agentcore/latest/devguide/policy.html), [MuleSoft Omni Gateway](https://docs.mulesoft.com/general/agent-fabric-overview), [Galileo Agent Control](https://galileo.ai/blog/announcing-agent-control) | Framework-neutral interception, authorization, rate/cost controls, policy and audit | Per-call allow/deny or a generic gateway is not a differentiator. |
+| Open policy standard/runtime | [Microsoft Agent Control Specification](https://microsoft.github.io/agent-governance-toolkit/packages/agent-control-specification/) | Deterministic, fail-closed decisions at agent-loop intervention points, with Rego and Cedar support | Prefer compatibility or contribution over inventing another generic policy language. Vouch Runtime's value must be stateful enforcement and transaction semantics around a policy decision. |
+| Fleet governance/control tower | [ServiceNow AI Control Tower](https://www.servicenow.com/uk/products/ai-control-tower.html), [IBM Agentic Control Plane](https://www.ibm.com/products/watsonx-orchestrate/agent-control-plane) | Discovery, inventory, governance, monitoring, policy, cost, audit and kill controls | A dashboard called “Agent Control Plane” is not an open market. |
+| Durable agent runtime | [LangSmith Deployment](https://www.langchain.com/langsmith/deployment) | Durable execution, human approval, fault tolerance, task queues, registry and rollback | Vouch should not compete as a general agent host or scheduler. |
+| Process orchestration | [Camunda agent orchestration](https://camunda.com/orchestrate/agents/) | Vendor-neutral BPMN sequences, tool permissions, durable state, human tasks, audit, retry, compensation and many connectors | This is serious overlap. Vouch must work beneath or beside workflow engines and protect open-ended proposed effects, rather than replace deterministic process orchestration. |
+| Native coding-agent controls | [GitHub Agentic Workflows](https://docs.github.com/en/enterprise-cloud@latest/copilot/concepts/agents/about-github-agentic-workflows), [Copilot cloud-agent mitigations](https://docs.github.com/en/enterprise-cloud@latest/copilot/concepts/agents/cloud-agent/risks-and-mitigations) | Firewalled agents, read-only defaults, isolated credentials, declared write outputs, protected branches and mandatory human merge | GitHub is a useful connector testbed, but a protected PR alone is not yet a compelling standalone product. |
+| Semantic transaction research | [Cordon](https://arxiv.org/abs/2606.17573), [Mnemosyne](https://arxiv.org/abs/2607.00269) | Task-scoped staged effects, composed-flow validation, authority separation, recovery and compensation | The architecture has strong independent validation, but the concept itself is not a moat. |
+
+A near-direct startup should also be benchmarked:
+[Prove7](https://prove7.ai/platform) markets a self-hosted governed execution
+layer with declared intent, policy, approvals, budgets, a kill switch, durable
+steps and audit. Those are vendor claims and its maturity is unverified, but
+they make a generic identity-plus-policy runtime insufficiently distinct.
+
+## The remaining defensible wedge
+
+Vouch should specialize in **connector-specific outcome integrity for
+open-ended agent work**:
+
+- evaluate ordered effects across actions, runs, systems and delegated
+  identity lineage;
+- stage or hold effects before they become public;
+- bind exact state, postconditions and unresolved risk into approval;
+- commit with connector-specific compare-and-swap and idempotency;
+- distinguish applied, failed and unknown external outcomes;
+- reconcile unknown outcomes before retry;
+- coordinate compensation without claiming universal rollback;
+- emit a replayable evidence chain from sponsor intent to committed outcome.
+
+This is narrower than the complete Vouch Agent OS, a gateway or a workflow
+engine. It is also a claim that must be demonstrated against substitutes rather
+than asserted.
+
+Vouch should integrate instead of replace:
+
+- Entra, Okta, OIDC and workload identity for principals;
+- Microsoft ACS, Cedar or OPA for ordinary deterministic policy;
+- Camunda or Temporal for explicitly modeled business workflows;
+- MCP and A2A for communication;
+- OpenTelemetry for observations;
+- [Google AP2](https://cloud.google.com/blog/products/ai-machine-learning/announcing-agents-to-payments-ap2-protocol)
+  for signed payment intent and mandates.
+
+## Important corrections to the initial examples
+
+### Accounts payable
+
+The dangerous vendor-bank-invoice-payment sequence is a useful illustration of
+composed authority, but it is not proof of an untouched market. SAP already
+documents
+[segregation-of-duties controls for vendor and payment processing](https://help.sap.com/docs/SAP_ACCESS_CONTROL/5cae1bc9a72348389e91183714220e30/4e8cb94820ff0867e10000000a421bc1.html).
+The Vouch hypothesis must instead concern cross-system, cross-session or common
+delegation-lineage effects that existing ERP controls cannot correlate. That
+gap needs validation with SAP GRC and finance-control practitioners before AP
+becomes a flagship use case.
+
+### GitHub
+
+GitHub already isolates coding agents, restricts their branch access, keeps
+credentials outside agent runtimes, and supports
+[required checks and stale-approval dismissal](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/available-rules-for-rulesets).
+GitHub should initially prove Vouch's connector, receipt and reconciliation
+model. It becomes a commercial wedge only if a customer values the additional
+task authority and cross-system evidence enough to pay for it.
+
+## Does the current repository solve the problem?
+
+The repository proves meaningful ingredients:
+
+- isolated daemon-owned agent and verifier execution;
+- immutable Git staging and exact-state verification;
+- an ordered effect ledger and sequence findings;
+- digest-bound independent approvals;
+- durable events and crash reconciliation;
+- credential-isolated model access;
+- compare-and-swap local Git publication.
+
+It does not yet prove the intended Runtime enforcement boundary:
+
+- the production transaction path does not create the existing durable
+  `AgentRun` or bind an `ExecutionContract` and compiled capability grants;
+- task budgets, lineage, data boundaries and release scope are not one atomic
+  authority envelope;
+- lifecycle controls do not yet interrupt a running production OCI workload;
+- there is no connector driver interface or external production connector;
+- sequence policy does not span transactions, sessions or identity lineage;
+- there is no Runtime fleet or Vouch Control Plane.
+
+The current implementation is therefore a strong local mechanism prototype,
+not yet evidence that customers will adopt or pay for the broader system.
+
+## Falsifiable product hypotheses
+
+| Hypothesis | Test | Evidence required to continue |
+| --- | --- | --- |
+| **H1: withheld authority is a top-three blocker.** | Interview 20 enterprises with live agent pilots about the last workflow they refused to automate. Do not pitch first. | At least 8 name consequential write authority as a top-three blocker, 5 produce a recent high-value refused workflow and 3 accept a scoped pilot. |
+| **H2: customers will accept non-bypassable mediation.** | Diagram the required credential and network changes and ask for monitor-mode or sandbox integration. | At least 3 organizations agree to remove scoped credentials from the agent and route the relevant writes through Vouch Runtime; otherwise the enforcement model is operationally unacceptable. |
+| **H3: transaction control adds value beyond IAM, gateways and workflow engines.** | Reconstruct ten workflows using the customer's existing Entra/Okta, gateway, native application controls and Camunda/Temporal controls. | At least 6 require bespoke stateful glue to cover a material composed-effect, exact-state or recovery gap. |
+| **H4: connector-specific staging and reconciliation are valuable.** | Demonstrate injected failures before dispatch, after external application and before receipt. | The buyer considers duplicate-effect prevention and exact recovery evidence important enough to influence deployment approval. |
+| **H5: Vouch expands permission safely.** | Run a design-partner pilot. | At least 20 real transactions, including 5 tasks the customer previously allowed an agent only to suggest; zero duplicate or unattributed effects. |
+| **H6: native alternatives are insufficient.** | Run side-by-side designs against the relevant GitHub, AWS, MuleSoft, Camunda or ERP controls. | Customers identify a material missing guarantee and choose Vouch despite the additional mediation boundary. |
+| **H7: there is willingness to pay.** | Offer a time-bounded paid pilot before building the Vouch Control Plane. | At least two paid pilots, not only free design partnerships. |
+
+Stop or reposition if customers are satisfied by native platform controls, will
+not route authority through Vouch, cannot name a material cross-action problem,
+or treat the receipts and recovery guarantees as compliance nice-to-haves.
+
+## Direction decision
+
+Proceed with:
+
+1. one coherent, stateful Runtime kernel path;
+2. an authenticated agent action protocol and durable connector coordinator;
+3. lineage-aware policy across runs, transactions and systems;
+4. GitHub as the first technical driver, not an assumed standalone market;
+5. rapid Kubernetes and PostgreSQL follow-through toward one cross-system
+   release transaction;
+6. customer discovery and paid-pilot tests in parallel.
+
+Do not build the Vouch Control Plane, a new identity system, a new generic
+policy language, a workflow engine or a connector marketplace until the paid
+evidence exists.

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -1,9 +1,8 @@
 # Agent Transactions
 
-Vouch's transaction runtime is the executable Agent Transaction Control path.
-Its development profile supports local exploration; its supported enforcement
-profile is deliberately limited to a single-node, single-tenant local-Git
-runtime.
+Vouch Runtime provides the executable transaction path. Its development
+profile supports local exploration; its supported enforcement profile is
+deliberately limited to a single-node, single-tenant local-Git runtime.
 
 The complete implemented lifecycle is:
 

--- a/docs/architecture/ADR-001-agent-kernel-boundary.md
+++ b/docs/architecture/ADR-001-agent-kernel-boundary.md
@@ -10,10 +10,10 @@ Vouch currently compiles human-owned release intent into typed specifications,
 stable obligations, verification plans, evidence requirements, and release
 decisions. That runtime begins near the end of an agent-authored change.
 
-Moving toward an agent operating system requires Vouch to govern the execution
-that produces the change without becoming the component that reasons about how
-to implement it. The architectural risk is collapsing four separate concerns
-into one service:
+Moving toward the Vouch Agent OS requires the customer-side Runtime to govern
+the execution that produces the change without becoming the component that
+reasons about how to implement it. The architectural risk is collapsing four
+separate concerns into one service:
 
 - Agent reasoning and planning.
 - Durable execution and scheduling.
@@ -21,13 +21,16 @@ into one service:
 - Contract, evidence, and release policy.
 
 The authority boundary must remain deterministic even when the agent, model,
-tool, runtime adapter, or external data is malicious or simply wrong.
+tool, agent adapter, or external data is malicious or simply wrong.
 
 ## Decision
 
-Vouch will be a user-space agent kernel and control plane. It will run above a
-host operating system and integrate with existing agent runtimes, sandboxes,
-identity systems, durable execution engines, and protocols.
+Vouch Runtime will contain the `vouchd` user-space kernel inside a
+customer-side enforcement boundary. It will run above a host operating system
+and integrate with existing agent frameworks, sandboxes, identity systems,
+durable execution engines and protocols. The organization-wide Vouch Control
+Plane will manage Runtime fleets; it is not the local kernel described by this
+ADR.
 
 Vouch owns:
 
@@ -35,7 +38,7 @@ Vouch owns:
 - Agent run identity, lineage, and lifecycle state.
 - Capability and delegation semantics.
 - Admission and action policy decisions.
-- Side-effect mediation through typed resource drivers.
+- Side-effect mediation through typed connector drivers.
 - Checkpoint, event, evidence, and audit semantics.
 - Human approval as a durable kernel operation.
 - Explanation of why work may advance.
@@ -53,9 +56,9 @@ Those systems connect through adapters. An adapter may report observations and
 request actions; it cannot create authoritative decisions, capabilities, or
 committed action receipts.
 
-## Control plane
+## `vouchd` authority subsystem
 
-The control plane is authoritative for:
+The local `vouchd` authority subsystem is authoritative for:
 
 - `AgentImage`
 - `ExecutionContract`
@@ -67,21 +70,23 @@ The control plane is authoritative for:
 - Human approvals
 - Materialized run state
 
-Control-plane writes occur through validated APIs. Each accepted change emits
+Authority-plane writes occur through validated APIs. Each accepted change emits
 an append-only event. Materialized state is a projection that must be
 reconstructable from the accepted event sequence.
 
-## Data plane
+## Runtime workload and connector subsystems
 
-The data plane contains:
+The Runtime workload and connector subsystems contain:
 
-- Runtime adapters that host or connect to agent loops.
-- Resource drivers that perform filesystem, process, MCP, GitHub, database, or
-  cloud operations.
+- Agent adapters that host or connect to agent loops.
+- Connector drivers that perform typed filesystem, process, MCP, GitHub,
+  database, or cloud operations.
 - Sandboxes and per-run workspaces.
 - Artifact and checkpoint storage.
 
-The data plane is replaceable and untrusted from the kernel's perspective.
+Agent sandboxes and adapters are untrusted from the kernel's perspective.
+Connector drivers execute privileged operations and therefore belong to the
+documented Runtime trust boundary.
 
 ## Enforcement sequence
 
@@ -95,7 +100,7 @@ agent or adapter
   -> policy evaluation
   -> deny | require approval | authorize
   -> persist decision
-  -> resource driver execution
+  -> connector driver execution
   -> persist receipt or mark result unknown
   -> link evidence and update run projection
 ```
@@ -108,13 +113,13 @@ be reconciled instead of retried blindly.
 ## Complete mediation
 
 Vouch can only claim authority over resources reached through its broker. A
-runtime that also possesses direct credentials or unrestricted host access can
-bypass the kernel.
+Runtime whose agent sandbox also possesses direct credentials or unrestricted
+host access can bypass the kernel.
 
 Therefore:
 
 - Production adapters receive no ambient privileged credentials.
-- Resource credentials are acquired by drivers after authorization.
+- Connector credentials are acquired by connector drivers after authorization.
 - Sandboxes restrict direct filesystem, process, and network escape paths.
 - Protocol integrations are exposed as typed driver operations, not raw
   passthrough connections.
@@ -129,10 +134,11 @@ The first implementation is local and single-node:
 - HTTP-framed control API over a mode-`0600` Unix socket.
 - SQLite transactions for events and materialized state.
 - Execution contracts compiled into time-bounded capability grants.
-- Traversal-resistant filesystem driver scoped to a per-run workspace.
+- Traversal-resistant filesystem connector driver scoped to a per-run
+  workspace.
 
-Local content-addressed artifacts, checkpoints, and a subprocess runtime
-adapter remain subsequent milestones.
+Local content-addressed artifacts, checkpoints and a subprocess agent adapter
+remain subsequent milestones.
 
 Distributed scheduling, PostgreSQL, external object storage, and remote
 identity are deferred until local crash and mediation invariants are proven.
@@ -151,13 +157,13 @@ daemon, CLI, and external adapters
 
 The existing contract compiler and evidence runtime remain independent of the
 daemon. The kernel calls them through narrow interfaces; compiler packages do
-not import storage, daemon, or runtime-adapter packages.
+not import storage, daemon or agent-adapter packages.
 
 ## Consequences
 
 Positive:
 
-- Vouch remains runtime- and model-independent.
+- Vouch remains agent-framework- and model-independent.
 - Deterministic policy stays outside probabilistic reasoning.
 - The existing compiler/evidence investment becomes a kernel subsystem.
 - Local invariants can be proven before distributed complexity is introduced.
@@ -165,11 +171,12 @@ Positive:
 
 Costs:
 
-- Useful operations require broker and driver coverage.
+- Useful operations require broker and connector-driver coverage.
 - Complete mediation depends on sandbox and credential configuration outside
   Vouch itself.
 - Event compatibility and recovery become long-term public contracts.
-- Driver reconciliation is required for ambiguous non-idempotent effects.
+- Connector-specific reconciliation is required for ambiguous non-idempotent
+  effects.
 
 ## Rejected alternatives
 

--- a/docs/architecture/ADR-002-agent-transaction-control.md
+++ b/docs/architecture/ADR-002-agent-transaction-control.md
@@ -65,9 +65,12 @@ engine, or universal rollback mechanism. It consumes identity and credentials
 from existing systems, governs agents from existing runtimes, and represents
 partial failure honestly.
 
-The immediate category name is **Agent Transaction Control**. “Agent OS” is the
-long-term system description only when Vouch owns a non-bypassable transaction
-boundary across the important resources in a workflow.
+The first sellable product is **Vouch Runtime — transaction and outcome control
+for autonomous-agent actions**. **Vouch Agent OS** names the complete
+architecture: a Control Plane plus a fleet of customer-side Runtimes, the
+transaction protocol and the connector model. An external complete-enterprise
+claim requires both non-bypassable multi-system Runtime enforcement and
+demonstrated fleet-level Control Plane operation.
 
 ## Resource boundaries
 

--- a/docs/architecture/KERNEL_SEMANTICS.md
+++ b/docs/architecture/KERNEL_SEMANTICS.md
@@ -57,7 +57,8 @@ Rules:
 
 - `denied`, `rejected`, `expired`, `committed`, and `failed` are terminal.
 - `unknown` is not success or failure. It means an effect may have occurred and
-  requires driver reconciliation or human resolution.
+  requires connector-specific reconciliation coordinated by `vouchd` or human
+  resolution.
 - Authorization is persisted before `executing`.
 - `committed` requires a validated receipt.
 - A request's normalized argument digest is immutable. A changed request needs
@@ -102,7 +103,7 @@ field. Human text may improve without changing the code.
 | `KERNEL_CHECKPOINT_INCOMPATIBLE` | Checkpoint cannot resume under current versions. |
 | `KERNEL_NOT_FOUND` | Requested kernel resource does not exist in the caller's namespace. |
 | `KERNEL_CONFLICT` | Optimistic concurrency or lease ownership failed. |
-| `KERNEL_DRIVER_UNAVAILABLE` | Required resource driver cannot accept work. |
+| `KERNEL_DRIVER_UNAVAILABLE` | Required connector driver cannot accept work. |
 | `KERNEL_INTERNAL` | Unexpected trusted-kernel failure. |
 
 Unknown or internal errors fail closed at admission and action boundaries.

--- a/docs/architecture/NORTH_STAR_DEMO.md
+++ b/docs/architecture/NORTH_STAR_DEMO.md
@@ -1,12 +1,30 @@
-# Agent Kernel North-Star Demonstration
+# Vouch Runtime Kernel North-Star Demonstration
 
-## Claim
+## Status
 
-Vouch can durably govern one untrusted coding agent through a complete action,
-approval, restart, evidence, and release path.
+This is a **target acceptance scenario**, not one currently executable path.
 
-The demonstration validates control-plane behavior. It does not claim that the
-agent's implementation is correct or that Vouch can infer arbitrary intent.
+The repository implements its pieces in two adjacent paths:
+
+- The supported transaction path runs an OCI agent, stages immutable local Git
+  effects, validates their sequence, runs daemon-owned verification, binds
+  signed approvals and publishes to an allowed local ref.
+- The lower-level kernel path models `AgentRun`, `ExecutionContract`,
+  capabilities and brokered filesystem actions, but it is disabled by the
+  production profile and is not created by `vouch run`.
+
+The roadmap's OS-2 through OS-7 work converges those paths before this document
+becomes an executable end-to-end acceptance test.
+
+## Target claim
+
+Vouch Runtime will durably govern one untrusted coding agent through a complete
+action, approval, restart, evidence and release path.
+
+The demonstration validates kernel authority and transaction behavior. It does
+not validate the future organization-wide Vouch Control Plane, claim that the
+agent's implementation is correct or claim that Vouch can infer arbitrary
+intent.
 
 ## Fixture
 
@@ -74,6 +92,8 @@ The fixture contains:
 
 ## Delivery sequence
 
-The scenario remains checked in before all steps are executable. Each kernel
-milestone converts another section from `pending` to an automated assertion.
-The final scenario is not replaced by easier component-only demonstrations.
+The scenario remains checked in before all steps are executable. Each
+kernel/Runtime milestone converts another section from target to an automated
+assertion. The final scenario is not replaced by easier component-only
+demonstrations, and the README and production guide must not present target
+steps as implemented.

--- a/docs/architecture/THREAT_MODEL.md
+++ b/docs/architecture/THREAT_MODEL.md
@@ -3,7 +3,7 @@
 ## Scope
 
 This threat model covers the agent-kernel architecture described in
-`ADR-001-agent-kernel-boundary.md`. It focuses on control-plane authority,
+`ADR-001-agent-kernel-boundary.md`. It focuses on kernel authority,
 resource mediation, durable execution, evidence, and audit.
 
 The model does not claim that Vouch can make an arbitrary model correct. It
@@ -21,7 +21,7 @@ this first driver and remains outside the complete-mediation claim.
 - Human and service authority delegated to an agent run.
 - Source code, repositories, filesystems, and workspaces.
 - Credentials, tokens, signing keys, and identity documents.
-- External systems reached through resource drivers.
+- External systems reached through connector drivers.
 - Contracts, policies, capability grants, and approval decisions.
 - Run state, checkpoints, memory, evidence, and artifacts.
 - Event-history integrity and attribution.
@@ -48,13 +48,13 @@ diagnosis and recovery.
 
 - Model output and generated code.
 - Agent reasoning loops.
-- Runtime adapters.
+- Agent adapters.
 - Child and remote agents.
 - MCP/A2A servers and external tools.
 - Web pages, repository contents, messages, retrieved documents, and memory
   candidates.
 - Evidence supplied by the run until provenance and artifact checks succeed.
-- Resource-driver responses until validated and recorded.
+- Connector-driver responses until validated and recorded.
 - Human-authored inputs that do not carry authenticated authority.
 
 ### Administrative trust
@@ -66,7 +66,7 @@ authority.
 ## Attacker models
 
 1. A prompt-injected agent tries to exceed its task.
-2. A compromised runtime adapter forges events or claims an action succeeded.
+2. A compromised agent adapter forges events or claims an action succeeded.
 3. A malicious tool returns instructions intended to change the agent's goal.
 4. A child agent attempts to escalate beyond its parent's delegation.
 5. A tenant tries to read another tenant's run, memory, or credentials.

--- a/docs/architecture/TRANSACTION_THREAT_MODEL.md
+++ b/docs/architecture/TRANSACTION_THREAT_MODEL.md
@@ -39,10 +39,16 @@ Initial required scenarios:
 
 ```text
 change security control -> change its test -> release
-create vendor -> change bank details -> initiate payment
+create vendor in one system -> change bank details in another
+  -> initiate payment under the same delegated lineage
 modify migration -> delete protected data -> deploy
 grant permission -> consume newly granted permission in the same transaction
 ```
+
+ERP products already provide native segregation-of-duties controls for common
+same-user vendor and payment conflicts. The finance scenario tests correlation
+across systems, sessions, agents or a shared delegation lineage; it must not be
+used to imply that native ERP controls do not exist.
 
 ## Stage escape and hidden effects
 
@@ -53,9 +59,9 @@ endpoint while Vouch records only the staged copy.
 
 Controls:
 
-- Remove ambient production credentials from the runtime.
-- Give the runtime access to transaction-scoped worktrees, clones, namespaces,
-  and credentials only.
+- Remove ambient production credentials from the agent sandbox.
+- Give Vouch Runtime connector drivers access only to transaction-scoped
+  worktrees, clones, namespaces and credentials.
 - Restrict egress to broker endpoints and explicit read-only sources.
 - Compare staged resources and broker receipts to expected effect inventory.
 - Mark deployments without complete mediation as monitor-only.
@@ -132,7 +138,8 @@ released before verification and approval.
 
 Controls:
 
-- Irreversible drivers implement prepare/hold and explicit release operations.
+- Connector drivers handling irreversible effects implement prepare/hold and
+  explicit release operations.
 - The transaction coordinator rejects irreversible effects whose connector
   cannot provide a reliable hold boundary.
 - Release requires a fresh approval-package digest and commit authorization.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,7 +1,8 @@
-# Vouch Runtime
+# Vouch
 
-Vouch Runtime is the transaction runtime for autonomous software agents. It
-controls the boundary between an agent's proposal and a real effect:
+Vouch is the transaction operating layer for autonomous software agents. Its
+customer-side Runtime controls the boundary between an agent's proposal and a
+real effect:
 
 ```text
 intent
@@ -14,19 +15,21 @@ intent
 ```
 
 Vouch does not decide how an agent reasons or writes code. The trusted local
-kernel, `vouchd`, owns execution, durable transaction state, verification,
-authority and commit.
+kernel, `vouchd`, orchestrates sandboxed execution and owns authoritative
+transaction state, verification, policy decisions and commit coordination.
 
 ## Product hierarchy
 
-- **Vouch Runtime** is the current product.
-- **`vouchd`** is its trusted transaction kernel.
+- **Vouch Agent OS** is the complete target architecture: the Control Plane,
+  Runtime fleet, transaction protocol and connector model. It is an umbrella,
+  not another process.
+- **Vouch Control Plane** is the planned commercial management layer for
+  Runtime fleets, organization policy, approvals, audit and incident response.
+- **Vouch Runtime** is the deployable customer-side enforcement boundary. A
+  narrow single-node local-Git profile is implemented today.
+- **`vouchd`** is the trusted transaction kernel inside each Runtime.
 - **Vouch Contracts** is an optional verification module that compiles release
   intent into obligations and maps evidence to them.
-- **Vouch Control Plane** is the future commercial management layer for fleets,
-  organization policy, approvals, audit and enterprise connectors.
-- **Agent OS** is the long-term north star, not a claim about the current
-  implementation.
 
 ## Try the runtime
 
@@ -95,4 +98,4 @@ Contracts and evidence enrich runtime verification and approval. They are not a
 generic AI code reviewer and do not prove arbitrary code correct.
 
 Use the **Contracts** navigation only when working with that optional module.
-The runtime and `vouchd` remain the product center.
+Vouch Runtime is the current product; `vouchd` is its trusted kernel.

--- a/skills.md
+++ b/skills.md
@@ -1,11 +1,14 @@
-# Vouch Runtime Operating Brief
+# Vouch Product Operating Brief
 
 Use this brief when choosing roadmap work, designing features, writing docs or
 describing Vouch.
 
 ## Product identity
 
-Vouch Runtime is the transaction runtime for autonomous agents.
+Vouch is the product name. **Vouch Agent OS** is the complete target
+architecture: the Vouch Control Plane plus a fleet of customer-side Vouch
+Runtimes. **Vouch Runtime** is the first sellable product and the enforcement
+boundary for autonomous-agent actions.
 
 Its job is to make an agent task a controlled transaction:
 
@@ -26,17 +29,22 @@ own the agent's planning, prompting or reasoning loop.
 
 Keep these names distinct:
 
-- **Vouch Runtime**: the current product.
-- **`vouchd`**: the trusted transaction kernel inside the runtime.
+- **Vouch Agent OS**: the complete architecture containing the Control Plane,
+  Runtime fleet, transaction protocol and connector model. It is an umbrella,
+  not a process.
+- **Vouch Control Plane**: the future central manager for Runtime fleets,
+  organization policy, approval routing, audit and incident response. It
+  manages connector configuration but does not execute downstream actions.
+- **Vouch Runtime**: the current product and customer-side enforcement
+  boundary.
+- **`vouchd` kernel**: the trusted authority and transaction engine inside each
+  Runtime.
 - **Vouch Contracts**: an optional module that compiles release intent into
   verification obligations and maps evidence to them.
-- **Vouch Control Plane**: a future commercial layer for managing runtime
-  fleets, policy, approvals, connectors, audit and enterprise operations.
-- **Agent OS**: the long-term north star, not a claim about the current
-  single-node implementation.
 
 Never describe Vouch Contracts as the whole product. Never describe the current
-runtime as a complete Agent OS or a production multi-tenant control plane.
+Vouch Runtime as a complete Vouch Agent OS or a production multi-tenant Vouch
+Control Plane.
 
 ## Runtime boundary
 
@@ -116,18 +124,22 @@ Avoid:
 
 Use:
 
-- “transaction runtime for autonomous agents”
+- “Vouch Runtime — transaction and outcome control for autonomous-agent
+  actions”
 - “the controlled boundary between an agent proposal and a real effect”
-- “agent transaction kernel”
+- “`vouchd` kernel” for the trusted authority and transaction engine
 - “isolated, verified and authorized agent execution”
 - “Vouch Runtime”
+- “Vouch Agent OS” for the complete Control Plane plus Runtime-fleet
+  architecture
 - “Vouch Contracts” when referring specifically to the optional compiler
 
 Use carefully:
 
-- “Agent Transaction Control” as the technical category.
-- “Agent OS” only as the north star.
-- “Control Plane” only for the future fleet-management product.
+- “enterprise Agent OS” as an external completeness claim only after
+  multi-system Runtime enforcement and fleet-level Control Plane operation are
+  implemented.
+- “Control Plane” only for the central fleet-management product.
 
 Avoid primary positioning as:
 
@@ -163,7 +175,7 @@ it.
    targets into task creation.
 3. Deliver one deep remote-Git/GitHub connector and approval experience.
 4. Prove paid design-partner demand for fleet policy, audit and approvals.
-5. Build the Control Plane around self-hosted runtimes.
+5. Build the Vouch Control Plane around customer-side Vouch Runtimes.
 6. Add Kubernetes and PostgreSQL transaction packs only after Git release and
    reconciliation are deep.
 


### PR DESCRIPTION
## What changed

- Defines one canonical hierarchy: Vouch Agent OS → Vouch Control Plane +
  Vouch Runtime → `vouchd` kernel.
- Distinguishes the implemented single-node local-Git Runtime slice from the
  target architecture.
- Adds an evidence-backed product and competitive assessment with explicit
  commercial hypotheses.
- Replaces the roadmap with bounded workstreams for atomic authority, data
  boundaries, supervision, connector coordination, the authenticated action
  protocol, lineage-aware policy, external connectors, operations, and the
  future Control Plane.
- Normalizes terminology across architecture, operations, security, comparison,
  contributor, and maintainer guidance.

## Why

The repository used OS, Runtime, kernel, and Control Plane inconsistently and
described target capabilities beside implemented behavior. That made the
product boundary and next engineering sequence difficult to evaluate.

The updated docs keep Vouch Runtime as the first product, reserve Vouch Agent OS
for the complete architecture, and gate broader claims on multi-system
enforcement, fleet management, and paid evidence.

## Impact

Documentation and planning only. No runtime behavior or public schema changes.

## Validation

- `go test ./...`
- `mkdocs build --strict`
- `git diff --check`
- Repo-wide stale-terminology scan
