### PR TITLE
ci: focus pull request validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,16 +1,21 @@
-name: CI
+name: Full validation
 
 on:
-  pull_request:
   push:
     branches:
       - main
+  schedule:
+    - cron: "17 3 * * *"
+  release:
+    types:
+      - published
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.ref }}
+  group: full-validation-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,141 @@
+name: PR validation
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: PR validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Verify validation routing
+        run: scripts/vouchci-plan-test.sh
+
+      - name: Select affected validation
+        id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          merge_base="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          git diff --name-only --no-renames "$merge_base" "$HEAD_SHA" \
+            > "$RUNNER_TEMP/vouch-changed-files"
+          scripts/vouchci-plan.sh --paths "$RUNNER_TEMP/vouch-changed-files" \
+            >> "$GITHUB_OUTPUT"
+
+      - name: Check formatting
+        run: |
+          files="$(gofmt -l .)"
+          if [ -n "$files" ]; then
+            echo "Go files need gofmt:"
+            echo "$files"
+            exit 1
+          fi
+
+      - name: Check module tidiness
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Run go vet
+        run: go vet ./...
+
+      - name: Run unit tests
+        run: go test ./...
+
+      - name: Set up Python for documentation
+        if: steps.plan.outputs.docs == 'true'
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: docs/requirements.txt
+
+      - name: Build documentation
+        if: steps.plan.outputs.docs == 'true'
+        run: |
+          python -m pip install -r docs/requirements.txt
+          mkdocs build --strict
+
+      - name: Run VouchBench
+        if: steps.plan.outputs.vouchbench == 'true'
+        run: scripts/vouchbench.sh --out /tmp/vouch-pr-validation/vouchbench
+
+      - name: Run VouchKernelBench
+        if: steps.plan.outputs.kernelbench == 'true'
+        run: scripts/vouchkernelbench.sh --out /tmp/vouch-pr-validation/kernelbench
+
+      - name: Run VouchTransactionBench
+        if: steps.plan.outputs.transactionbench == 'true'
+        run: scripts/vouchtransactionbench.sh
+
+      - name: Run VouchRuntimeBench
+        if: steps.plan.outputs.runtimebench == 'true'
+        run: scripts/vouchruntimebench.sh
+
+      - name: Verify Docker
+        if: steps.plan.outputs.production == 'true'
+        run: |
+          docker version
+          command -v curl
+          command -v jq
+
+      - name: Build local production fixture image
+        if: steps.plan.outputs.production == 'true'
+        id: fixture
+        run: |
+          image="$(scripts/vouchproductionfixture.sh \
+            --tag "vouch-production-fixture:${GITHUB_SHA}")"
+          echo "image=$image" >> "$GITHUB_OUTPUT"
+
+      - name: Run production OCI acceptance
+        if: steps.plan.outputs.production == 'true'
+        env:
+          VOUCH_PRODUCTION_IMAGE: ${{ steps.fixture.outputs.image }}
+        run: scripts/vouchproductionbench.sh
+
+      - name: Summarize validation plan
+        if: always()
+        env:
+          DOCS: ${{ steps.plan.outputs.docs }}
+          VOUCHBENCH: ${{ steps.plan.outputs.vouchbench }}
+          KERNELBENCH: ${{ steps.plan.outputs.kernelbench }}
+          TRANSACTIONBENCH: ${{ steps.plan.outputs.transactionbench }}
+          RUNTIMEBENCH: ${{ steps.plan.outputs.runtimebench }}
+          PRODUCTION: ${{ steps.plan.outputs.production }}
+          CHANGED_COUNT: ${{ steps.plan.outputs.changed_count }}
+        run: |
+          {
+            echo "### PR validation plan"
+            echo
+            echo "Changed paths: ${CHANGED_COUNT:-unknown}"
+            echo
+            echo "| Validation | Selected |"
+            echo "| --- | --- |"
+            echo "| Go format, tidy, vet and unit tests | always |"
+            echo "| Strict documentation build | ${DOCS:-unknown} |"
+            echo "| VouchBench | ${VOUCHBENCH:-unknown} |"
+            echo "| VouchKernelBench | ${KERNELBENCH:-unknown} |"
+            echo "| VouchTransactionBench | ${TRANSACTIONBENCH:-unknown} |"
+            echo "| VouchRuntimeBench | ${RUNTIMEBENCH:-unknown} |"
+            echo "| Production OCI boundary | ${PRODUCTION:-unknown} |"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/vouchci-plan-test.sh
+++ b/scripts/vouchci-plan-test.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLANNER="$ROOT/scripts/vouchci-plan.sh"
+TEST_DIR="$(mktemp -d "${TMPDIR:-/tmp}/vouchci-plan-test.XXXXXX")"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+run_plan() {
+  local name="$1"
+  shift
+  printf '%s\n' "$@" > "$TEST_DIR/$name.paths"
+  "$PLANNER" --paths "$TEST_DIR/$name.paths"
+}
+
+assert_output() {
+  local output="$1"
+  local expected="$2"
+  if ! grep -qx "$expected" <<< "$output"; then
+    echo "vouchci-plan-test: expected '$expected' in:" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+}
+
+touch "$TEST_DIR/empty.paths"
+if "$PLANNER" --paths "$TEST_DIR/empty.paths" >/dev/null 2>&1; then
+  echo "vouchci-plan-test: an empty change set must fail closed" >&2
+  exit 1
+fi
+
+docs_plan="$(run_plan docs docs/PRODUCTION.md README.md)"
+assert_output "$docs_plan" "docs=true"
+assert_output "$docs_plan" "vouchbench=false"
+assert_output "$docs_plan" "production=false"
+
+contracts_plan="$(run_plan contracts internal/vouch/compiler.go demo_repo/README.md)"
+assert_output "$contracts_plan" "vouchbench=true"
+assert_output "$contracts_plan" "kernelbench=false"
+assert_output "$contracts_plan" "production=false"
+
+kernel_plan="$(run_plan kernel internal/kernel/identity/oidc.go)"
+assert_output "$kernel_plan" "runtimebench=true"
+assert_output "$kernel_plan" "kernelbench=false"
+assert_output "$kernel_plan" "transactionbench=false"
+assert_output "$kernel_plan" "production=true"
+
+broker_plan="$(run_plan broker internal/kernel/broker/broker.go)"
+assert_output "$broker_plan" "kernelbench=true"
+assert_output "$broker_plan" "transactionbench=false"
+assert_output "$broker_plan" "runtimebench=false"
+
+transaction_plan="$(run_plan transaction internal/kernel/transaction/prepare.go)"
+assert_output "$transaction_plan" "kernelbench=false"
+assert_output "$transaction_plan" "transactionbench=true"
+assert_output "$transaction_plan" "runtimebench=false"
+
+schema_plan="$(run_plan schema schemas/vouch.agent_task.v0.schema.json)"
+assert_output "$schema_plan" "docs=true"
+assert_output "$schema_plan" "vouchbench=true"
+assert_output "$schema_plan" "production=true"
+
+critical_paths=(
+  internal/kernel/sandbox/oci.go
+  internal/kernel/identity/oidc.go
+  internal/vouch/approval_cli.go
+  internal/vouch/transaction_cli.go
+  build/production-fixture.Dockerfile
+  connectors/github/driver.go
+  .vouch/agent-profiles.json
+  .gitattributes
+  scripts/vouchci-plan.sh
+  .github/workflows/pr.yml
+  go.mod
+)
+critical_index=0
+for critical_path in "${critical_paths[@]}"; do
+  critical_plan="$(run_plan "critical-$critical_index" "$critical_path")"
+  assert_output "$critical_plan" "production=true"
+  critical_index=$((critical_index + 1))
+done
+
+unknown_plan="$(run_plan unknown connectors/github/driver.go)"
+assert_output "$unknown_plan" "vouchbench=true"
+assert_output "$unknown_plan" "kernelbench=true"
+
+echo "vouchci-plan-test: all routing cases passed"

--- a/scripts/vouchci-plan.sh
+++ b/scripts/vouchci-plan.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: scripts/vouchci-plan.sh --paths FILE
+
+Classifies changed repository paths for the focused pull-request validation
+workflow. The output is suitable for appending to GITHUB_OUTPUT.
+EOF
+}
+
+if [[ $# -ne 2 || "$1" != "--paths" ]]; then
+  usage >&2
+  exit 2
+fi
+
+paths_file="$2"
+if [[ ! -f "$paths_file" ]]; then
+  echo "vouchci-plan: path list does not exist: $paths_file" >&2
+  exit 2
+fi
+
+docs=false
+vouchbench=false
+kernelbench=false
+transactionbench=false
+runtimebench=false
+production=false
+changed_count=0
+
+select_runtime_acceptance() {
+  kernelbench=true
+  transactionbench=true
+  runtimebench=true
+}
+
+select_everything() {
+  vouchbench=true
+  select_runtime_acceptance
+  production=true
+}
+
+while IFS= read -r path || [[ -n "$path" ]]; do
+  [[ -n "$path" ]] || continue
+  changed_count=$((changed_count + 1))
+
+  case "$path" in
+    README.md|ROADMAP.md|CONTRIBUTING.md|SECURITY.md|LICENSE|LICENSE.*)
+      docs=true
+      ;;
+    docs/*|assets/*|mkdocs.yml)
+      docs=true
+      ;;
+    schemas/README.md)
+      docs=true
+      ;;
+    schemas/*)
+      docs=true
+      select_everything
+      ;;
+    demo_repo/*|benchmarks/results/vouchbench.*)
+      vouchbench=true
+      ;;
+    scripts/vouchbench.sh|scripts/vouchbench-repo.sh)
+      vouchbench=true
+      ;;
+    internal/vouch/artifacts.go|\
+    internal/vouch/bootstrap_cli_test.go|\
+    internal/vouch/compile.go|\
+    internal/vouch/compile_cli_test.go|\
+    internal/vouch/compiler.go|\
+    internal/vouch/contracts_cli.go|\
+    internal/vouch/contracts_cli_test.go|\
+    internal/vouch/diagnostics.go|\
+    internal/vouch/evidence*.go|\
+    internal/vouch/github_summary_test.go|\
+    internal/vouch/intent.go|\
+    internal/vouch/ir.go|\
+    internal/vouch/junit_map*.go|\
+    internal/vouch/load.go|\
+    internal/vouch/onboarding*.go|\
+    internal/vouch/plan.go|\
+    internal/vouch/policy.go|\
+    internal/vouch/render.go|\
+    internal/vouch/sarif.go|\
+    internal/vouch/try*.go|\
+    internal/vouch/types.go|\
+    internal/vouch/validate.go)
+      vouchbench=true
+      ;;
+    internal/kernel/broker/*|\
+    internal/kernel/capability/*|\
+    internal/kernel/client/*|\
+    internal/kernel/driver/*|\
+    internal/kernel/eventlog/*|\
+    internal/kernel/reducer/*)
+      kernelbench=true
+      production=true
+      ;;
+    internal/kernel/transaction/*|\
+    internal/kernel/api/transaction_handlers*|\
+    internal/kernel/model/transaction*|\
+    internal/kernel/store/transaction_store*)
+      transactionbench=true
+      production=true
+      ;;
+    internal/kernel/approval/*|\
+    internal/kernel/daemon/*|\
+    internal/kernel/identity/*|\
+    internal/kernel/model/agent_task*|\
+    internal/kernel/modelbroker/*|\
+    internal/kernel/sandbox/*|\
+    internal/kernel/verification/*)
+      runtimebench=true
+      production=true
+      ;;
+    internal/kernel/*)
+      runtimebench=true
+      production=true
+      ;;
+    internal/vouch/action_cli.go|internal/vouch/kernel_cli*.go)
+      kernelbench=true
+      production=true
+      ;;
+    internal/vouch/transaction_cli.go)
+      transactionbench=true
+      production=true
+      ;;
+    internal/vouch/approval_cli*.go|\
+    internal/vouch/daemon_cli.go|\
+    internal/vouch/identity_cli*.go|\
+    internal/vouch/transaction_profile_cli*.go|\
+    internal/vouch/transaction_run_cli*.go|\
+    internal/vouch/transaction_verify_cli*.go)
+      runtimebench=true
+      production=true
+      ;;
+    internal/vouch/cli.go)
+      vouchbench=true
+      runtimebench=true
+      production=true
+      ;;
+    cmd/vouchd/*|cmd/vouch-model-broker/*)
+      runtimebench=true
+      production=true
+      ;;
+    cmd/vouch/*)
+      select_everything
+      ;;
+    scripts/vouchkernelbench.sh)
+      kernelbench=true
+      production=true
+      ;;
+    scripts/vouchtransactionbench.sh)
+      transactionbench=true
+      production=true
+      ;;
+    scripts/vouchruntimebench.sh)
+      runtimebench=true
+      production=true
+      ;;
+    build/*|scripts/vouchproductionbench.sh|scripts/vouchproductionfixture.sh)
+      production=true
+      ;;
+    .gitignore|.editorconfig|CODEOWNERS|.github/CODEOWNERS)
+      ;;
+    *.md)
+      docs=true
+      ;;
+    *)
+      # Unknown code, configuration, workflow and executable paths fail closed.
+      select_everything
+      ;;
+  esac
+done < "$paths_file"
+
+if [[ "$changed_count" -eq 0 ]]; then
+  echo "vouchci-plan: no changed paths were supplied" >&2
+  exit 1
+fi
+
+printf 'docs=%s\n' "$docs"
+printf 'vouchbench=%s\n' "$vouchbench"
+printf 'kernelbench=%s\n' "$kernelbench"
+printf 'transactionbench=%s\n' "$transactionbench"
+printf 'runtimebench=%s\n' "$runtimebench"
+printf 'production=%s\n' "$production"
+printf 'changed_count=%s\n' "$changed_count"


### PR DESCRIPTION
## What changed

- Replace the eight-job pull-request fan-out with one stable `PR validation` check.
- Always run Go format, module, vet, and unit checks; run strict docs and the smallest affected acceptance harness only when relevant.
- Keep production OCI acceptance on every enforcement-sensitive Runtime change, with unknown executable paths failing closed.
- Move race, vulnerability, every-benchmark, production, and advisory collections to `main`, nightly, release, and manual full validation.
- Add executable routing tests covering docs-only, Contracts-only, broker, transaction, identity, sandbox, approval, release, schema, connector, workflow, dependency, and unknown paths.

## Why

Every PR currently starts eight separate checks, repeats setup and builds, and runs unrelated benchmark families even for documentation changes. The result is noisy and expensive without improving the review signal.

## Impact

Reviewers get one concise result. Typical changes run only the relevant scenario; security-critical Runtime changes still prove the real OCI enforcement boundary. Exhaustive coverage remains off the latency-sensitive PR path.

## Validation

- `scripts/vouchci-plan-test.sh`
- `bash -n scripts/vouchci-plan.sh scripts/vouchci-plan-test.sh`
- YAML parsing for all workflows
- formatting and module-tidiness checks
- `go vet ./...`
- `go test ./...`
- `git diff --check`
