### PR TITLE
feat(kernel): add atomic task admission

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,16 +60,17 @@ The operating-system analogy is precise:
 | **Vouch Agent OS** | The complete target architecture: Control Plane, Runtime fleet, transaction protocol and connector model. It is an umbrella, not a process. | Product direction |
 | **Vouch Control Plane** | Organization-wide fleet, policy, approval, audit and incident management. It manages Runtimes but does not execute agent actions. | Planned |
 | **Vouch Runtime** | The deployable enforcement boundary installed in a customer environment. It contains `vouchd`, agent sandboxes, local durable state and connector drivers. | Narrow single-node local-Git profile implemented |
-| **`vouchd` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Foundation implemented; production authority paths are not yet unified |
+| **`vouchd` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Atomic task admission implemented; execution and action enforcement are still converging |
 | **Agent sandbox** | The isolated, untrusted environment in which an agent loop executes. It receives no downstream production credentials. | OCI implementation available |
 | **Agent adapter** | Connects an existing agent framework or command to the kernel. It may request work and actions but cannot authorize itself or create receipts. | Command/profile and lower-level integration exist; supported broker API planned |
 | **Connector driver** | Performs typed operations against one downstream system after kernel authorization and reconciles external state. `vouchd` records authoritative receipts and coordinates recovery. | Rooted filesystem and local Git exist; common interface and remote connectors planned |
 | **Vouch Contracts** | Optional verification module that turns human-owned intent into evidence obligations used by Runtime policy. | Beta |
 
 The diagram states the intended ownership boundary, not a completion claim.
-Today the supported transaction path and the lower-level
-run/capability/action path are adjacent but not yet one authoritative
-lifecycle. Converging them is the first implementation milestone.
+Today `vouch run` atomically admits its task, content-bound contract, real run,
+initial grants and transaction. The OCI execution and lower-level brokered
+action path do not yet consume that authority as one synchronized lifecycle;
+that is the next Runtime milestone.
 
 Every consequential action must follow one authority path:
 
@@ -140,12 +141,14 @@ The public profile schema is
 with a complete
 [example profile](schemas/fixtures/runtime/valid/agent_profiles.json). Vouch
 binds the selected profile, final command, pinned image and exact task intent
-into a durable task envelope. Daemon-owned OCI agents receive that envelope
-read-only at `/vouch/task.json`.
+into a durable task envelope. Before launch, `vouchd` atomically admits that
+task with its derived execution contract, real run, initial grants and
+transaction. Daemon-owned OCI agents receive the task envelope read-only at
+`/vouch/task.json`.
 
-`vouch run` currently creates the transaction and worktree, runs the agent, freezes
-its Git effects, and performs deterministic sequence validation. Inspect the
-result with:
+`vouch run` then creates the isolated worktree, runs the agent, freezes its Git
+effects, and performs deterministic sequence validation. Inspect the result
+with:
 
 ```sh
 vouch --repo /path/to/service status <transaction-id> \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -59,20 +59,19 @@ The repository contains a substantial foundation:
 The supported profile remains one node, one security tenant and publication to
 an allowed local Git ref. It does not yet control a remote enterprise system.
 
-### Critical architecture gap
+### Next architecture gap
 
-The repository currently has two adjacent authority paths:
+The production `vouch run` path now uses one daemon-owned, idempotent admission
+operation to persist the exact `AgentTask`, content-bound
+`ExecutionContract`, real `AgentRun`, initial capability grants and
+`AgentTransaction` in one SQLite transaction.
 
-1. The production `vouch run` path creates an `AgentTask` and
-   `AgentTransaction`, executes an OCI workload and stages Git effects.
-2. The older kernel path owns `AgentRun`, `ExecutionContract`, capability
-   grants and brokered `ActionRequest` resources, but those endpoints are
-   disabled by the production profile.
-
-The production transaction therefore does not yet bind a real kernel run,
-contract, capabilities, lineage and task budgets into one authoritative
-lifecycle. Adding remote connectors before converging these paths would create
-connector-specific product logic around the wrong kernel boundary.
+Execution is not yet the same authority lifecycle. The OCI workload advances
+the transaction without advancing the admitted run or consuming its grants,
+budgets and data boundaries. The older brokered `ActionRequest` endpoints also
+remain disabled by the production profile. OS-3 must close that gap before
+remote connectors are added, or connector behavior would form a second
+authority path around the kernel.
 
 ## Execution principles
 

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -434,8 +434,9 @@ acceptable:
 - Verifiers use a private, read-only materialization of the exact frozen Git
   tree. The Git executable, object database, and host materialization path
   remain trusted operator-controlled inputs.
-- Legacy client-supervised execution/verification mutation APIs are disabled
-  in production, and the mediated filesystem API cannot access `.git` or
+- Legacy transaction creation and client-supervised execution/verification
+  mutation APIs are disabled in production; transaction authority begins at
+  atomic task admission. The mediated filesystem API cannot access `.git` or
   `.vouch` control state.
 - No claim of universal rollback. The implemented commit primitive is an
   atomic, version-checked Git-ref update.

--- a/docs/PRODUCT_VALIDATION.md
+++ b/docs/PRODUCT_VALIDATION.md
@@ -180,10 +180,12 @@ The repository proves meaningful ingredients:
 
 It does not yet prove the intended Runtime enforcement boundary:
 
-- the production transaction path does not create the existing durable
-  `AgentRun` or bind an `ExecutionContract` and compiled capability grants;
-- task budgets, lineage, data boundaries and release scope are not one atomic
-  authority envelope;
+- atomic admission now binds the retained task, a content-digest
+  `ExecutionContract`, a durable `AgentRun`, initial capability grants and the
+  transaction, but production OCI execution does not yet transition that run
+  or consume those grants;
+- budgets, lineage, data boundaries and release scope are therefore not yet
+  enforced as one synchronized execution lifecycle;
 - lifecycle controls do not yet interrupt a running production OCI workload;
 - there is no connector driver interface or external production connector;
 - sequence policy does not span transactions, sessions or identity lineage;

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -110,10 +110,12 @@ These commands require the hardened daemon identity, verifier, approval and
 release configuration described in
 [Production Runtime Operations](PRODUCTION.md).
 
-The lower-level `vouch tx create|start|worktree|stage|validate` commands remain
-available for connector development, recovery and debugging. They do not
-replace the primary task-oriented path. Abort discards an unreleased isolated
-worktree:
+The lower-level `vouch tx create` command remains available only in the
+development profile. Existing-transaction operations such as
+`start|worktree|stage|validate` remain available for connector development,
+recovery and debugging. They do not replace the primary task-oriented path,
+and production transaction creation requires atomic task admission. Abort
+discards an unreleased isolated worktree:
 
 ```sh
 vouch --repo /path/to/service tx abort \

--- a/docs/architecture/KERNEL_SEMANTICS.md
+++ b/docs/architecture/KERNEL_SEMANTICS.md
@@ -40,6 +40,25 @@ Rules:
 - A reason is required when entering `blocked`, `failed`, or `cancelled`.
 - Every transition uses the next contiguous run-event sequence.
 
+## Task admission
+
+`POST /v0/namespaces/{namespace}/task-admissions` is the production authority
+creation boundary. The request contains caller-owned intent, sponsor, agent
+profile, contract limits and an idempotency key; it cannot contain event
+envelopes, lifecycle state, timestamps or authoritative digests.
+
+For a new admission, `vouchd` derives and persists the exact `AgentTask`,
+content-digest `ExecutionContract`, `AgentRun`, initial capability grants and
+`AgentTransaction` in one database transaction. It authors
+`run.created`, `capabilities.granted`, `run.state_changed` to `admitted`, and
+`transaction.created`.
+
+The idempotency key is scoped to its namespace. Retrying the same immutable
+input returns the original admission representation, including after restart
+or later lifecycle progress. Reusing the key with changed authority fails with
+`KERNEL_IDEMPOTENCY_CONFLICT`. A failed persistence step leaves none of the
+admission resources behind.
+
 ## Action lifecycle
 
 ```text
@@ -103,6 +122,7 @@ field. Human text may improve without changing the code.
 | `KERNEL_CHECKPOINT_INCOMPATIBLE` | Checkpoint cannot resume under current versions. |
 | `KERNEL_NOT_FOUND` | Requested kernel resource does not exist in the caller's namespace. |
 | `KERNEL_CONFLICT` | Optimistic concurrency or lease ownership failed. |
+| `KERNEL_IDEMPOTENCY_CONFLICT` | An idempotency key is already bound to different immutable admission input. |
 | `KERNEL_DRIVER_UNAVAILABLE` | Required connector driver cannot accept work. |
 | `KERNEL_INTERNAL` | Unexpected trusted-kernel failure. |
 

--- a/docs/architecture/NORTH_STAR_DEMO.md
+++ b/docs/architecture/NORTH_STAR_DEMO.md
@@ -4,17 +4,17 @@
 
 This is a **target acceptance scenario**, not one currently executable path.
 
-The repository implements its pieces in two adjacent paths:
+The supported transaction path now atomically admits its task,
+`ExecutionContract`, `AgentRun`, initial capabilities and transaction before it
+runs an OCI agent. It then stages immutable local Git effects, validates their
+sequence, runs daemon-owned verification, binds signed approvals and publishes
+to an allowed local ref.
 
-- The supported transaction path runs an OCI agent, stages immutable local Git
-  effects, validates their sequence, runs daemon-owned verification, binds
-  signed approvals and publishes to an allowed local ref.
-- The lower-level kernel path models `AgentRun`, `ExecutionContract`,
-  capabilities and brokered filesystem actions, but it is disabled by the
-  production profile and is not created by `vouch run`.
-
-The roadmap's OS-2 through OS-7 work converges those paths before this document
-becomes an executable end-to-end acceptance test.
+The OCI workload does not yet advance that admitted run or consume its
+capabilities through the lower-level brokered action path. The roadmap's OS-3
+through OS-7 work closes that execution, supervision, connector and temporal
+policy gap before this document becomes an executable end-to-end acceptance
+test.
 
 ## Target claim
 

--- a/internal/kernel/admission/admission.go
+++ b/internal/kernel/admission/admission.go
@@ -1,0 +1,671 @@
+// Package admission constructs and validates the daemon-authored authority
+// envelope for one supervised agent task.
+package admission
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/capability"
+	"github.com/duriantaco/vouch/internal/kernel/eventlog"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+const (
+	RequestVersion = "vouch.task_admission_request.v0"
+	ResultVersion  = "vouch.task_admission.v0"
+)
+
+// ContractSpec contains only caller-owned policy inputs. The daemon derives
+// the contract identity, owner, goal and content digest from the enclosing
+// admission request.
+type ContractSpec struct {
+	Risk               string                        `json:"risk"`
+	Resources          []model.ContractResource      `json:"resources"`
+	Budgets            model.BudgetLimits            `json:"budgets"`
+	Deadline           *time.Time                    `json:"deadline,omitempty"`
+	MaxChildDepth      *int64                        `json:"max_child_depth,omitempty"`
+	MaxChildren        *int64                        `json:"max_children,omitempty"`
+	Checkpoints        []model.CheckpointRequirement `json:"checkpoints,omitempty"`
+	Obligations        []model.ContractObligation    `json:"obligations,omitempty"`
+	Escalation         *model.EscalationPolicy       `json:"escalation,omitempty"`
+	ReleaseContractRef string                        `json:"release_contract_ref,omitempty"`
+}
+
+// Request is the non-authoritative task admission input accepted by vouchd.
+// Digests, event envelopes, timestamps and lifecycle state are intentionally
+// absent.
+type Request struct {
+	Version        string                        `json:"version"`
+	IdempotencyKey string                        `json:"idempotency_key"`
+	TransactionID  string                        `json:"transaction_id"`
+	RunID          string                        `json:"run_id,omitempty"`
+	Intent         string                        `json:"intent"`
+	AgentProfile   model.AgentTaskProfileBinding `json:"agent_profile"`
+	Sponsor        model.Principal               `json:"sponsor"`
+	Actor          model.Principal               `json:"actor"`
+	Contract       ContractSpec                  `json:"contract"`
+}
+
+// Result is the immutable representation returned for both the initial
+// admission and an identical idempotent retry.
+type Result struct {
+	Version        string                        `json:"version"`
+	IdempotencyKey string                        `json:"idempotency_key"`
+	RequestDigest  string                        `json:"request_digest"`
+	Task           model.AgentTask               `json:"task"`
+	Contract       model.ExecutionContract       `json:"contract"`
+	Run            reducer.Projection            `json:"run"`
+	Grants         []model.CapabilityGrant       `json:"grants"`
+	Transaction    transactionreducer.Projection `json:"transaction"`
+}
+
+// Prepared carries the immutable result plus the exact daemon-authored events
+// that a Store must persist in one database transaction.
+type Prepared struct {
+	Namespace        string
+	IdempotencyKey   string
+	RequestDigest    string
+	Result           Result
+	RunEvents        []model.RunEvent
+	TransactionEvent model.TransactionEvent
+}
+
+// ComputeRequestDigest binds the authenticated, caller-owned admission input
+// without binding one short-lived OIDC token's claims digest. The principal
+// identity and issuer remain material.
+func ComputeRequestDigest(namespace string, request Request) (string, error) {
+	if !model.IsIdentifier(namespace) {
+		return "", admissionError(
+			model.ErrorSchemaInvalid,
+			"compute_admission_request_digest",
+			namespace,
+			"namespace is invalid",
+			nil,
+		)
+	}
+	normalized := request
+	normalized.IdempotencyKey = ""
+	normalized.Actor.ClaimsDigest = ""
+	if normalized.Contract.Deadline != nil {
+		deadline := normalized.Contract.Deadline.UTC()
+		normalized.Contract.Deadline = &deadline
+	}
+	input := struct {
+		Namespace string  `json:"namespace"`
+		Request   Request `json:"request"`
+	}{
+		Namespace: namespace,
+		Request:   normalized,
+	}
+	data, err := json.Marshal(input)
+	if err != nil {
+		return "", admissionError(
+			model.ErrorInternal,
+			"compute_admission_request_digest",
+			request.TransactionID,
+			"encode admission request",
+			err,
+		)
+	}
+	return digestBytes(data), nil
+}
+
+// Prepare creates the exact resources and event histories for a new task
+// admission. Callers should check the idempotency index before invoking it so
+// an old admission can still be replayed after its authority has expired.
+func Prepare(namespace string, request Request, now time.Time) (Prepared, error) {
+	if request.Version != RequestVersion {
+		return Prepared{}, admissionError(
+			model.ErrorSchemaInvalid,
+			"prepare_task_admission",
+			request.TransactionID,
+			fmt.Sprintf("version must be %q", RequestVersion),
+			nil,
+		)
+	}
+	for field, value := range map[string]string{
+		"idempotency_key": request.IdempotencyKey,
+		"transaction_id":  request.TransactionID,
+	} {
+		if !model.IsIdentifier(value) {
+			return Prepared{}, admissionError(
+				model.ErrorSchemaInvalid,
+				"prepare_task_admission",
+				request.TransactionID,
+				field+" is invalid",
+				nil,
+			)
+		}
+	}
+	if request.RunID != "" && !model.IsIdentifier(request.RunID) {
+		return Prepared{}, admissionError(
+			model.ErrorSchemaInvalid,
+			"prepare_task_admission",
+			request.RunID,
+			"run_id is invalid",
+			nil,
+		)
+	}
+	now = now.UTC()
+	if now.IsZero() {
+		return Prepared{}, admissionError(
+			model.ErrorSchemaInvalid,
+			"prepare_task_admission",
+			request.TransactionID,
+			"daemon clock is required",
+			nil,
+		)
+	}
+	requestDigest, err := ComputeRequestDigest(namespace, request)
+	if err != nil {
+		return Prepared{}, err
+	}
+	runID := request.RunID
+	if runID == "" {
+		runID = stableID("run", namespace, request.TransactionID)
+	}
+	taskID := stableID("task", namespace, request.TransactionID)
+	contractID := stableID("contract", namespace, request.TransactionID)
+	deadline := cloneTime(request.Contract.Deadline)
+	if request.Contract.Budgets.MaxWallTimeSeconds != nil {
+		const maxDurationSeconds = int64((1<<63 - 1) / int64(time.Second))
+		seconds := *request.Contract.Budgets.MaxWallTimeSeconds
+		if seconds < 1 || seconds > maxDurationSeconds {
+			return Prepared{}, admissionError(
+				model.ErrorSchemaInvalid,
+				"prepare_task_admission",
+				request.TransactionID,
+				"max_wall_time_seconds must fit the supported positive duration range",
+				nil,
+			)
+		}
+		wallTimeDeadline := now.Add(
+			time.Duration(seconds) * time.Second,
+		)
+		if deadline == nil || wallTimeDeadline.Before(*deadline) {
+			deadline = &wallTimeDeadline
+		}
+	}
+
+	contract := model.ExecutionContract{
+		Version:            model.ExecutionContractVersion,
+		ID:                 contractID,
+		Owner:              request.Sponsor,
+		Goal:               request.Intent,
+		Risk:               request.Contract.Risk,
+		Resources:          append([]model.ContractResource(nil), request.Contract.Resources...),
+		Budgets:            request.Contract.Budgets,
+		Deadline:           deadline,
+		MaxChildDepth:      cloneInt64(request.Contract.MaxChildDepth),
+		MaxChildren:        cloneInt64(request.Contract.MaxChildren),
+		Checkpoints:        append([]model.CheckpointRequirement(nil), request.Contract.Checkpoints...),
+		Obligations:        append([]model.ContractObligation(nil), request.Contract.Obligations...),
+		Escalation:         cloneEscalation(request.Contract.Escalation),
+		ReleaseContractRef: request.Contract.ReleaseContractRef,
+	}
+	contract.Digest, err = model.ComputeExecutionContractDigest(contract)
+	if err != nil {
+		return Prepared{}, err
+	}
+	if err := contract.Validate(); err != nil {
+		return Prepared{}, err
+	}
+
+	task, err := model.NewAgentTask(
+		taskID,
+		request.TransactionID,
+		namespace,
+		runID,
+		request.Intent,
+		request.AgentProfile,
+		now,
+	)
+	if err != nil {
+		return Prepared{}, err
+	}
+	imageDigest := request.AgentProfile.ImageDigest
+	if imageDigest == "" {
+		// Host execution has no OCI image. Its command digest is the immutable
+		// executable boundary understood by the current v0 AgentRun model.
+		imageDigest = request.AgentProfile.CommandDigest
+	}
+	run := model.AgentRun{
+		Version:                model.AgentRunVersion,
+		ID:                     runID,
+		Namespace:              namespace,
+		ImageDigest:            imageDigest,
+		ContractDigest:         contract.Digest,
+		Principal:              model.Principal{ID: runID, Kind: model.PrincipalRun, Issuer: "vouchd"},
+		DelegationChain:        []model.Principal{request.Sponsor},
+		State:                  model.RunCreated,
+		Deadline:               cloneTime(contract.Deadline),
+		BudgetLimits:           contract.Budgets,
+		BudgetUsage:            model.BudgetUsage{},
+		CapabilityIDs:          []string{},
+		OutstandingApprovalIDs: []string{},
+		EventSequence:          1,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	if err := run.Validate(); err != nil {
+		return Prepared{}, err
+	}
+	createdEvent, err := createRunEvent(run, request.Actor, now)
+	if err != nil {
+		return Prepared{}, err
+	}
+	runProjection, err := reducer.Apply(nil, createdEvent)
+	if err != nil {
+		return Prepared{}, err
+	}
+	grants, err := capability.Compile(contract, runProjection.Run, now)
+	if err != nil {
+		return Prepared{}, err
+	}
+	daemon := daemonPrincipal()
+	grantsEvent, err := eventlog.Next(
+		runProjection,
+		reducer.EventCapabilitiesGranted,
+		daemon,
+		now,
+		model.CapabilitiesGrantedPayload{
+			ContractDigest: contract.Digest,
+			Grants:         grants,
+		},
+	)
+	if err != nil {
+		return Prepared{}, err
+	}
+	grantsEvent.PolicyDecisionID = grants[0].PolicyDecisionID
+	grantsEvent.Digest, err = model.ComputeEventDigest(grantsEvent)
+	if err != nil {
+		return Prepared{}, err
+	}
+	runProjection, err = reducer.Apply(&runProjection, grantsEvent)
+	if err != nil {
+		return Prepared{}, err
+	}
+	admittedEvent, err := eventlog.Next(
+		runProjection,
+		reducer.EventRunStateChanged,
+		daemon,
+		now,
+		model.RunStateChangedPayload{
+			From: model.RunCreated,
+			To:   model.RunAdmitted,
+		},
+	)
+	if err != nil {
+		return Prepared{}, err
+	}
+	runProjection, err = reducer.Apply(&runProjection, admittedEvent)
+	if err != nil {
+		return Prepared{}, err
+	}
+
+	transaction := model.AgentTransaction{
+		Version:      model.AgentTransactionVersion,
+		ID:           request.TransactionID,
+		Namespace:    namespace,
+		IntentDigest: task.IntentDigest,
+		Task:         &task,
+		Admission: &model.TransactionAdmissionBinding{
+			TaskDigest:     task.Digest,
+			RunID:          runID,
+			ContractDigest: contract.Digest,
+		},
+		Sponsor:                request.Sponsor,
+		AgentRunIDs:            []string{runID},
+		StageBindings:          []model.StageBinding{},
+		State:                  model.TransactionCreated,
+		EffectIDs:              []string{},
+		VerificationResultIDs:  []string{},
+		OutstandingApprovalIDs: []string{},
+		EventSequence:          1,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	transactionEvent, err := transactionreducer.CreationEvent(transaction, request.Actor)
+	if err != nil {
+		return Prepared{}, err
+	}
+	transactionProjection, err := transactionreducer.Apply(nil, transactionEvent)
+	if err != nil {
+		return Prepared{}, err
+	}
+	result := Result{
+		Version:        ResultVersion,
+		IdempotencyKey: request.IdempotencyKey,
+		RequestDigest:  requestDigest,
+		Task:           task,
+		Contract:       contract,
+		Run:            runProjection,
+		Grants:         grants,
+		Transaction:    transactionProjection,
+	}
+	prepared := Prepared{
+		Namespace:        namespace,
+		IdempotencyKey:   request.IdempotencyKey,
+		RequestDigest:    requestDigest,
+		Result:           result,
+		RunEvents:        []model.RunEvent{createdEvent, grantsEvent, admittedEvent},
+		TransactionEvent: transactionEvent,
+	}
+	if err := prepared.Validate(); err != nil {
+		return Prepared{}, err
+	}
+	return prepared, nil
+}
+
+// Validate checks the immutable admission representation without requiring
+// access to its event rows.
+func (result Result) Validate(namespace string) error {
+	if result.Version != ResultVersion ||
+		!model.IsIdentifier(namespace) ||
+		!model.IsIdentifier(result.IdempotencyKey) ||
+		!model.IsSHA256Digest(result.RequestDigest) {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			result.IdempotencyKey,
+			"admission result envelope is invalid",
+			nil,
+		)
+	}
+	if err := result.Task.Validate(); err != nil {
+		return err
+	}
+	if err := result.Contract.Validate(); err != nil {
+		return err
+	}
+	contractDigest, err := model.ComputeExecutionContractDigest(result.Contract)
+	if err != nil {
+		return err
+	}
+	if contractDigest != result.Contract.Digest {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			result.Contract.ID,
+			"contract digest does not match its content",
+			nil,
+		)
+	}
+	if err := result.Run.Run.Validate(); err != nil {
+		return err
+	}
+	if err := result.Transaction.Validate(); err != nil {
+		return err
+	}
+	run := result.Run.Run
+	transaction := result.Transaction.Transaction
+	binding := transaction.Admission
+	if run.State != model.RunAdmitted ||
+		run.EventSequence != 3 ||
+		transaction.State != model.TransactionCreated ||
+		transaction.EventSequence != 1 ||
+		binding == nil ||
+		result.Task.Namespace != namespace ||
+		run.Namespace != namespace ||
+		transaction.Namespace != namespace ||
+		result.Task.TransactionID != transaction.ID ||
+		result.Task.RunID != run.ID ||
+		result.Task.IntentDigest != transaction.IntentDigest ||
+		transaction.Task == nil ||
+		!reflect.DeepEqual(*transaction.Task, result.Task) ||
+		len(transaction.AgentRunIDs) != 1 ||
+		transaction.AgentRunIDs[0] != run.ID ||
+		binding.TaskDigest != result.Task.Digest ||
+		binding.RunID != run.ID ||
+		binding.ContractDigest != result.Contract.Digest ||
+		run.ContractDigest != result.Contract.Digest {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			transaction.ID,
+			"task, contract, run, and transaction bindings do not match",
+			nil,
+		)
+	}
+	if len(run.CapabilityIDs) != len(result.Grants) {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			run.ID,
+			"run capability IDs do not match the admission grants",
+			nil,
+		)
+	}
+	for index, grant := range result.Grants {
+		if err := grant.Validate(); err != nil {
+			return err
+		}
+		if grant.SubjectRunID != run.ID ||
+			run.CapabilityIDs[index] != grant.ID {
+			return admissionError(
+				model.ErrorEventChain,
+				"validate_task_admission",
+				grant.ID,
+				"capability grant is not bound to the admitted run",
+				nil,
+			)
+		}
+	}
+	return nil
+}
+
+// Validate verifies every resource, digest, event chain and cross-resource
+// binding before a Store is allowed to persist the aggregate.
+func (prepared Prepared) Validate() error {
+	if !model.IsIdentifier(prepared.Namespace) ||
+		prepared.IdempotencyKey != prepared.Result.IdempotencyKey ||
+		prepared.RequestDigest != prepared.Result.RequestDigest {
+		return admissionError(
+			model.ErrorSchemaInvalid,
+			"validate_task_admission",
+			prepared.IdempotencyKey,
+			"prepared identity does not match its admission result",
+			nil,
+		)
+	}
+	result := prepared.Result
+	if err := result.Validate(prepared.Namespace); err != nil {
+		return err
+	}
+	if len(prepared.RunEvents) != 3 ||
+		prepared.RunEvents[0].Type != reducer.EventRunCreated ||
+		prepared.RunEvents[1].Type != reducer.EventCapabilitiesGranted ||
+		prepared.RunEvents[2].Type != reducer.EventRunStateChanged {
+		return admissionError(
+			model.ErrorEventSequence,
+			"validate_task_admission",
+			result.Run.Run.ID,
+			"admission requires exactly the created, grants, and admitted run events",
+			nil,
+		)
+	}
+	for _, event := range prepared.RunEvents {
+		valid, err := model.VerifyEventDigest(event)
+		if err != nil {
+			return admissionError(
+				model.ErrorInternal,
+				"validate_task_admission",
+				event.ID,
+				"compute run event digest",
+				err,
+			)
+		}
+		if !valid {
+			return admissionError(
+				model.ErrorEventChain,
+				"validate_task_admission",
+				event.ID,
+				"run event digest does not match its content",
+				nil,
+			)
+		}
+	}
+	replayedRun, err := reducer.Replay(prepared.RunEvents)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(replayedRun, result.Run) {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			result.Run.Run.ID,
+			"run projection does not match event replay",
+			nil,
+		)
+	}
+	grantMap, _, err := capability.GrantsFromEvents(prepared.RunEvents)
+	if err != nil {
+		return err
+	}
+	if len(grantMap) != len(result.Grants) ||
+		len(result.Run.Run.CapabilityIDs) != len(result.Grants) {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			result.Run.Run.ID,
+			"capability projections do not match the grant event",
+			nil,
+		)
+	}
+	for index, grant := range result.Grants {
+		stored, exists := grantMap[grant.ID]
+		if !exists || !reflect.DeepEqual(stored, grant) ||
+			result.Run.Run.CapabilityIDs[index] != grant.ID {
+			return admissionError(
+				model.ErrorEventChain,
+				"validate_task_admission",
+				grant.ID,
+				"capability grant is not bound to the admitted run",
+				nil,
+			)
+		}
+	}
+	replayedTransaction, err := transactionreducer.Replay(
+		[]model.TransactionEvent{prepared.TransactionEvent},
+	)
+	if err != nil {
+		return err
+	}
+	if !reflect.DeepEqual(replayedTransaction, result.Transaction) {
+		return admissionError(
+			model.ErrorEventChain,
+			"validate_task_admission",
+			result.Transaction.Transaction.ID,
+			"transaction projection does not match event replay",
+			nil,
+		)
+	}
+	return nil
+}
+
+func createRunEvent(
+	run model.AgentRun,
+	actor model.Principal,
+	occurredAt time.Time,
+) (model.RunEvent, error) {
+	payload, err := json.Marshal(model.RunCreatedPayload{Run: run})
+	if err != nil {
+		return model.RunEvent{}, admissionError(
+			model.ErrorInternal,
+			"prepare_task_admission",
+			run.ID,
+			"encode run creation",
+			err,
+		)
+	}
+	event := model.RunEvent{
+		Version:    model.RunEventVersion,
+		ID:         eventlog.ID(run.ID, 1),
+		RunID:      run.ID,
+		Sequence:   1,
+		Type:       reducer.EventRunCreated,
+		Actor:      actor,
+		OccurredAt: occurredAt.UTC(),
+		Payload:    payload,
+	}
+	event.Digest, err = model.ComputeEventDigest(event)
+	if err != nil {
+		return model.RunEvent{}, admissionError(
+			model.ErrorInternal,
+			"prepare_task_admission",
+			run.ID,
+			"digest run creation",
+			err,
+		)
+	}
+	return event, nil
+}
+
+func daemonPrincipal() model.Principal {
+	return model.Principal{
+		ID:     "service:vouchd",
+		Kind:   model.PrincipalService,
+		Issuer: "vouchd",
+	}
+}
+
+func stableID(prefix string, values ...string) string {
+	hash := sha256.New()
+	for _, value := range values {
+		_, _ = hash.Write([]byte(value))
+		_, _ = hash.Write([]byte{0})
+	}
+	return prefix + ":" + hex.EncodeToString(hash.Sum(nil)[:16])
+}
+
+func digestBytes(data []byte) string {
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:])
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
+}
+
+func cloneInt64(value *int64) *int64 {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneEscalation(value *model.EscalationPolicy) *model.EscalationPolicy {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	cloned.TimeoutSeconds = cloneInt64(value.TimeoutSeconds)
+	return &cloned
+}
+
+func admissionError(
+	code model.ErrorCode,
+	operation, resource, message string,
+	cause error,
+) *model.KernelError {
+	return &model.KernelError{
+		Code:      code,
+		Operation: operation,
+		Resource:  resource,
+		Message:   strings.TrimSpace(message),
+		Cause:     cause,
+	}
+}

--- a/internal/kernel/admission/admission_test.go
+++ b/internal/kernel/admission/admission_test.go
@@ -1,0 +1,306 @@
+package admission
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+)
+
+func TestComputeRequestDigestIsDeterministicAndIgnoresActorClaimsDigest(t *testing.T) {
+	t.Parallel()
+	request := validAdmissionRequest()
+	first, err := ComputeRequestDigest("engineering", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repeated, err := ComputeRequestDigest("engineering", request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repeated != first {
+		t.Fatalf("request digest changed across identical calls: %q != %q", repeated, first)
+	}
+
+	changedClaims := request
+	changedClaims.Actor.ClaimsDigest = testDigest("f")
+	withoutClaims := request
+	withoutClaims.Actor.ClaimsDigest = ""
+	for _, equivalent := range []Request{changedClaims, withoutClaims} {
+		digest, err := ComputeRequestDigest("engineering", equivalent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if digest != first {
+			t.Fatal("short-lived authenticated actor claims changed the request digest")
+		}
+	}
+
+	changedActor := request
+	changedActor.Actor.ID = "operator:different"
+	digest, err := ComputeRequestDigest("engineering", changedActor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if digest == first {
+		t.Fatal("material actor identity did not change the request digest")
+	}
+}
+
+func TestPrepareAuthorsAdmittedRunEventChain(t *testing.T) {
+	t.Parallel()
+	request := validAdmissionRequest()
+	prepared := mustPrepareAdmission(t, request)
+	if len(prepared.RunEvents) != 3 {
+		t.Fatalf("run event count = %d, want 3", len(prepared.RunEvents))
+	}
+	wantTypes := []string{
+		reducer.EventRunCreated,
+		reducer.EventCapabilitiesGranted,
+		reducer.EventRunStateChanged,
+	}
+	daemon := daemonPrincipal()
+	for index, event := range prepared.RunEvents {
+		if event.Type != wantTypes[index] {
+			t.Fatalf("event %d type = %q, want %q", index, event.Type, wantTypes[index])
+		}
+		if event.Sequence != int64(index+1) {
+			t.Fatalf("event %d sequence = %d", index, event.Sequence)
+		}
+		if index == 0 {
+			if event.Actor != request.Actor {
+				t.Fatalf("creation actor = %#v, want %#v", event.Actor, request.Actor)
+			}
+		} else if event.Actor != daemon {
+			t.Fatalf("daemon event %d actor = %#v, want %#v", index, event.Actor, daemon)
+		}
+		valid, err := model.VerifyEventDigest(event)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !valid {
+			t.Fatalf("event %d digest was not daemon-authored from its content", index)
+		}
+		if index > 0 && event.PreviousDigest != prepared.RunEvents[index-1].Digest {
+			t.Fatalf("event %d does not extend the prior digest", index)
+		}
+	}
+
+	granted, err := model.DecodePayloadStrict[model.CapabilitiesGrantedPayload](
+		prepared.RunEvents[1],
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if granted.ContractDigest != prepared.Result.Contract.Digest ||
+		!reflect.DeepEqual(granted.Grants, prepared.Result.Grants) {
+		t.Fatal("capability event does not contain the admitted contract grants")
+	}
+	admitted, err := model.DecodePayloadStrict[model.RunStateChangedPayload](
+		prepared.RunEvents[2],
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if admitted.From != model.RunCreated || admitted.To != model.RunAdmitted {
+		t.Fatalf("admission transition = %s -> %s", admitted.From, admitted.To)
+	}
+	replayed, err := reducer.Replay(prepared.RunEvents)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(replayed, prepared.Result.Run) {
+		t.Fatal("daemon-authored events did not replay to the returned run")
+	}
+	if replayed.Run.State != model.RunAdmitted || replayed.Run.EventSequence != 3 {
+		t.Fatalf("run ended at state=%s sequence=%d", replayed.Run.State, replayed.Run.EventSequence)
+	}
+}
+
+func TestPrepareBindsContractTaskRunAndTransaction(t *testing.T) {
+	t.Parallel()
+	request := validAdmissionRequest()
+	prepared := mustPrepareAdmission(t, request)
+	result := prepared.Result
+
+	contractDigest, err := model.ComputeExecutionContractDigest(result.Contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if contractDigest != result.Contract.Digest {
+		t.Fatal("admitted contract digest does not bind its content")
+	}
+	changedContract := result.Contract
+	changedContract.Goal += " Also alter the release policy."
+	changedDigest, err := model.ComputeExecutionContractDigest(changedContract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changedDigest == contractDigest {
+		t.Fatal("material contract mutation retained the admitted digest")
+	}
+
+	transaction := result.Transaction.Transaction
+	binding := transaction.Admission
+	if binding == nil {
+		t.Fatal("transaction omitted its admission binding")
+	}
+	if transaction.Task == nil || !reflect.DeepEqual(*transaction.Task, result.Task) {
+		t.Fatal("transaction does not retain the exact admitted task")
+	}
+	if result.Task.TransactionID != transaction.ID ||
+		result.Task.RunID != result.Run.Run.ID ||
+		len(transaction.AgentRunIDs) != 1 ||
+		transaction.AgentRunIDs[0] != result.Run.Run.ID {
+		t.Fatal("task, run, and transaction identities are not cross-bound")
+	}
+	if binding.TaskDigest != result.Task.Digest ||
+		binding.RunID != result.Run.Run.ID ||
+		binding.ContractDigest != result.Contract.Digest ||
+		result.Run.Run.ContractDigest != result.Contract.Digest {
+		t.Fatal("task, run, transaction, and contract digests are not cross-bound")
+	}
+	if len(result.Grants) == 0 ||
+		len(result.Run.Run.CapabilityIDs) != len(result.Grants) {
+		t.Fatal("admitted run does not retain its initial grants")
+	}
+	for index, grant := range result.Grants {
+		if grant.SubjectRunID != result.Run.Run.ID ||
+			result.Run.Run.CapabilityIDs[index] != grant.ID {
+			t.Fatalf("grant %q is not bound to the admitted run", grant.ID)
+		}
+	}
+}
+
+func TestPreparedValidateRejectsAdmissionMutations(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		edit func(*Prepared)
+	}{
+		{
+			name: "contract content",
+			edit: func(prepared *Prepared) {
+				prepared.Result.Contract.Goal += " Mutated."
+			},
+		},
+		{
+			name: "task intent",
+			edit: func(prepared *Prepared) {
+				prepared.Result.Task.Intent += " Mutated."
+			},
+		},
+		{
+			name: "run contract binding",
+			edit: func(prepared *Prepared) {
+				prepared.Result.Run.Run.ContractDigest = testDigest("e")
+			},
+		},
+		{
+			name: "grant subject",
+			edit: func(prepared *Prepared) {
+				prepared.Result.Grants[0].SubjectRunID = "run:different"
+			},
+		},
+		{
+			name: "transaction admission binding",
+			edit: func(prepared *Prepared) {
+				prepared.Result.Transaction.Transaction.Admission.ContractDigest =
+					testDigest("e")
+			},
+		},
+		{
+			name: "run event digest",
+			edit: func(prepared *Prepared) {
+				prepared.RunEvents[1].Digest = testDigest("e")
+			},
+		},
+		{
+			name: "run event content",
+			edit: func(prepared *Prepared) {
+				prepared.RunEvents[2].Actor.ID = "service:tampered"
+			},
+		},
+		{
+			name: "transaction event digest",
+			edit: func(prepared *Prepared) {
+				prepared.TransactionEvent.Digest = testDigest("e")
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			prepared := mustPrepareAdmission(t, validAdmissionRequest())
+			test.edit(&prepared)
+			if err := prepared.Validate(); err == nil {
+				t.Fatal("mutated admission passed validation")
+			}
+		})
+	}
+}
+
+func mustPrepareAdmission(t *testing.T, request Request) Prepared {
+	t.Helper()
+	prepared, err := Prepare(
+		"engineering",
+		request,
+		time.Date(2026, 7, 27, 8, 0, 0, 0, time.UTC),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := prepared.Validate(); err != nil {
+		t.Fatalf("prepared admission did not validate: %v", err)
+	}
+	return prepared
+}
+
+func validAdmissionRequest() Request {
+	maxToolCalls := int64(20)
+	deadline := time.Date(2026, 7, 27, 10, 0, 0, 0, time.UTC)
+	return Request{
+		Version:        RequestVersion,
+		IdempotencyKey: "admission:auth-fix",
+		TransactionID:  "tx:auth-fix",
+		Intent:         "Fix authentication without changing public behavior.",
+		AgentProfile: model.AgentTaskProfileBinding{
+			ID:            "agent-profile:secure-coder",
+			Digest:        testDigest("a"),
+			RuntimeClass:  "oci",
+			ImageDigest:   testDigest("b"),
+			Entrypoint:    "/opt/vouch-agent",
+			CommandDigest: testDigest("c"),
+		},
+		Sponsor: model.Principal{
+			ID: "human:sponsor", Kind: model.PrincipalHuman,
+			Issuer: "https://identity.example.invalid",
+		},
+		Actor: model.Principal{
+			ID: "operator:creator", Kind: model.PrincipalOperator,
+			Issuer: "https://identity.example.invalid", ClaimsDigest: testDigest("d"),
+		},
+		Contract: ContractSpec{
+			Risk: "high",
+			Resources: []model.ContractResource{{
+				ID: "workspace-files",
+				Selector: model.ResourceSelector{
+					Kind: "filesystem", Pattern: "workspace/**",
+				},
+				Operations: []string{"filesystem.read", "filesystem.write"},
+				Conditions: model.CapabilityConditions{
+					WorkspaceRoot: "workspace",
+				},
+			}},
+			Budgets:  model.BudgetLimits{MaxToolCalls: &maxToolCalls},
+			Deadline: &deadline,
+		},
+	}
+}
+
+func testDigest(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}

--- a/internal/kernel/api/admission.go
+++ b/internal/kernel/api/admission.go
@@ -1,0 +1,97 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+)
+
+func (s *Server) admitTask(w http.ResponseWriter, r *http.Request) {
+	var request admission.Request
+	if err := decodeBody(w, r, &request); err != nil {
+		writeError(w, err)
+		return
+	}
+	namespace := r.PathValue("namespace")
+	requestDigest, err := admission.ComputeRequestDigest(namespace, request)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
+	existing, storedDigest, err := s.store.GetTaskAdmission(
+		r.Context(),
+		namespace,
+		request.IdempotencyKey,
+	)
+	switch {
+	case err == nil:
+		if storedDigest != requestDigest {
+			writeError(w, idempotencyConflict(request.IdempotencyKey))
+			return
+		}
+		writeJSON(w, http.StatusOK, existing)
+		return
+	case !isNotFound(err):
+		writeError(w, err)
+		return
+	}
+
+	switch request.AgentProfile.RuntimeClass {
+	case "host":
+		if !s.executionPolicy.AllowHost {
+			writeError(w, &model.KernelError{
+				Code:      model.ErrorCapabilityDenied,
+				Operation: "admit_task",
+				Resource:  request.TransactionID,
+				Message:   "host execution is disabled by daemon policy",
+			})
+			return
+		}
+	case "oci":
+		if !s.executionPolicy.agentImageAllowed(
+			request.AgentProfile.ImageDigest,
+		) {
+			writeError(w, &model.KernelError{
+				Code:      model.ErrorCapabilityDenied,
+				Operation: "admit_task",
+				Resource:  request.AgentProfile.ImageDigest,
+				Message:   "OCI image digest is not allowed by daemon policy",
+			})
+			return
+		}
+	}
+
+	prepared, err := admission.Prepare(namespace, request, s.now().UTC())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	result, created, err := s.store.AdmitTask(r.Context(), prepared)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	status := http.StatusOK
+	if created {
+		status = http.StatusCreated
+	}
+	writeJSON(w, status, result)
+}
+
+func isNotFound(err error) bool {
+	var kernelErr *model.KernelError
+	return errors.As(err, &kernelErr) &&
+		kernelErr.Code == model.ErrorNotFound
+}
+
+func idempotencyConflict(key string) *model.KernelError {
+	return &model.KernelError{
+		Code:      model.ErrorIdempotencyConflict,
+		Operation: "admit_task",
+		Resource:  key,
+		Message:   "idempotency key is already bound to different admission input",
+	}
+}

--- a/internal/kernel/api/admission_test.go
+++ b/internal/kernel/api/admission_test.go
@@ -1,0 +1,377 @@
+package api
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"net/http"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/identity"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/store"
+)
+
+func TestTaskAdmissionCreatesAtomicAuthorityAndReplaysIdempotently(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 27, 8, 30, 0, 0, time.UTC)
+	imageDigest := testDigest("b")
+	kernelStore, err := store.OpenSQLite(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernelStore.Close() })
+	handler := NewServer(
+		kernelStore,
+		WithClock(func() time.Time { return now }),
+		WithExecutionRuntimePolicy(ExecutionRuntimePolicy{
+			AllowedAgentImageDigests: map[string]struct{}{imageDigest: {}},
+		}),
+	).Handler()
+	request := validTaskAdmissionRequest(imageDigest)
+	path := "/v0/namespaces/engineering/task-admissions"
+
+	response := requestJSON(t, handler, http.MethodPost, path, request)
+	if response.Code != http.StatusCreated {
+		t.Fatalf(
+			"create status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var created admission.Result
+	decodeResponse(t, response, &created)
+	if created.Version != admission.ResultVersion ||
+		created.Task.Intent != request.Intent ||
+		created.Run.Run.State != model.RunAdmitted ||
+		created.Run.Run.EventSequence != 3 ||
+		created.Transaction.Transaction.Admission == nil {
+		t.Fatalf("unexpected admission result: %#v", created)
+	}
+	if err := kernelStore.VerifyRun(
+		context.Background(),
+		"engineering",
+		created.Run.Run.ID,
+	); err != nil {
+		t.Fatalf("verify admitted run: %v", err)
+	}
+	if err := kernelStore.VerifyTransaction(
+		context.Background(),
+		"engineering",
+		created.Transaction.Transaction.ID,
+	); err != nil {
+		t.Fatalf("verify admitted transaction: %v", err)
+	}
+
+	response = requestJSON(t, handler, http.MethodPost, path, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf(
+			"replay status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var replayed admission.Result
+	decodeResponse(t, response, &replayed)
+	if !reflect.DeepEqual(replayed, created) {
+		t.Fatalf("idempotent replay changed the result:\ncreated=%#v\nreplayed=%#v", created, replayed)
+	}
+
+	changed := request
+	changed.Intent = "A different task must not reuse this admission key."
+	response = requestJSON(t, handler, http.MethodPost, path, changed)
+	if response.Code != http.StatusConflict {
+		t.Fatalf(
+			"changed replay status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var conflict model.KernelError
+	decodeResponse(t, response, &conflict)
+	if conflict.Code != model.ErrorIdempotencyConflict {
+		t.Fatalf("conflict code=%q", conflict.Code)
+	}
+}
+
+func TestTaskAdmissionAppliesRuntimePolicyOnlyToNewAuthority(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 27, 9, 0, 0, 0, time.UTC)
+	allowedDigest := testDigest("b")
+	kernelStore, err := store.OpenSQLite(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernelStore.Close() })
+	allowedHandler := NewServer(
+		kernelStore,
+		WithClock(func() time.Time { return now }),
+		WithExecutionRuntimePolicy(ExecutionRuntimePolicy{
+			AllowedAgentImageDigests: map[string]struct{}{allowedDigest: {}},
+		}),
+	).Handler()
+	request := validTaskAdmissionRequest(allowedDigest)
+	path := "/v0/namespaces/engineering/task-admissions"
+	response := requestJSON(
+		t,
+		allowedHandler,
+		http.MethodPost,
+		path,
+		request,
+	)
+	if response.Code != http.StatusCreated {
+		t.Fatalf(
+			"initial status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+
+	deniedHandler := NewServer(
+		kernelStore,
+		WithClock(func() time.Time { return now.Add(time.Hour) }),
+		WithExecutionRuntimePolicy(ExecutionRuntimePolicy{
+			AllowedAgentImageDigests: map[string]struct{}{testDigest("d"): {}},
+		}),
+	).Handler()
+	response = requestJSON(t, deniedHandler, http.MethodPost, path, request)
+	if response.Code != http.StatusOK {
+		t.Fatalf(
+			"existing admission should replay despite changed policy: status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+
+	newRequest := validTaskAdmissionRequest(allowedDigest)
+	newRequest.IdempotencyKey = "admission:new-denied-image"
+	newRequest.TransactionID = "tx:new-denied-image"
+	response = requestJSON(
+		t,
+		deniedHandler,
+		http.MethodPost,
+		path,
+		newRequest,
+	)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf(
+			"disallowed image status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var denied model.KernelError
+	decodeResponse(t, response, &denied)
+	if denied.Code != model.ErrorCapabilityDenied {
+		t.Fatalf("disallowed image code=%q", denied.Code)
+	}
+
+	hostRequest := validTaskAdmissionRequest(allowedDigest)
+	hostRequest.IdempotencyKey = "admission:new-host"
+	hostRequest.TransactionID = "tx:new-host"
+	hostRequest.AgentProfile.RuntimeClass = "host"
+	hostRequest.AgentProfile.ImageDigest = ""
+	response = requestJSON(
+		t,
+		deniedHandler,
+		http.MethodPost,
+		path,
+		hostRequest,
+	)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf(
+			"disabled host status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+}
+
+func TestProductionRejectsLegacyTransactionCreation(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 27, 9, 15, 0, 0, time.UTC)
+	kernelStore, err := store.OpenSQLite(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernelStore.Close() })
+	prepared, err := admission.Prepare(
+		"engineering",
+		validTaskAdmissionRequest(testDigest("b")),
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := NewServer(
+		kernelStore,
+		WithClock(func() time.Time { return now }),
+		WithExecutionRuntimePolicy(ExecutionRuntimePolicy{
+			EnforcementProfile: store.EnforcementProfileProduction,
+		}),
+	).Handler()
+	response := requestJSON(
+		t,
+		handler,
+		http.MethodPost,
+		"/v0/transactions",
+		prepared.TransactionEvent,
+	)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf(
+			"legacy production creation status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	if _, err := kernelStore.GetTransaction(
+		context.Background(),
+		"engineering",
+		prepared.Result.Transaction.Transaction.ID,
+	); !isNotFound(err) {
+		t.Fatalf("legacy production creation persisted authority: %v", err)
+	}
+}
+
+func TestTaskAdmissionBindsAuthenticatedOperatorToBothLedgers(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 27, 9, 30, 0, 0, time.UTC)
+	publicKey, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	jwk, err := identity.Ed25519JWK("key:task-admission", publicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	verifier, err := identity.NewVerifier(identity.TrustDocument{
+		Version:                 identity.TrustDocumentVersion,
+		Issuer:                  "https://issuer.example.invalid",
+		Audiences:               []string{"vouch-api"},
+		MaxTokenLifetimeSeconds: 3600,
+		JWKS:                    identity.JWKS{Keys: []identity.JWK{jwk}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	kernelStore, err := store.OpenSQLite(":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernelStore.Close() })
+	imageDigest := testDigest("b")
+	handler := NewServer(
+		kernelStore,
+		WithClock(func() time.Time { return now }),
+		WithIdentityVerifier(verifier),
+		WithExecutionRuntimePolicy(ExecutionRuntimePolicy{
+			AllowedAgentImageDigests: map[string]struct{}{imageDigest: {}},
+		}),
+	).Handler()
+	request := validTaskAdmissionRequest(imageDigest)
+	request.Actor = model.Principal{
+		ID: "operator:alice", Kind: model.PrincipalOperator,
+	}
+	token := apiIdentityToken(
+		t,
+		privateKey,
+		"key:task-admission",
+		now,
+		"operator:alice",
+		model.PrincipalOperator,
+		[]string{"engineering"},
+		[]string{"viewer", "operator"},
+	)
+	response := requestJSONWithToken(
+		t,
+		handler,
+		http.MethodPost,
+		"/v0/namespaces/engineering/task-admissions",
+		request,
+		token,
+	)
+	if response.Code != http.StatusCreated {
+		t.Fatalf(
+			"authenticated admission status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var result admission.Result
+	decodeResponse(t, response, &result)
+	runEvents, err := kernelStore.Events(
+		context.Background(),
+		"engineering",
+		result.Run.Run.ID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transactionEvents, err := kernelStore.TransactionEvents(
+		context.Background(),
+		"engineering",
+		result.Transaction.Transaction.ID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, actor := range []model.Principal{
+		runEvents[0].Actor,
+		transactionEvents[0].Actor,
+	} {
+		if actor.ID != "operator:alice" ||
+			actor.Issuer != "https://issuer.example.invalid" ||
+			!model.IsSHA256Digest(actor.ClaimsDigest) {
+			t.Fatalf("ledger actor was not bound to authenticated claims: %#v", actor)
+		}
+	}
+}
+
+func validTaskAdmissionRequest(imageDigest string) admission.Request {
+	maxToolCalls := int64(100)
+	maxWallTime := int64(1800)
+	return admission.Request{
+		Version:        admission.RequestVersion,
+		IdempotencyKey: "admission:engineering-task",
+		TransactionID:  "tx:engineering-task",
+		Intent:         "Update the service inside its isolated workspace.",
+		AgentProfile: model.AgentTaskProfileBinding{
+			ID:            "agent-profile:engineering",
+			Digest:        testDigest("a"),
+			RuntimeClass:  "oci",
+			ImageDigest:   imageDigest,
+			CommandDigest: testDigest("c"),
+		},
+		Sponsor: model.Principal{
+			ID: "human:sponsor", Kind: model.PrincipalHuman,
+		},
+		Actor: model.Principal{
+			ID: "operator:supervisor", Kind: model.PrincipalOperator,
+		},
+		Contract: admission.ContractSpec{
+			Risk: "medium",
+			Resources: []model.ContractResource{{
+				ID: "transaction-workspace",
+				Selector: model.ResourceSelector{
+					Kind: "filesystem", Pattern: "workspace/**",
+				},
+				Operations: []string{
+					"filesystem.read",
+					"filesystem.write",
+				},
+				Conditions: model.CapabilityConditions{
+					WorkspaceRoot: "workspace",
+				},
+			}},
+			Budgets: model.BudgetLimits{
+				MaxToolCalls:       &maxToolCalls,
+				MaxWallTimeSeconds: &maxWallTime,
+			},
+		},
+	}
+}

--- a/internal/kernel/api/identity.go
+++ b/internal/kernel/api/identity.go
@@ -43,7 +43,7 @@ func (s *Server) identityMiddleware(next http.Handler) http.Handler {
 			writeIdentityError(w, http.StatusForbidden, "identity role does not authorize this operation")
 			return
 		}
-		namespace := namespaceFromPath(r.URL.Path)
+		namespace := namespaceFromPath(r.URL.EscapedPath())
 		var body []byte
 		if r.Body != nil && r.Method != http.MethodGet && r.Method != http.MethodHead {
 			body, err = io.ReadAll(io.LimitReader(r.Body, maxRequestBytes+1))

--- a/internal/kernel/api/identity_test.go
+++ b/internal/kernel/api/identity_test.go
@@ -60,6 +60,14 @@ func TestIdentityMiddlewareEnforcesRoleNamespaceAndActorBinding(t *testing.T) {
 		t, privateKey, "key:api-test", now, "service:auditor", model.PrincipalService,
 		[]string{"fixture"}, []string{"viewer"},
 	)
+	parentNamespaceToken := apiIdentityToken(
+		t, privateKey, "key:api-test", now, "service:parent", model.PrincipalService,
+		[]string{"team"}, []string{"viewer"},
+	)
+	nestedNamespaceToken := apiIdentityToken(
+		t, privateKey, "key:api-test", now, "service:nested", model.PrincipalService,
+		[]string{"team/platform"}, []string{"viewer"},
+	)
 
 	response := requestJSONWithToken(
 		t, handler, http.MethodGet, "/healthz", nil, "",
@@ -114,6 +122,28 @@ func TestIdentityMiddlewareEnforcesRoleNamespaceAndActorBinding(t *testing.T) {
 	)
 	if response.Code != http.StatusForbidden {
 		t.Fatalf("cross-namespace viewer status=%d, want 403", response.Code)
+	}
+	escapedNamespacePath := "/v0/namespaces/team%2Fplatform/runs"
+	response = requestJSONWithToken(
+		t, handler, http.MethodGet,
+		escapedNamespacePath, nil, parentNamespaceToken,
+	)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf(
+			"parent namespace token crossed encoded namespace boundary: status=%d",
+			response.Code,
+		)
+	}
+	response = requestJSONWithToken(
+		t, handler, http.MethodGet,
+		escapedNamespacePath, nil, nestedNamespaceToken,
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf(
+			"encoded namespace token did not reach its namespace: status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
 	}
 
 	forged := created

--- a/internal/kernel/api/server.go
+++ b/internal/kernel/api/server.go
@@ -194,6 +194,10 @@ func (s *Server) Handler() http.Handler {
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /healthz", s.health)
 	mux.HandleFunc("GET /readyz", s.ready)
+	mux.HandleFunc(
+		"POST /v0/namespaces/{namespace}/task-admissions",
+		s.admitTask,
+	)
 	mux.HandleFunc("POST /v0/runs", s.requireLegacyHostRuntime(s.createRun))
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/runs", s.listRuns)
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/runs/{runID}", s.getRun)
@@ -210,7 +214,10 @@ func (s *Server) Handler() http.Handler {
 		"POST /v0/namespaces/{namespace}/runs/{runID}/actions",
 		s.requireLegacyHostRuntime(s.executeAction),
 	)
-	mux.HandleFunc("POST /v0/transactions", s.createTransaction)
+	mux.HandleFunc(
+		"POST /v0/transactions",
+		s.requireLegacyTransactionCreation(s.createTransaction),
+	)
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions", s.listTransactions)
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions/{transactionID}", s.getTransaction)
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions/{transactionID}/events", s.listTransactionEvents)
@@ -241,6 +248,24 @@ func (s *Server) requireLegacyHostRuntime(next http.HandlerFunc) http.HandlerFun
 				Operation: "legacy_host_runtime",
 				Resource:  r.URL.Path,
 				Message:   "legacy host run and filesystem action APIs are disabled by daemon policy",
+			})
+			return
+		}
+		next(w, r)
+	}
+}
+
+func (s *Server) requireLegacyTransactionCreation(
+	next http.HandlerFunc,
+) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if s.executionPolicy.EnforcementProfile ==
+			store.EnforcementProfileProduction {
+			writeError(w, &model.KernelError{
+				Code:      model.ErrorCapabilityDenied,
+				Operation: "legacy_transaction_creation",
+				Resource:  r.URL.Path,
+				Message:   "production transactions require atomic task admission",
 			})
 			return
 		}
@@ -510,7 +535,8 @@ func writeError(w http.ResponseWriter, err error) {
 			status = http.StatusBadRequest
 		case model.ErrorNotFound:
 			status = http.StatusNotFound
-		case model.ErrorConflict, model.ErrorTransactionConflict:
+		case model.ErrorConflict, model.ErrorIdempotencyConflict,
+			model.ErrorTransactionConflict:
 			status = http.StatusConflict
 		case model.ErrorCapabilityDenied, model.ErrorCapabilityExpired, model.ErrorCapabilityRevoked,
 			model.ErrorDelegationExceeded, model.ErrorBudgetExceeded:

--- a/internal/kernel/client/client.go
+++ b/internal/kernel/client/client.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/duriantaco/vouch/internal/kernel/admission"
 	"github.com/duriantaco/vouch/internal/kernel/broker"
 	"github.com/duriantaco/vouch/internal/kernel/model"
 	"github.com/duriantaco/vouch/internal/kernel/reducer"
@@ -132,6 +133,17 @@ func (c *Client) CreateTransaction(ctx context.Context, event model.TransactionE
 	var projection transactionreducer.Projection
 	err := c.do(ctx, http.MethodPost, "/v0/transactions", event, &projection)
 	return projection, err
+}
+
+func (c *Client) AdmitTask(
+	ctx context.Context,
+	namespace string,
+	request admission.Request,
+) (admission.Result, error) {
+	var result admission.Result
+	path := "/v0/namespaces/" + url.PathEscape(namespace) + "/task-admissions"
+	err := c.do(ctx, http.MethodPost, path, request, &result)
+	return result, err
 }
 
 // CreateTaskTransaction is the product-level creation path for a single

--- a/internal/kernel/client/client_test.go
+++ b/internal/kernel/client/client_test.go
@@ -2,10 +2,14 @@ package client
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
+	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -33,5 +37,59 @@ func TestClientSendsExplicitBearerToken(t *testing.T) {
 	}
 	if authorization != "Bearer signed-token" {
 		t.Fatalf("authorization=%q", authorization)
+	}
+}
+
+func TestClientAdmitTaskUsesNamespaceEndpoint(t *testing.T) {
+	t.Parallel()
+	input := admission.Request{
+		Version:        admission.RequestVersion,
+		IdempotencyKey: "admission:client-test",
+		TransactionID:  "tx:client-test",
+		Intent:         "Exercise the task admission client.",
+	}
+	want := admission.Result{
+		Version:        admission.ResultVersion,
+		IdempotencyKey: input.IdempotencyKey,
+		RequestDigest:  "sha256:" + strings.Repeat("a", 64),
+	}
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodPost {
+			t.Fatalf("method=%q", request.Method)
+		}
+		if request.URL.EscapedPath() !=
+			"/v0/namespaces/team%2Fplatform/task-admissions" {
+			t.Fatalf("path=%q", request.URL.EscapedPath())
+		}
+		var got admission.Request
+		if err := json.NewDecoder(request.Body).Decode(&got); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(got, input) {
+			t.Fatalf("request=%#v, want %#v", got, input)
+		}
+		data, err := json.Marshal(want)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Status:     "201 Created",
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(string(data))),
+			Request:    request,
+		}, nil
+	})
+	client := NewWithTransport(transport)
+	got, err := client.AdmitTask(
+		context.Background(),
+		"team/platform",
+		input,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("result=%#v, want %#v", got, want)
 	}
 }

--- a/internal/kernel/model/agent_task_test.go
+++ b/internal/kernel/model/agent_task_test.go
@@ -38,16 +38,7 @@ func TestAgentTaskRetainsAndBindsExactIntentAndProfile(t *testing.T) {
 
 func TestAgentTransactionTaskCrossBindingIsOptionalButStrict(t *testing.T) {
 	t.Parallel()
-	task := validAgentTask(t)
-	transaction := AgentTransaction{
-		Version: AgentTransactionVersion, ID: task.TransactionID,
-		Namespace: task.Namespace, IntentDigest: task.IntentDigest, Task: &task,
-		Sponsor:     Principal{ID: "human:sponsor", Kind: PrincipalHuman},
-		AgentRunIDs: []string{task.RunID}, StageBindings: []StageBinding{},
-		State: TransactionCreated, EffectIDs: []string{},
-		VerificationResultIDs: []string{}, OutstandingApprovalIDs: []string{},
-		EventSequence: 1, CreatedAt: task.CreatedAt, UpdatedAt: task.CreatedAt,
-	}
+	transaction := validAgentTaskTransaction(t)
 	if err := transaction.Validate(); err != nil {
 		t.Fatal(err)
 	}
@@ -62,6 +53,88 @@ func TestAgentTransactionTaskCrossBindingIsOptionalButStrict(t *testing.T) {
 	mismatched.IntentDigest = "sha256:" + strings.Repeat("0", 64)
 	if err := mismatched.Validate(); err == nil {
 		t.Fatal("transaction accepted a task bound to a different intent")
+	}
+}
+
+func TestAgentTransactionAdmissionBindingIsOptionalButStrict(t *testing.T) {
+	t.Parallel()
+	transaction := validAgentTaskTransaction(t)
+	transaction.Admission = &TransactionAdmissionBinding{
+		TaskDigest:     transaction.Task.Digest,
+		RunID:          transaction.Task.RunID,
+		ContractDigest: "sha256:" + strings.Repeat("d", 64),
+	}
+	if err := transaction.Validate(); err != nil {
+		t.Fatalf("valid admission binding: %v", err)
+	}
+
+	legacy := transaction
+	legacy.Admission = nil
+	if err := legacy.Validate(); err != nil {
+		t.Fatalf("transaction without an admission binding was broken: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		edit func(*AgentTransaction)
+	}{
+		{
+			name: "missing task",
+			edit: func(value *AgentTransaction) {
+				value.Task = nil
+			},
+		},
+		{
+			name: "different task digest",
+			edit: func(value *AgentTransaction) {
+				value.Admission.TaskDigest = "sha256:" + strings.Repeat("e", 64)
+			},
+		},
+		{
+			name: "different task run",
+			edit: func(value *AgentTransaction) {
+				value.Admission.RunID = "run:different"
+				value.AgentRunIDs = append(value.AgentRunIDs, value.Admission.RunID)
+			},
+		},
+		{
+			name: "run not attached",
+			edit: func(value *AgentTransaction) {
+				value.AgentRunIDs = []string{}
+			},
+		},
+		{
+			name: "invalid contract digest",
+			edit: func(value *AgentTransaction) {
+				value.Admission.ContractDigest = "not-a-digest"
+			},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			mutated := transaction
+			binding := *transaction.Admission
+			mutated.Admission = &binding
+			test.edit(&mutated)
+			if err := mutated.Validate(); err == nil {
+				t.Fatal("transaction accepted an invalid admission binding")
+			}
+		})
+	}
+}
+
+func validAgentTaskTransaction(t *testing.T) AgentTransaction {
+	t.Helper()
+	task := validAgentTask(t)
+	return AgentTransaction{
+		Version: AgentTransactionVersion, ID: task.TransactionID,
+		Namespace: task.Namespace, IntentDigest: task.IntentDigest, Task: &task,
+		Sponsor:     Principal{ID: "human:sponsor", Kind: PrincipalHuman},
+		AgentRunIDs: []string{task.RunID}, StageBindings: []StageBinding{},
+		State: TransactionCreated, EffectIDs: []string{},
+		VerificationResultIDs: []string{}, OutstandingApprovalIDs: []string{},
+		EventSequence: 1, CreatedAt: task.CreatedAt, UpdatedAt: task.CreatedAt,
 	}
 }
 

--- a/internal/kernel/model/contract_digest.go
+++ b/internal/kernel/model/contract_digest.go
@@ -1,0 +1,21 @@
+package model
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+)
+
+// ComputeExecutionContractDigest returns the deterministic local v0 digest of
+// an execution contract. The existing Digest value is excluded so callers can
+// verify a persisted contract or author its digest from the same function.
+func ComputeExecutionContractDigest(contract ExecutionContract) (string, error) {
+	contract.Digest = ""
+	data, err := json.Marshal(contract)
+	if err != nil {
+		return "", fmt.Errorf("encode execution contract digest input: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}

--- a/internal/kernel/model/contract_digest_test.go
+++ b/internal/kernel/model/contract_digest_test.go
@@ -1,0 +1,44 @@
+package model
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestComputeExecutionContractDigestExcludesDigestAndBindsContent(t *testing.T) {
+	t.Parallel()
+	data := readFixture(t, "valid", "execution_contract.json")
+	contract, err := DecodeStrict[ExecutionContract](data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	originalDigest := contract.Digest
+	computed, err := ComputeExecutionContractDigest(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(computed, "sha256:") || len(computed) != len("sha256:")+64 {
+		t.Fatalf("computed digest has invalid form: %q", computed)
+	}
+	if contract.Digest != originalDigest {
+		t.Fatal("digest computation mutated its input")
+	}
+
+	contract.Digest = "sha256:" + strings.Repeat("0", 64)
+	withDifferentClaim, err := ComputeExecutionContractDigest(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withDifferentClaim != computed {
+		t.Fatal("existing digest claim changed the computed content digest")
+	}
+
+	contract.Goal += " Preserve all audit evidence."
+	withChangedContent, err := ComputeExecutionContractDigest(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if withChangedContent == computed {
+		t.Fatal("material contract content did not change the computed digest")
+	}
+}

--- a/internal/kernel/model/errors.go
+++ b/internal/kernel/model/errors.go
@@ -22,6 +22,7 @@ const (
 	ErrorCheckpointIncompatible ErrorCode = "KERNEL_CHECKPOINT_INCOMPATIBLE"
 	ErrorNotFound               ErrorCode = "KERNEL_NOT_FOUND"
 	ErrorConflict               ErrorCode = "KERNEL_CONFLICT"
+	ErrorIdempotencyConflict    ErrorCode = "KERNEL_IDEMPOTENCY_CONFLICT"
 	ErrorDriverUnavailable      ErrorCode = "KERNEL_DRIVER_UNAVAILABLE"
 	ErrorTransactionConflict    ErrorCode = "TRANSACTION_CONFLICT"
 	ErrorEffectSequence         ErrorCode = "TRANSACTION_EFFECT_SEQUENCE"

--- a/internal/kernel/model/transaction_types.go
+++ b/internal/kernel/model/transaction_types.go
@@ -163,28 +163,38 @@ type ModelBrokerExecution struct {
 	OutputTokens        int64  `json:"output_tokens"`
 }
 
+// TransactionAdmissionBinding pins the task, run, and execution contract that
+// were admitted together. It is optional so transaction projections created
+// before atomic task admission remain readable.
+type TransactionAdmissionBinding struct {
+	TaskDigest     string `json:"task_digest"`
+	RunID          string `json:"run_id"`
+	ContractDigest string `json:"contract_digest"`
+}
+
 type AgentTransaction struct {
-	Version                string           `json:"version"`
-	ID                     string           `json:"id"`
-	Namespace              string           `json:"namespace"`
-	IntentDigest           string           `json:"intent_digest"`
-	Task                   *AgentTask       `json:"task,omitempty"`
-	Sponsor                Principal        `json:"sponsor"`
-	AgentRunIDs            []string         `json:"agent_run_ids"`
-	StageBindings          []StageBinding   `json:"stage_bindings"`
-	State                  TransactionState `json:"state"`
-	StateReason            string           `json:"state_reason,omitempty"`
-	EffectIDs              []string         `json:"effect_ids"`
-	VerificationResultIDs  []string         `json:"verification_result_ids"`
-	OutstandingApprovalIDs []string         `json:"outstanding_approval_ids"`
-	StagedStateDigest      string           `json:"staged_state_digest,omitempty"`
-	EffectSetDigest        string           `json:"effect_set_digest,omitempty"`
-	ApprovalPackageDigest  string           `json:"approval_package_digest,omitempty"`
-	CommitPlanDigest       string           `json:"commit_plan_digest,omitempty"`
-	EventSequence          int64            `json:"event_sequence"`
-	CreatedAt              time.Time        `json:"created_at"`
-	UpdatedAt              time.Time        `json:"updated_at"`
-	CompletedAt            *time.Time       `json:"completed_at,omitempty"`
+	Version                string                       `json:"version"`
+	ID                     string                       `json:"id"`
+	Namespace              string                       `json:"namespace"`
+	IntentDigest           string                       `json:"intent_digest"`
+	Task                   *AgentTask                   `json:"task,omitempty"`
+	Admission              *TransactionAdmissionBinding `json:"admission,omitempty"`
+	Sponsor                Principal                    `json:"sponsor"`
+	AgentRunIDs            []string                     `json:"agent_run_ids"`
+	StageBindings          []StageBinding               `json:"stage_bindings"`
+	State                  TransactionState             `json:"state"`
+	StateReason            string                       `json:"state_reason,omitempty"`
+	EffectIDs              []string                     `json:"effect_ids"`
+	VerificationResultIDs  []string                     `json:"verification_result_ids"`
+	OutstandingApprovalIDs []string                     `json:"outstanding_approval_ids"`
+	StagedStateDigest      string                       `json:"staged_state_digest,omitempty"`
+	EffectSetDigest        string                       `json:"effect_set_digest,omitempty"`
+	ApprovalPackageDigest  string                       `json:"approval_package_digest,omitempty"`
+	CommitPlanDigest       string                       `json:"commit_plan_digest,omitempty"`
+	EventSequence          int64                        `json:"event_sequence"`
+	CreatedAt              time.Time                    `json:"created_at"`
+	UpdatedAt              time.Time                    `json:"updated_at"`
+	CompletedAt            *time.Time                   `json:"completed_at,omitempty"`
 }
 
 // StageBinding records an isolated resource boundary owned by a transaction.

--- a/internal/kernel/model/transaction_validate.go
+++ b/internal/kernel/model/transaction_validate.go
@@ -66,6 +66,30 @@ func (transaction AgentTransaction) Validate() error {
 			return invalid(resource, "task.run_id", "task run must be attached to the transaction")
 		}
 	}
+	if transaction.Admission != nil {
+		admission := transaction.Admission
+		if err := validateDigest(resource, "admission.task_digest", admission.TaskDigest); err != nil {
+			return err
+		}
+		if err := validateIdentifier(resource, "admission.run_id", admission.RunID); err != nil {
+			return err
+		}
+		if err := validateDigest(resource, "admission.contract_digest", admission.ContractDigest); err != nil {
+			return err
+		}
+		if transaction.Task == nil {
+			return invalid(resource, "admission.task_digest", "admission requires the bound task")
+		}
+		if admission.TaskDigest != transaction.Task.Digest {
+			return invalid(resource, "admission.task_digest", "admission task digest does not match the transaction task")
+		}
+		if admission.RunID != transaction.Task.RunID {
+			return invalid(resource, "admission.run_id", "admission run does not match the transaction task")
+		}
+		if !slices.Contains(transaction.AgentRunIDs, admission.RunID) {
+			return invalid(resource, "admission.run_id", "admission run must be attached to the transaction")
+		}
+	}
 	if err := validatePrincipal(resource, "sponsor", transaction.Sponsor); err != nil {
 		return err
 	}

--- a/internal/kernel/store/admission_store.go
+++ b/internal/kernel/store/admission_store.go
@@ -1,0 +1,840 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+const (
+	admitTaskOperation = "admit_task"
+
+	admissionFaultAfterContractInsert           = "after_contract_insert"
+	admissionFaultAfterTaskInsert               = "after_task_insert"
+	admissionFaultAfterRunProjectionInsert      = "after_run_projection_insert"
+	admissionFaultAfterRunCreatedEvent          = "after_run_created_event"
+	admissionFaultAfterCapabilitiesGrantedEvent = "after_capabilities_granted_event"
+	admissionFaultAfterRunAdmittedEvent         = "after_run_admitted_event"
+	admissionFaultAfterTransactionInsert        = "after_transaction_projection_insert"
+	admissionFaultAfterTransactionCreatedEvent  = "after_transaction_created_event"
+	admissionFaultAfterAdmissionInsert          = "after_admission_insert"
+	admissionFaultBeforeCommit                  = "before_commit"
+)
+
+var admissionFaultPoints = []string{
+	admissionFaultAfterContractInsert,
+	admissionFaultAfterTaskInsert,
+	admissionFaultAfterRunProjectionInsert,
+	admissionFaultAfterRunCreatedEvent,
+	admissionFaultAfterCapabilitiesGrantedEvent,
+	admissionFaultAfterRunAdmittedEvent,
+	admissionFaultAfterTransactionInsert,
+	admissionFaultAfterTransactionCreatedEvent,
+	admissionFaultAfterAdmissionInsert,
+	admissionFaultBeforeCommit,
+}
+
+type encodedAdmission struct {
+	resultJSON            []byte
+	taskJSON              []byte
+	contractJSON          []byte
+	runJSON               []byte
+	runEventJSON          [][]byte
+	transactionJSON       []byte
+	transactionEventJSON  []byte
+	runProjection         reducer.Projection
+	transactionProjection transactionreducer.Projection
+}
+
+// AdmitTask persists one prepared admission as a single SQLite transaction.
+// The bool result is true only when this call created the admission. An
+// identical idempotency retry returns the immutable first result with false;
+// reuse of the key with different request authority conflicts.
+func (s *SQLiteStore) AdmitTask(
+	ctx context.Context,
+	prepared admission.Prepared,
+) (admission.Result, bool, error) {
+	if err := validateAdmissionKey(
+		prepared.Namespace,
+		prepared.IdempotencyKey,
+		prepared.RequestDigest,
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return admission.Result{}, false, storeError(
+			model.ErrorInternal,
+			admitTaskOperation,
+			prepared.IdempotencyKey,
+			"begin admission transaction",
+			err,
+		)
+	}
+	defer tx.Rollback()
+
+	existing, requestDigest, err := loadTaskAdmission(
+		ctx,
+		tx,
+		prepared.Namespace,
+		prepared.IdempotencyKey,
+	)
+	switch {
+	case err == nil:
+		if requestDigest != prepared.RequestDigest {
+			return admission.Result{}, false, storeError(
+				model.ErrorIdempotencyConflict,
+				admitTaskOperation,
+				prepared.IdempotencyKey,
+				"idempotency key is already bound to different admission authority",
+				nil,
+			)
+		}
+		return existing, false, nil
+	case hasStoreCode(err, model.ErrorNotFound):
+		// This is the only branch allowed to create authority.
+	default:
+		return admission.Result{}, false, err
+	}
+
+	encoded, err := prepareAdmission(prepared)
+	if err != nil {
+		return admission.Result{}, false, err
+	}
+
+	if err := ensureExecutionContract(
+		ctx,
+		tx,
+		prepared,
+		encoded.contractJSON,
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+	if err := s.runAdmissionFault(
+		admissionFaultAfterContractInsert,
+		prepared.IdempotencyKey,
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	if err := s.execAdmissionStep(
+		ctx,
+		tx,
+		admissionFaultAfterTaskInsert,
+		prepared.IdempotencyKey,
+		prepared.Result.Task.ID,
+		`INSERT INTO agent_tasks(
+			namespace, task_id, task_digest, transaction_id, run_id,
+			task_json, created_at
+		) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		prepared.Namespace,
+		prepared.Result.Task.ID,
+		prepared.Result.Task.Digest,
+		prepared.Result.Task.TransactionID,
+		prepared.Result.Task.RunID,
+		encoded.taskJSON,
+		prepared.Result.Task.CreatedAt.Format(timeFormat),
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	run := encoded.runProjection.Run
+	if err := s.execAdmissionStep(
+		ctx,
+		tx,
+		admissionFaultAfterRunProjectionInsert,
+		prepared.IdempotencyKey,
+		run.ID,
+		`INSERT INTO runs(
+			namespace, run_id, event_sequence, last_event_digest,
+			state_json, created_at, updated_at
+		) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		run.Namespace,
+		run.ID,
+		run.EventSequence,
+		encoded.runProjection.LastEventDigest,
+		encoded.runJSON,
+		run.CreatedAt.Format(timeFormat),
+		run.UpdatedAt.Format(timeFormat),
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	runEventFaults := []string{
+		admissionFaultAfterRunCreatedEvent,
+		admissionFaultAfterCapabilitiesGrantedEvent,
+		admissionFaultAfterRunAdmittedEvent,
+	}
+	for index, event := range prepared.RunEvents {
+		if err := insertEvent(
+			ctx,
+			tx,
+			prepared.Namespace,
+			event,
+			encoded.runEventJSON[index],
+		); err != nil {
+			return admission.Result{}, false, err
+		}
+		if err := s.runAdmissionFault(
+			runEventFaults[index],
+			prepared.IdempotencyKey,
+		); err != nil {
+			return admission.Result{}, false, err
+		}
+	}
+
+	transaction := encoded.transactionProjection.Transaction
+	if err := s.execAdmissionStep(
+		ctx,
+		tx,
+		admissionFaultAfterTransactionInsert,
+		prepared.IdempotencyKey,
+		transaction.ID,
+		`INSERT INTO agent_transactions(
+			namespace, transaction_id, event_sequence, last_event_digest,
+			projection_json, created_at, updated_at
+		) VALUES(?, ?, ?, ?, ?, ?, ?)`,
+		transaction.Namespace,
+		transaction.ID,
+		transaction.EventSequence,
+		encoded.transactionProjection.LastEventDigest,
+		encoded.transactionJSON,
+		transaction.CreatedAt.Format(timeFormat),
+		transaction.UpdatedAt.Format(timeFormat),
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	if err := insertTransactionEvent(
+		ctx,
+		tx,
+		prepared.Namespace,
+		prepared.TransactionEvent,
+		encoded.transactionEventJSON,
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+	if err := s.runAdmissionFault(
+		admissionFaultAfterTransactionCreatedEvent,
+		prepared.IdempotencyKey,
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	if err := s.execAdmissionStep(
+		ctx,
+		tx,
+		admissionFaultAfterAdmissionInsert,
+		prepared.IdempotencyKey,
+		prepared.IdempotencyKey,
+		`INSERT INTO task_admissions(
+			namespace, idempotency_key, request_digest,
+			task_id, task_digest, contract_digest, run_id, transaction_id,
+			result_json, created_at
+		) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		prepared.Namespace,
+		prepared.IdempotencyKey,
+		prepared.RequestDigest,
+		prepared.Result.Task.ID,
+		prepared.Result.Task.Digest,
+		prepared.Result.Contract.Digest,
+		run.ID,
+		transaction.ID,
+		encoded.resultJSON,
+		prepared.Result.Task.CreatedAt.Format(timeFormat),
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+	if err := s.runAdmissionFault(
+		admissionFaultBeforeCommit,
+		prepared.IdempotencyKey,
+	); err != nil {
+		return admission.Result{}, false, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return admission.Result{}, false, classifyWriteError(
+			admitTaskOperation,
+			prepared.IdempotencyKey,
+			err,
+		)
+	}
+	return prepared.Result, true, nil
+}
+
+func (s *SQLiteStore) GetTaskAdmission(
+	ctx context.Context,
+	namespace, idempotencyKey string,
+) (admission.Result, string, error) {
+	if err := validateAdmissionLookupKey(namespace, idempotencyKey); err != nil {
+		return admission.Result{}, "", err
+	}
+	return loadTaskAdmission(ctx, s.db, namespace, idempotencyKey)
+}
+
+func prepareAdmission(prepared admission.Prepared) (encodedAdmission, error) {
+	if err := prepared.Validate(); err != nil {
+		return encodedAdmission{}, err
+	}
+	encoded := encodedAdmission{
+		runProjection:         prepared.Result.Run,
+		transactionProjection: prepared.Result.Transaction,
+		runEventJSON:          make([][]byte, len(prepared.RunEvents)),
+	}
+	for _, target := range []struct {
+		name  string
+		value any
+		out   *[]byte
+	}{
+		{"admission result", prepared.Result, &encoded.resultJSON},
+		{"task", prepared.Result.Task, &encoded.taskJSON},
+		{"contract", prepared.Result.Contract, &encoded.contractJSON},
+		{"run projection", prepared.Result.Run.Run, &encoded.runJSON},
+		{"transaction projection", prepared.Result.Transaction, &encoded.transactionJSON},
+		{"transaction event", prepared.TransactionEvent, &encoded.transactionEventJSON},
+	} {
+		data, marshalErr := json.Marshal(target.value)
+		if marshalErr != nil {
+			return encodedAdmission{}, storeError(
+				model.ErrorInternal,
+				admitTaskOperation,
+				prepared.IdempotencyKey,
+				"encode "+target.name,
+				marshalErr,
+			)
+		}
+		*target.out = data
+	}
+	for index, event := range prepared.RunEvents {
+		data, err := json.Marshal(event)
+		if err != nil {
+			return encodedAdmission{}, storeError(
+				model.ErrorInternal,
+				admitTaskOperation,
+				event.ID,
+				"encode run event",
+				err,
+			)
+		}
+		encoded.runEventJSON[index] = data
+	}
+	return encoded, nil
+}
+
+func ensureExecutionContract(
+	ctx context.Context,
+	tx *sql.Tx,
+	prepared admission.Prepared,
+	contractJSON []byte,
+) error {
+	contract := prepared.Result.Contract
+	var existingID string
+	var existingJSON []byte
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT contract_id, contract_json
+		 FROM execution_contracts
+		 WHERE namespace = ? AND contract_digest = ?`,
+		prepared.Namespace,
+		contract.Digest,
+	).Scan(&existingID, &existingJSON)
+	switch {
+	case err == nil:
+		if existingID != contract.ID || !bytes.Equal(existingJSON, contractJSON) {
+			return conflict(
+				admitTaskOperation,
+				contract.Digest,
+				"contract digest is already bound to different content",
+				nil,
+			)
+		}
+		return nil
+	case !errors.Is(err, sql.ErrNoRows):
+		return storeError(
+			model.ErrorInternal,
+			admitTaskOperation,
+			contract.Digest,
+			"query execution contract",
+			err,
+		)
+	}
+	if _, err := tx.ExecContext(
+		ctx,
+		`INSERT INTO execution_contracts(
+			namespace, contract_digest, contract_id, contract_json, created_at
+		) VALUES(?, ?, ?, ?, ?)`,
+		prepared.Namespace,
+		contract.Digest,
+		contract.ID,
+		contractJSON,
+		prepared.Result.Task.CreatedAt.Format(timeFormat),
+	); err != nil {
+		return classifyWriteError(admitTaskOperation, contract.Digest, err)
+	}
+	return nil
+}
+
+func loadTaskAdmission(
+	ctx context.Context,
+	query rowQuerier,
+	namespace, idempotencyKey string,
+) (admission.Result, string, error) {
+	var requestDigest, taskID, taskDigest, contractDigest, runID, transactionID string
+	var resultJSON, taskJSON, contractJSON, runJSON, transactionJSON []byte
+	var runLastDigest, transactionLastDigest string
+	err := query.QueryRowContext(
+		ctx,
+		`SELECT
+			a.request_digest, a.task_id, a.task_digest, a.contract_digest,
+			a.run_id, a.transaction_id, a.result_json,
+			t.task_json, c.contract_json,
+			r.state_json, r.last_event_digest,
+			x.projection_json, x.last_event_digest
+		 FROM task_admissions AS a
+		 JOIN agent_tasks AS t
+		   ON t.namespace = a.namespace
+		  AND t.task_id = a.task_id
+		  AND t.task_digest = a.task_digest
+		 JOIN execution_contracts AS c
+		   ON c.namespace = a.namespace
+		  AND c.contract_digest = a.contract_digest
+		 JOIN runs AS r
+		   ON r.namespace = a.namespace
+		  AND r.run_id = a.run_id
+		 JOIN agent_transactions AS x
+		   ON x.namespace = a.namespace
+		  AND x.transaction_id = a.transaction_id
+		 WHERE a.namespace = ? AND a.idempotency_key = ?`,
+		namespace,
+		idempotencyKey,
+	).Scan(
+		&requestDigest,
+		&taskID,
+		&taskDigest,
+		&contractDigest,
+		&runID,
+		&transactionID,
+		&resultJSON,
+		&taskJSON,
+		&contractJSON,
+		&runJSON,
+		&runLastDigest,
+		&transactionJSON,
+		&transactionLastDigest,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return admission.Result{}, "", storeError(
+			model.ErrorNotFound,
+			"get_task_admission",
+			idempotencyKey,
+			"task admission not found in namespace",
+			err,
+		)
+	}
+	if err != nil {
+		return admission.Result{}, "", storeError(
+			model.ErrorInternal,
+			"get_task_admission",
+			idempotencyKey,
+			"query task admission",
+			err,
+		)
+	}
+	result, err := decodeAdmissionJSON[admission.Result](
+		resultJSON, idempotencyKey, "admission result",
+	)
+	if err != nil {
+		return admission.Result{}, "", err
+	}
+	task, err := decodeAdmissionJSON[model.AgentTask](taskJSON, taskID, "task")
+	if err != nil {
+		return admission.Result{}, "", err
+	}
+	contract, err := decodeAdmissionJSON[model.ExecutionContract](
+		contractJSON, contractDigest, "contract",
+	)
+	if err != nil {
+		return admission.Result{}, "", err
+	}
+	run, err := decodeAdmissionJSON[model.AgentRun](runJSON, runID, "run projection")
+	if err != nil {
+		return admission.Result{}, "", err
+	}
+	if err := run.Validate(); err != nil {
+		return admission.Result{}, "", storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			runID,
+			"stored authoritative run failed validation",
+			err,
+		)
+	}
+	transaction, err := decodeAdmissionJSON[transactionreducer.Projection](
+		transactionJSON, transactionID, "transaction projection",
+	)
+	if err != nil {
+		return admission.Result{}, "", err
+	}
+	if err := transaction.Validate(); err != nil {
+		return admission.Result{}, "", storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			transactionID,
+			"stored authoritative transaction failed validation",
+			err,
+		)
+	}
+	if !digestPattern.MatchString(requestDigest) ||
+		result.IdempotencyKey != idempotencyKey ||
+		result.RequestDigest != requestDigest ||
+		result.Task.ID != taskID ||
+		result.Task.Digest != taskDigest ||
+		result.Contract.Digest != contractDigest ||
+		result.Run.Run.ID != runID ||
+		result.Transaction.Transaction.ID != transactionID {
+		return admission.Result{}, "", storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			idempotencyKey,
+			"stored admission identity or digest is invalid",
+			nil,
+		)
+	}
+	if err := validateLoadedAdmissionResult(
+		result,
+		namespace,
+		idempotencyKey,
+		requestDigest,
+	); err != nil {
+		return admission.Result{}, "", err
+	}
+	if err := equalJSON(
+		task,
+		result.Task,
+		"stored task does not match its admission result",
+		taskID,
+	); err != nil {
+		return admission.Result{}, "", err
+	}
+	if err := equalJSON(
+		contract,
+		result.Contract,
+		"stored contract does not match its admission result",
+		contractDigest,
+	); err != nil {
+		return admission.Result{}, "", err
+	}
+	if !digestPattern.MatchString(runLastDigest) ||
+		!digestPattern.MatchString(transactionLastDigest) ||
+		run.EventSequence < result.Run.Run.EventSequence ||
+		transaction.Transaction.EventSequence <
+			result.Transaction.Transaction.EventSequence {
+		return admission.Result{}, "", storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			idempotencyKey,
+			"stored authority projection precedes its admission",
+			nil,
+		)
+	}
+	if (run.EventSequence == result.Run.Run.EventSequence &&
+		runLastDigest != result.Run.LastEventDigest) ||
+		(transaction.Transaction.EventSequence ==
+			result.Transaction.Transaction.EventSequence &&
+			transactionLastDigest != result.Transaction.LastEventDigest) {
+		return admission.Result{}, "", storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			idempotencyKey,
+			"stored authority event digest changed without lifecycle advancement",
+			nil,
+		)
+	}
+	if err := validateCurrentAdmissionBindings(result, run, transaction); err != nil {
+		return admission.Result{}, "", err
+	}
+	if err := verifyAdmissionEventPrefixes(
+		ctx,
+		query,
+		namespace,
+		result,
+	); err != nil {
+		return admission.Result{}, "", err
+	}
+	return result, requestDigest, nil
+}
+
+func validateCurrentAdmissionBindings(
+	initial admission.Result,
+	currentRun model.AgentRun,
+	currentTransaction transactionreducer.Projection,
+) error {
+	initialRun := initial.Run.Run
+	current := currentTransaction.Transaction
+	admittedTransaction := initial.Transaction.Transaction
+	for _, comparison := range []struct {
+		left, right any
+		message     string
+		resource    string
+	}{
+		{currentRun.ImageDigest, initialRun.ImageDigest, "run image changed after admission", currentRun.ID},
+		{currentRun.ContractDigest, initialRun.ContractDigest, "run contract changed after admission", currentRun.ID},
+		{currentRun.Principal, initialRun.Principal, "run principal changed after admission", currentRun.ID},
+		{currentRun.DelegationChain, initialRun.DelegationChain, "run delegation changed after admission", currentRun.ID},
+		{currentRun.ParentRunID, initialRun.ParentRunID, "run parent changed after admission", currentRun.ID},
+		{currentRun.Deadline, initialRun.Deadline, "run deadline changed after admission", currentRun.ID},
+		{currentRun.BudgetLimits, initialRun.BudgetLimits, "run budget limits changed after admission", currentRun.ID},
+		{current.IntentDigest, admittedTransaction.IntentDigest, "transaction intent changed after admission", current.ID},
+		{current.Task, admittedTransaction.Task, "transaction task changed after admission", current.ID},
+		{current.Admission, admittedTransaction.Admission, "transaction admission binding changed", current.ID},
+		{current.Sponsor, admittedTransaction.Sponsor, "transaction sponsor changed after admission", current.ID},
+		{current.AgentRunIDs, admittedTransaction.AgentRunIDs, "transaction run binding changed after admission", current.ID},
+	} {
+		if err := equalJSON(
+			comparison.left,
+			comparison.right,
+			comparison.message,
+			comparison.resource,
+		); err != nil {
+			return err
+		}
+	}
+	if len(currentRun.CapabilityIDs) < len(initialRun.CapabilityIDs) ||
+		!slices.Equal(
+			currentRun.CapabilityIDs[:len(initialRun.CapabilityIDs)],
+			initialRun.CapabilityIDs,
+		) {
+		return storeError(
+			model.ErrorEventChain, "get_task_admission", currentRun.ID,
+			"run lost or reordered capabilities installed at admission", nil,
+		)
+	}
+	return nil
+}
+
+func verifyAdmissionEventPrefixes(
+	ctx context.Context,
+	query rowQuerier,
+	namespace string,
+	result admission.Result,
+) error {
+	runEvents := make([]model.RunEvent, result.Run.Run.EventSequence)
+	for index := range runEvents {
+		var data []byte
+		if err := query.QueryRowContext(
+			ctx,
+			`SELECT event_json FROM events
+			 WHERE namespace = ? AND run_id = ? AND sequence = ?`,
+			namespace,
+			result.Run.Run.ID,
+			index+1,
+		).Scan(&data); err != nil {
+			return storeError(
+				model.ErrorEventChain,
+				"get_task_admission",
+				result.Run.Run.ID,
+				"authoritative run event prefix is incomplete",
+				err,
+			)
+		}
+		event, err := decodeAdmissionJSON[model.RunEvent](
+			data, result.Run.Run.ID, "run event prefix",
+		)
+		if err != nil {
+			return err
+		}
+		runEvents[index] = event
+	}
+
+	var transactionEventJSON []byte
+	if err := query.QueryRowContext(
+		ctx,
+		`SELECT event_json FROM transaction_events
+		 WHERE namespace = ? AND transaction_id = ? AND sequence = 1`,
+		namespace,
+		result.Transaction.Transaction.ID,
+	).Scan(&transactionEventJSON); err != nil {
+		return storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			result.Transaction.Transaction.ID,
+			"authoritative transaction event prefix is incomplete",
+			err,
+		)
+	}
+	transactionEvent, err := decodeAdmissionJSON[model.TransactionEvent](
+		transactionEventJSON,
+		result.Transaction.Transaction.ID,
+		"transaction event prefix",
+	)
+	if err != nil {
+		return err
+	}
+	prepared := admission.Prepared{
+		Namespace:        namespace,
+		IdempotencyKey:   result.IdempotencyKey,
+		RequestDigest:    result.RequestDigest,
+		Result:           result,
+		RunEvents:        runEvents,
+		TransactionEvent: transactionEvent,
+	}
+	if err := prepared.Validate(); err != nil {
+		return storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			result.IdempotencyKey,
+			"stored admission does not match its authoritative event prefixes",
+			err,
+		)
+	}
+	return nil
+}
+
+func validateLoadedAdmissionResult(
+	result admission.Result,
+	namespace, idempotencyKey, requestDigest string,
+) error {
+	if result.IdempotencyKey != idempotencyKey ||
+		result.RequestDigest != requestDigest {
+		return storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			idempotencyKey,
+			"stored admission result envelope is invalid",
+			nil,
+		)
+	}
+	if err := result.Validate(namespace); err != nil {
+		return storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			idempotencyKey,
+			"stored admission result failed validation",
+			err,
+		)
+	}
+	return nil
+}
+
+func validateAdmissionKey(namespace, idempotencyKey, requestDigest string) error {
+	if err := validateAdmissionLookupKey(namespace, idempotencyKey); err != nil {
+		return err
+	}
+	if !digestPattern.MatchString(requestDigest) {
+		return storeError(
+			model.ErrorSchemaInvalid,
+			admitTaskOperation,
+			idempotencyKey,
+			"request digest must be a SHA-256 digest",
+			nil,
+		)
+	}
+	return nil
+}
+
+func validateAdmissionLookupKey(namespace, idempotencyKey string) error {
+	if err := validateNamespace(namespace); err != nil {
+		return err
+	}
+	if !identifierPattern.MatchString(idempotencyKey) {
+		return storeError(
+			model.ErrorSchemaInvalid,
+			"get_task_admission",
+			idempotencyKey,
+			"invalid idempotency key",
+			nil,
+		)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) execAdmissionStep(
+	ctx context.Context,
+	tx *sql.Tx,
+	point, admissionKey, resource, statement string,
+	args ...any,
+) error {
+	if _, err := tx.ExecContext(ctx, statement, args...); err != nil {
+		return classifyWriteError(admitTaskOperation, resource, err)
+	}
+	return s.runAdmissionFault(point, admissionKey)
+}
+
+func (s *SQLiteStore) runAdmissionFault(point, resource string) error {
+	if s.admissionFault == nil {
+		return nil
+	}
+	if err := s.admissionFault(point); err != nil {
+		return storeError(
+			model.ErrorInternal,
+			admitTaskOperation,
+			resource,
+			fmt.Sprintf("admission persistence fault at %s", point),
+			err,
+		)
+	}
+	return nil
+}
+
+func decodeAdmissionJSON[T any](data []byte, resource, name string) (T, error) {
+	value, err := model.DecodeStrict[T](data)
+	if err != nil {
+		var zero T
+		return zero, storeError(
+			model.ErrorEventChain,
+			"get_task_admission",
+			resource,
+			"stored "+name+" is invalid",
+			err,
+		)
+	}
+	return value, nil
+}
+
+func equalJSON(left, right any, message, resource string) error {
+	leftJSON, err := json.Marshal(left)
+	if err != nil {
+		return storeError(
+			model.ErrorInternal,
+			admitTaskOperation,
+			resource,
+			"encode comparison input",
+			err,
+		)
+	}
+	rightJSON, err := json.Marshal(right)
+	if err != nil {
+		return storeError(
+			model.ErrorInternal,
+			admitTaskOperation,
+			resource,
+			"encode comparison input",
+			err,
+		)
+	}
+	if !bytes.Equal(leftJSON, rightJSON) {
+		return storeError(
+			model.ErrorEventChain,
+			admitTaskOperation,
+			resource,
+			message,
+			nil,
+		)
+	}
+	return nil
+}
+
+func hasStoreCode(err error, code model.ErrorCode) bool {
+	var kernelError *model.KernelError
+	return errors.As(err, &kernelError) && kernelError.Code == code
+}

--- a/internal/kernel/store/admission_store_test.go
+++ b/internal/kernel/store/admission_store_test.go
@@ -1,0 +1,471 @@
+package store
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/eventlog"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+func TestTaskAdmissionPersistsAtomicallyAndReplaysIdempotently(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kernel.db")
+	kernelStore, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared := prepareStoreAdmission(t, "replay")
+
+	first, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil {
+		t.Fatalf("admit task: %v", err)
+	}
+	if !created {
+		t.Fatal("first admission was reported as a replay")
+	}
+	assertAdmissionRows(t, kernelStore, []int{1, 1, 1, 3, 1, 1, 1})
+	if err := kernelStore.VerifyRun(
+		ctx,
+		prepared.Namespace,
+		first.Run.Run.ID,
+	); err != nil {
+		t.Fatalf("verify admitted run: %v", err)
+	}
+	if err := kernelStore.VerifyTransaction(
+		ctx,
+		prepared.Namespace,
+		first.Transaction.Transaction.ID,
+	); err != nil {
+		t.Fatalf("verify admitted transaction: %v", err)
+	}
+
+	replayed, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil {
+		t.Fatalf("replay task admission: %v", err)
+	}
+	if created {
+		t.Fatal("identical admission replay created another admission")
+	}
+	assertSameAdmission(t, replayed, first)
+	assertAdmissionRows(t, kernelStore, []int{1, 1, 1, 3, 1, 1, 1})
+
+	loaded, requestDigest, err := kernelStore.GetTaskAdmission(
+		ctx,
+		prepared.Namespace,
+		prepared.IdempotencyKey,
+	)
+	if err != nil {
+		t.Fatalf("get task admission: %v", err)
+	}
+	if requestDigest != prepared.RequestDigest {
+		t.Fatalf("request digest = %q, want %q", requestDigest, prepared.RequestDigest)
+	}
+	assertSameAdmission(t, loaded, first)
+
+	changed := prepared
+	changed.RequestDigest = "sha256:" + strings.Repeat("f", 64)
+	_, created, err = kernelStore.AdmitTask(ctx, changed)
+	if created {
+		t.Fatal("changed idempotency retry created authority")
+	}
+	assertKernelCode(t, err, model.ErrorIdempotencyConflict)
+	assertAdmissionRows(t, kernelStore, []int{1, 1, 1, 3, 1, 1, 1})
+
+	if err := kernelStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	afterRestart, created, err := reopened.AdmitTask(ctx, prepared)
+	if err != nil {
+		t.Fatalf("replay task admission after restart: %v", err)
+	}
+	if created {
+		t.Fatal("restart replay created another admission")
+	}
+	assertSameAdmission(t, afterRestart, first)
+	assertAdmissionRows(t, reopened, []int{1, 1, 1, 3, 1, 1, 1})
+}
+
+func TestTaskAdmissionFaultsRollBackEveryPersistenceStep(t *testing.T) {
+	t.Parallel()
+	for _, point := range admissionFaultPoints {
+		point := point
+		t.Run(point, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			kernelStore := openTestStore(t)
+			prepared := prepareStoreAdmission(t, strings.ReplaceAll(point, "_", "-"))
+			injected := errors.New("injected admission failure")
+			kernelStore.admissionFault = func(candidate string) error {
+				if candidate == point {
+					return injected
+				}
+				return nil
+			}
+
+			_, created, err := kernelStore.AdmitTask(ctx, prepared)
+			if created {
+				t.Fatal("faulted admission was reported as created")
+			}
+			if !errors.Is(err, injected) {
+				t.Fatalf("admission error = %v, want injected fault", err)
+			}
+			assertKernelCode(t, err, model.ErrorInternal)
+			assertAdmissionRows(t, kernelStore, []int{0, 0, 0, 0, 0, 0, 0})
+			if _, err := kernelStore.GetRun(
+				ctx,
+				prepared.Namespace,
+				prepared.Result.Run.Run.ID,
+			); err == nil {
+				t.Fatal("fault left an orphan run")
+			}
+			if _, err := kernelStore.GetTransaction(
+				ctx,
+				prepared.Namespace,
+				prepared.Result.Transaction.Transaction.ID,
+			); err == nil {
+				t.Fatal("fault left an orphan transaction")
+			}
+			if _, _, err := kernelStore.GetTaskAdmission(
+				ctx,
+				prepared.Namespace,
+				prepared.IdempotencyKey,
+			); err == nil {
+				t.Fatal("fault left an orphan admission")
+			}
+
+			kernelStore.admissionFault = nil
+			if _, created, err := kernelStore.AdmitTask(ctx, prepared); err != nil {
+				t.Fatalf("admit after rollback: %v", err)
+			} else if !created {
+				t.Fatal("admission after rollback was treated as a replay")
+			}
+			assertAdmissionRows(t, kernelStore, []int{1, 1, 1, 3, 1, 1, 1})
+		})
+	}
+}
+
+func TestTaskAdmissionReplaySurvivesLifecycleAdvancement(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	prepared := prepareStoreAdmission(t, "advanced")
+	initial, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil || !created {
+		t.Fatalf("admit task: created=%v err=%v", created, err)
+	}
+	actor := model.Principal{
+		ID: "service:vouchd", Kind: model.PrincipalService, Issuer: "vouchd",
+	}
+	advancedAt := initial.Task.CreatedAt.Add(time.Second)
+	runEvent, err := eventlog.Next(
+		initial.Run,
+		reducer.EventRunStateChanged,
+		actor,
+		advancedAt,
+		model.RunStateChangedPayload{
+			From: model.RunAdmitted,
+			To:   model.RunRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kernelStore.AppendEvent(
+		ctx,
+		prepared.Namespace,
+		initial.Run.Run.EventSequence,
+		runEvent,
+	); err != nil {
+		t.Fatalf("advance admitted run: %v", err)
+	}
+	transactionEvent, err := transactionreducer.NextEvent(
+		initial.Transaction,
+		transactionreducer.EventTransactionStateChanged,
+		actor,
+		advancedAt,
+		transactionreducer.TransactionStateChangedPayload{
+			From: model.TransactionCreated,
+			To:   model.TransactionRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kernelStore.AppendTransactionEvents(
+		ctx,
+		prepared.Namespace,
+		initial.Transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{transactionEvent},
+	); err != nil {
+		t.Fatalf("advance admitted transaction: %v", err)
+	}
+
+	loaded, _, err := kernelStore.GetTaskAdmission(
+		ctx,
+		prepared.Namespace,
+		prepared.IdempotencyKey,
+	)
+	if err != nil {
+		t.Fatalf("get admission after lifecycle advancement: %v", err)
+	}
+	assertSameAdmission(t, loaded, initial)
+	replayed, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil {
+		t.Fatalf("idempotent retry after lifecycle advancement: %v", err)
+	}
+	if created {
+		t.Fatal("advanced admission retry created new authority")
+	}
+	assertSameAdmission(t, replayed, initial)
+	assertAdmissionRows(t, kernelStore, []int{1, 1, 1, 4, 1, 2, 1})
+}
+
+func TestGetTaskAdmissionRejectsUnknownKey(t *testing.T) {
+	t.Parallel()
+	kernelStore := openTestStore(t)
+	_, _, err := kernelStore.GetTaskAdmission(
+		context.Background(),
+		"store-test",
+		"admission:missing",
+	)
+	assertKernelCode(t, err, model.ErrorNotFound)
+}
+
+func TestLegacyTransactionCreationCannotForgeAdmissionBinding(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	prepared := prepareStoreAdmission(t, "forged-binding")
+	_, err := kernelStore.CreateTransaction(
+		ctx,
+		prepared.TransactionEvent,
+	)
+	assertKernelCode(t, err, model.ErrorCapabilityDenied)
+	if _, err := kernelStore.GetTransaction(
+		ctx,
+		prepared.Namespace,
+		prepared.Result.Transaction.Transaction.ID,
+	); !hasStoreCode(err, model.ErrorNotFound) {
+		t.Fatalf("forged admission binding reached the transaction ledger: %v", err)
+	}
+}
+
+func TestSQLiteV3MigrationPreservesLegacyRunWithoutInventingAdmission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kernel.db")
+	kernelStore, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	legacy, err := kernelStore.CreateRun(ctx, readCreationEvent(t))
+	if err != nil {
+		t.Fatalf("create legacy run: %v", err)
+	}
+	if err := kernelStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	legacyDB, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, statement := range []string{
+		"PRAGMA foreign_keys = OFF",
+		"DROP TABLE task_admissions",
+		"DROP TABLE agent_tasks",
+		"DROP TABLE execution_contracts",
+		"UPDATE kernel_metadata SET value = '2' WHERE key = 'schema_version'",
+	} {
+		if _, err := legacyDB.ExecContext(ctx, statement); err != nil {
+			_ = legacyDB.Close()
+			t.Fatalf("prepare v2 fixture with %q: %v", statement, err)
+		}
+	}
+	if err := legacyDB.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatalf("migrate v2 store: %v", err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	var version string
+	if err := reopened.db.QueryRowContext(
+		ctx,
+		`SELECT value FROM kernel_metadata WHERE key = 'schema_version'`,
+	).Scan(&version); err != nil {
+		t.Fatal(err)
+	}
+	if version != "3" {
+		t.Fatalf("schema version = %q, want 3", version)
+	}
+	restored, err := reopened.GetRun(ctx, legacy.Run.Namespace, legacy.Run.ID)
+	if err != nil {
+		t.Fatalf("get legacy run after migration: %v", err)
+	}
+	if restored.LastEventDigest != legacy.LastEventDigest {
+		t.Fatal("v3 migration changed legacy run history")
+	}
+	if _, _, err := reopened.GetTaskAdmission(
+		ctx,
+		legacy.Run.Namespace,
+		"admission:legacy",
+	); err == nil {
+		t.Fatal("v3 migration invented an admission for a legacy run")
+	} else {
+		assertKernelCode(t, err, model.ErrorNotFound)
+	}
+	for _, table := range []string{
+		"execution_contracts", "agent_tasks", "task_admissions",
+	} {
+		var name string
+		if err := reopened.db.QueryRowContext(
+			ctx,
+			`SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?`,
+			table,
+		).Scan(&name); err != nil {
+			t.Fatalf("v3 table %s was not created: %v", table, err)
+		}
+	}
+}
+
+func TestGetTaskAdmissionDetectsAuthoritativeProjectionMismatch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	prepared := prepareStoreAdmission(t, "projection-mismatch")
+	if _, _, err := kernelStore.AdmitTask(ctx, prepared); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kernelStore.db.ExecContext(
+		ctx,
+		`UPDATE runs
+		 SET last_event_digest = ?
+		 WHERE namespace = ? AND run_id = ?`,
+		"sha256:"+strings.Repeat("f", 64),
+		prepared.Namespace,
+		prepared.Result.Run.Run.ID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := kernelStore.GetTaskAdmission(
+		ctx,
+		prepared.Namespace,
+		prepared.IdempotencyKey,
+	)
+	assertKernelCode(t, err, model.ErrorEventChain)
+}
+
+func prepareStoreAdmission(t *testing.T, suffix string) admission.Prepared {
+	t.Helper()
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	maxTools := int64(8)
+	deadline := now.Add(2 * time.Hour)
+	prepared, err := admission.Prepare(
+		"store-test",
+		admission.Request{
+			Version:        admission.RequestVersion,
+			IdempotencyKey: "admission:" + suffix,
+			TransactionID:  "tx:" + suffix,
+			RunID:          "run:" + suffix,
+			Intent:         "Make the exact bounded fixture change.",
+			AgentProfile: model.AgentTaskProfileBinding{
+				ID:            "agent-profile:store-test",
+				Digest:        "sha256:" + strings.Repeat("a", 64),
+				RuntimeClass:  "oci",
+				ImageDigest:   "sha256:" + strings.Repeat("b", 64),
+				CommandDigest: "sha256:" + strings.Repeat("c", 64),
+			},
+			Sponsor: model.Principal{
+				ID: "human:store-sponsor", Kind: model.PrincipalHuman,
+			},
+			Actor: model.Principal{
+				ID: "operator:store-test", Kind: model.PrincipalOperator,
+			},
+			Contract: admission.ContractSpec{
+				Risk: "low",
+				Resources: []model.ContractResource{
+					{
+						ID: "workspace",
+						Selector: model.ResourceSelector{
+							Kind: "filesystem", Pattern: "workspace/**",
+						},
+						Operations: []string{"filesystem.read", "filesystem.write"},
+						Conditions: model.CapabilityConditions{
+							WorkspaceRoot: "workspace",
+						},
+					},
+				},
+				Budgets: model.BudgetLimits{
+					MaxToolCalls: &maxTools,
+				},
+				Deadline: &deadline,
+			},
+		},
+		now,
+	)
+	if err != nil {
+		t.Fatalf("prepare admission: %v", err)
+	}
+	return prepared
+}
+
+func assertAdmissionRows(t *testing.T, kernelStore *SQLiteStore, want []int) {
+	t.Helper()
+	tables := []string{
+		"execution_contracts",
+		"agent_tasks",
+		"runs",
+		"events",
+		"agent_transactions",
+		"transaction_events",
+		"task_admissions",
+	}
+	if len(want) != len(tables) {
+		t.Fatalf("invalid row-count fixture: %d values for %d tables", len(want), len(tables))
+	}
+	for index, table := range tables {
+		var count int
+		query := "SELECT COUNT(*) FROM " + table + " WHERE namespace = ?"
+		if err := kernelStore.db.QueryRow(query, "store-test").Scan(&count); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		if count != want[index] {
+			t.Fatalf("%s rows = %d, want %d", table, count, want[index])
+		}
+	}
+}
+
+func assertSameAdmission(t *testing.T, got, want admission.Result) {
+	t.Helper()
+	gotJSON, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantJSON, err := json.Marshal(want)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(gotJSON, wantJSON) {
+		t.Fatalf("admission changed:\ngot  %s\nwant %s", gotJSON, wantJSON)
+	}
+}

--- a/internal/kernel/store/enforcement_profile.go
+++ b/internal/kernel/store/enforcement_profile.go
@@ -124,6 +124,9 @@ func ledgerHasEntries(ctx context.Context, tx *sql.Tx) (bool, error) {
 		UNION ALL SELECT 1 FROM events
 		UNION ALL SELECT 1 FROM agent_transactions
 		UNION ALL SELECT 1 FROM transaction_events
+		UNION ALL SELECT 1 FROM execution_contracts
+		UNION ALL SELECT 1 FROM agent_tasks
+		UNION ALL SELECT 1 FROM task_admissions
 	)`).Scan(&nonempty)
 	if err != nil {
 		return false, enforcementProfileError(model.ErrorInternal, "inspect ledger contents", err)

--- a/internal/kernel/store/sqlite.go
+++ b/internal/kernel/store/sqlite.go
@@ -17,10 +17,11 @@ import (
 	_ "modernc.org/sqlite"
 )
 
-const sqliteSchemaVersion = 2
+const sqliteSchemaVersion = 3
 
 type SQLiteStore struct {
-	db *sql.DB
+	db             *sql.DB
+	admissionFault func(string) error
 }
 
 // Health performs a bounded, constant-work database readiness check. It does
@@ -195,6 +196,57 @@ func (s *SQLiteStore) initialize(ctx context.Context) error {
 		) STRICT`,
 		`CREATE INDEX IF NOT EXISTS transaction_events_by_type
 			ON transaction_events(namespace, transaction_id, event_type, sequence)`,
+		`CREATE TABLE IF NOT EXISTS execution_contracts (
+			namespace TEXT NOT NULL,
+			contract_digest TEXT NOT NULL,
+			contract_id TEXT NOT NULL,
+			contract_json BLOB NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (namespace, contract_digest),
+			UNIQUE (namespace, contract_id)
+		) STRICT`,
+		`CREATE TABLE IF NOT EXISTS agent_tasks (
+			namespace TEXT NOT NULL,
+			task_id TEXT NOT NULL,
+			task_digest TEXT NOT NULL,
+			transaction_id TEXT NOT NULL,
+			run_id TEXT NOT NULL,
+			task_json BLOB NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (namespace, task_id),
+			UNIQUE (namespace, task_digest),
+			UNIQUE (namespace, transaction_id),
+			UNIQUE (namespace, run_id),
+			UNIQUE (namespace, task_id, task_digest)
+		) STRICT`,
+		`CREATE TABLE IF NOT EXISTS task_admissions (
+			namespace TEXT NOT NULL,
+			idempotency_key TEXT NOT NULL,
+			request_digest TEXT NOT NULL,
+			task_id TEXT NOT NULL,
+			task_digest TEXT NOT NULL,
+			contract_digest TEXT NOT NULL,
+			run_id TEXT NOT NULL,
+			transaction_id TEXT NOT NULL,
+			result_json BLOB NOT NULL,
+			created_at TEXT NOT NULL,
+			PRIMARY KEY (namespace, idempotency_key),
+			UNIQUE (namespace, task_id),
+			UNIQUE (namespace, run_id),
+			UNIQUE (namespace, transaction_id),
+			FOREIGN KEY (namespace, task_id, task_digest)
+				REFERENCES agent_tasks(namespace, task_id, task_digest)
+				ON DELETE RESTRICT,
+			FOREIGN KEY (namespace, contract_digest)
+				REFERENCES execution_contracts(namespace, contract_digest)
+				ON DELETE RESTRICT,
+			FOREIGN KEY (namespace, run_id)
+				REFERENCES runs(namespace, run_id)
+				ON DELETE RESTRICT,
+			FOREIGN KEY (namespace, transaction_id)
+				REFERENCES agent_transactions(namespace, transaction_id)
+				ON DELETE RESTRICT
+		) STRICT`,
 	}
 	for _, statement := range statements {
 		if _, err := s.db.ExecContext(ctx, statement); err != nil {
@@ -217,6 +269,15 @@ func (s *SQLiteStore) initialize(ctx context.Context) error {
 	if version == "1" {
 		if _, err := s.db.ExecContext(ctx,
 			`UPDATE kernel_metadata SET value = ? WHERE key = 'schema_version' AND value = '1'`,
+			"2",
+		); err != nil {
+			return storeError(model.ErrorInternal, "migrate_store", "", "upgrade schema version", err)
+		}
+		version = "2"
+	}
+	if version == "2" {
+		if _, err := s.db.ExecContext(ctx,
+			`UPDATE kernel_metadata SET value = ? WHERE key = 'schema_version' AND value = '2'`,
 			fmt.Sprintf("%d", sqliteSchemaVersion),
 		); err != nil {
 			return storeError(model.ErrorInternal, "migrate_store", "", "upgrade schema version", err)

--- a/internal/kernel/store/store.go
+++ b/internal/kernel/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 
+	"github.com/duriantaco/vouch/internal/kernel/admission"
 	"github.com/duriantaco/vouch/internal/kernel/model"
 	"github.com/duriantaco/vouch/internal/kernel/reducer"
 	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
@@ -33,6 +34,13 @@ type TransactionStore interface {
 	VerifyTransaction(context.Context, string, string) error
 }
 
+// AdmissionStore atomically creates and retrieves the immutable authority
+// envelope that binds a task, contract, run, capabilities, and transaction.
+type AdmissionStore interface {
+	AdmitTask(context.Context, admission.Prepared) (admission.Result, bool, error)
+	GetTaskAdmission(context.Context, string, string) (admission.Result, string, error)
+}
+
 // Store combines the local kernel persistence boundaries with lifecycle
 // management. Implementations must commit an event and its projection in one
 // transaction.
@@ -40,6 +48,7 @@ type Store interface {
 	RunStore
 	EventStore
 	TransactionStore
+	AdmissionStore
 	Health(context.Context) error
 	Close() error
 }

--- a/internal/kernel/store/transaction_store.go
+++ b/internal/kernel/store/transaction_store.go
@@ -24,6 +24,15 @@ func (s *SQLiteStore) CreateTransaction(ctx context.Context, event model.Transac
 	if err := projection.Validate(); err != nil {
 		return transactionreducer.Projection{}, err
 	}
+	if projection.Transaction.Admission != nil {
+		return transactionreducer.Projection{}, storeError(
+			model.ErrorCapabilityDenied,
+			"create_transaction",
+			event.TransactionID,
+			"admission bindings can only be created by atomic task admission",
+			nil,
+		)
+	}
 	projectionJSON, err := json.Marshal(projection)
 	if err != nil {
 		return transactionreducer.Projection{}, storeError(model.ErrorInternal, "create_transaction", event.TransactionID, "encode projection", err)

--- a/internal/vouch/transaction_cli.go
+++ b/internal/vouch/transaction_cli.go
@@ -13,12 +13,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/duriantaco/vouch/internal/kernel/admission"
 	kernelclient "github.com/duriantaco/vouch/internal/kernel/client"
 	"github.com/duriantaco/vouch/internal/kernel/model"
 	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
 )
 
 type transactionClient interface {
+	AdmitTask(context.Context, string, admission.Request) (admission.Result, error)
 	CreateTransaction(context.Context, model.TransactionEvent) (transactionreducer.Projection, error)
 	GetTransaction(context.Context, string, string) (transactionreducer.Projection, error)
 	ListTransactions(context.Context, string) ([]model.AgentTransaction, error)

--- a/internal/vouch/transaction_run_cli.go
+++ b/internal/vouch/transaction_run_cli.go
@@ -18,6 +18,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/duriantaco/vouch/internal/kernel/admission"
 	kernelclient "github.com/duriantaco/vouch/internal/kernel/client"
 	"github.com/duriantaco/vouch/internal/kernel/model"
 	"github.com/duriantaco/vouch/internal/kernel/sandbox"
@@ -211,53 +212,53 @@ func transactionRunNamed(
 		*runID = "run:" + *id
 	}
 	actor := model.Principal{ID: *actorID, Kind: model.PrincipalKind(*actorKind)}
-	now := time.Now().UTC()
 	profileBinding, err := selectedProfile.binding()
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	task, err := model.NewAgentTask(
-		transactionTaskID(*id),
-		*id,
+	maxWallTimeSeconds := int64(*timeout / time.Second)
+	admissionRequest := admission.Request{
+		Version:        admission.RequestVersion,
+		IdempotencyKey: *id,
+		TransactionID:  *id,
+		RunID:          *runID,
+		Intent:         string(intentBytes),
+		AgentProfile:   profileBinding,
+		Sponsor: model.Principal{
+			ID:   *sponsorID,
+			Kind: model.PrincipalKind(*sponsorKind),
+		},
+		Actor: actor,
+		Contract: admission.ContractSpec{
+			Risk: "high",
+			Resources: []model.ContractResource{{
+				ID: "workspace",
+				Selector: model.ResourceSelector{
+					Kind:    "filesystem",
+					Pattern: "workspace/**",
+				},
+				Operations: []string{"filesystem.read", "filesystem.write"},
+				Conditions: model.CapabilityConditions{
+					WorkspaceRoot: "workspace",
+				},
+			}},
+			Budgets: model.BudgetLimits{
+				MaxWallTimeSeconds: &maxWallTimeSeconds,
+			},
+		},
+	}
+	client := newClient(*socket)
+	admitted, err := client.AdmitTask(
+		context.Background(),
 		*namespace,
-		*runID,
-		string(intentBytes),
-		profileBinding,
-		now,
+		admissionRequest,
 	)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	transaction := model.AgentTransaction{
-		Version:                model.AgentTransactionVersion,
-		ID:                     *id,
-		Namespace:              *namespace,
-		IntentDigest:           task.IntentDigest,
-		Sponsor:                model.Principal{ID: *sponsorID, Kind: model.PrincipalKind(*sponsorKind)},
-		AgentRunIDs:            []string{*runID},
-		Task:                   &task,
-		StageBindings:          []model.StageBinding{},
-		State:                  model.TransactionCreated,
-		EffectIDs:              []string{},
-		VerificationResultIDs:  []string{},
-		OutstandingApprovalIDs: []string{},
-		EventSequence:          1,
-		CreatedAt:              now,
-		UpdatedAt:              now,
-	}
-	creation, err := transactionreducer.CreationEvent(transaction, actor)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
-	client := newClient(*socket)
-	projection, err := client.CreateTransaction(context.Background(), creation)
-	if err != nil {
-		fmt.Fprintln(stderr, err)
-		return 1
-	}
+	projection := admitted.Transaction
 	projection, err = client.StartTransaction(
 		context.Background(), *namespace, *id,
 		projection.Transaction.EventSequence, actor,
@@ -405,11 +406,6 @@ func generateTransactionID(now time.Time) (string, error) {
 		now.UTC().Format("20060102T150405Z"),
 		hex.EncodeToString(random),
 	), nil
-}
-
-func transactionTaskID(transactionID string) string {
-	sum := sha256.Sum256([]byte(transactionID))
-	return "task:" + hex.EncodeToString(sum[:16])
 }
 
 func digestCommand(command []string) (string, error) {

--- a/internal/vouch/transaction_run_cli_test.go
+++ b/internal/vouch/transaction_run_cli_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -453,12 +454,42 @@ func TestTransactionRunDaemonOCIProvidesPersistedTaskEnvelope(t *testing.T) {
 	if result.Projection.Transaction.Task == nil {
 		t.Fatal("OCI transaction did not retain its task envelope")
 	}
+	if result.Projection.Transaction.Admission == nil {
+		t.Fatal("OCI transaction did not retain its atomic admission binding")
+	}
 	if result.Execution.Status != model.AgentExecutionSucceeded ||
 		result.Execution.TaskDigest != result.Projection.Transaction.Task.Digest {
 		t.Fatalf("execution was not bound to the persisted task: %#v", result.Execution)
 	}
 	if len(result.Projection.Effects) != 1 {
 		t.Fatalf("effects=%d, want one task-driven source change", len(result.Projection.Effects))
+	}
+	admitted, requestDigest, err := kernelStore.GetTaskAdmission(
+		context.Background(), "payments", "tx:task-envelope-oci",
+	)
+	if err != nil {
+		t.Fatalf("load atomic task admission: %v", err)
+	}
+	if requestDigest != admitted.RequestDigest ||
+		admitted.Transaction.Transaction.Admission == nil ||
+		admitted.Transaction.Transaction.Admission.TaskDigest != admitted.Task.Digest ||
+		admitted.Transaction.Transaction.Admission.ContractDigest != admitted.Contract.Digest ||
+		admitted.Run.Run.ContractDigest != admitted.Contract.Digest ||
+		admitted.Run.Run.State != model.RunAdmitted ||
+		admitted.Run.Run.EventSequence != 3 ||
+		len(admitted.Grants) != 1 ||
+		len(admitted.Run.Run.CapabilityIDs) != 1 ||
+		admitted.Grants[0].ID != admitted.Run.Run.CapabilityIDs[0] {
+		t.Fatalf("atomic admission bindings are incomplete: %#v", admitted)
+	}
+	runEvents, err := kernelStore.Events(
+		context.Background(), "payments", "run:task-envelope-oci", 0,
+	)
+	if err != nil {
+		t.Fatalf("load admitted run events: %v", err)
+	}
+	if len(runEvents) != 3 {
+		t.Fatalf("admitted run events=%d, want 3", len(runEvents))
 	}
 }
 
@@ -561,15 +592,12 @@ func TestProductionRuntimePolicyRejectsHostExecution(t *testing.T) {
 	if code != 1 || !strings.Contains(stderr, string(model.ErrorCapabilityDenied)) {
 		t.Fatalf("host execution was not rejected: code=%d stderr=%s", code, stderr)
 	}
-	projection, err := newClient("").GetTransaction(
+	_, err = newClient("").GetTransaction(
 		context.Background(), "payments", "tx:production-host-denied",
 	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(projection.Executions) != 0 ||
-		projection.Transaction.State != model.TransactionRunning {
-		t.Fatalf("rejected host execution changed authority: %#v", projection)
+	var kernelErr *model.KernelError
+	if !errors.As(err, &kernelErr) || kernelErr.Code != model.ErrorNotFound {
+		t.Fatalf("rejected host admission persisted partial authority: %v", err)
 	}
 }
 

--- a/schemas/vouch.agent_transaction.v0.schema.json
+++ b/schemas/vouch.agent_transaction.v0.schema.json
@@ -15,6 +15,16 @@
     "namespace": { "$ref": "vouch.kernel.common.v0.schema.json#/$defs/identifier" },
     "intent_digest": { "$ref": "vouch.kernel.common.v0.schema.json#/$defs/digest" },
     "task": { "$ref": "vouch.agent_task.v0.schema.json" },
+    "admission": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["task_digest", "run_id", "contract_digest"],
+      "properties": {
+        "task_digest": { "$ref": "vouch.kernel.common.v0.schema.json#/$defs/digest" },
+        "run_id": { "$ref": "vouch.kernel.common.v0.schema.json#/$defs/identifier" },
+        "contract_digest": { "$ref": "vouch.kernel.common.v0.schema.json#/$defs/digest" }
+      }
+    },
     "sponsor": { "$ref": "vouch.kernel.common.v0.schema.json#/$defs/principal" },
     "agent_run_ids": {
       "type": "array",


### PR DESCRIPTION
## What

Atomically admits a task, content-bound contract, run, grants, and transaction before execution. Retries are stable, conflicting reuse is rejected, `vouch run` uses admission, and production can no longer enter through the legacy transaction path.

## Why

The Runtime had separate transaction and kernel lifecycles, leaving authority split at the execution boundary.

## Checked

Full Go tests, vet, kernel race tests, strict docs, all four benchmark suites, and production OCI acceptance.

## Next

OS-3 makes admitted grants, budgets, and action policy authoritative during execution.
