### PR TITLE
runtime: enforce live execution authority

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,10 +4,10 @@ Thanks for helping build Vouch Runtime.
 
 ## Product first principle
 
-Vouch Runtime provides transaction and outcome control for autonomous-agent
-actions. A contribution should strengthen the controlled path from task intent
-to isolated execution, staged effects, exact-state verification, authority,
-commit and recovery.
+The current Vouch Runtime provides transaction and outcome control inside a
+narrow local-Git boundary. A contribution should strengthen the controlled path
+from task intent to isolated execution, staged effects, exact-state
+verification, authority, commit and recovery.
 
 Keep the hierarchy clear:
 
@@ -16,6 +16,8 @@ Keep the hierarchy clear:
   fleet, transaction protocol and connector model.
 - Vouch Runtime is the first sellable product and customer-side enforcement
   boundary.
+- Vouch Developer Runtime is the local experience around one Runtime, using the
+  same kernel rather than a separate developer-only enforcement path.
 - `vouchd` is the trusted transaction kernel inside each Runtime.
 - Vouch Contracts is an optional verification module.
 - Vouch Control Plane is the future central fleet, policy, approval and audit

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ The operating-system analogy is precise:
 | **Vouch Agent OS** | The complete target architecture: Control Plane, Runtime fleet, transaction protocol and connector model. It is an umbrella, not a process. | Product direction |
 | **Vouch Control Plane** | Organization-wide fleet, policy, approval, audit and incident management. It manages Runtimes but does not execute agent actions. | Planned |
 | **Vouch Runtime** | The deployable enforcement boundary installed in a customer environment. It contains `vouchd`, agent sandboxes, local durable state and connector drivers. | Narrow single-node local-Git profile implemented |
-| **`vouchd` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Atomic task admission implemented; execution and action enforcement are still converging |
+| **`vouchd` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Atomic task admission, live OCI authority preflight and head-pinned launch claim implemented; paired lifecycle and action enforcement are still converging |
 | **Agent sandbox** | The isolated, untrusted environment in which an agent loop executes. It receives no downstream production credentials. | OCI implementation available |
 | **Agent adapter** | Connects an existing agent framework or command to the kernel. It may request work and actions but cannot authorize itself or create receipts. | Command/profile and lower-level integration exist; supported broker API planned |
 | **Connector driver** | Performs typed operations against one downstream system after kernel authorization and reconciles external state. `vouchd` records authoritative receipts and coordinates recovery. | Rooted filesystem and local Git exist; common interface and remote connectors planned |
@@ -68,9 +68,13 @@ The operating-system analogy is precise:
 
 The diagram states the intended ownership boundary, not a completion claim.
 Today `vouch run` atomically admits its task, content-bound contract, real run,
-initial grants and transaction. The OCI execution and lower-level brokered
-action path do not yet consume that authority as one synchronized lifecycle;
-that is the next Runtime milestone.
+initial grants and transaction. Before OCI launch, `vouchd` reloads that live
+authority and fail-closed derives the permitted image, command, full-workspace
+access, model-broker access and deadline. It then atomically verifies the
+admitted run and transaction heads while recording execution start, before
+starting any broker or agent workload. Execution still advances only the
+transaction ledger; paired run lifecycle and durable budget charging are the
+next Runtime milestone.
 
 Every consequential action must follow one authority path:
 
@@ -126,6 +130,30 @@ vouch --repo /path/to/service run \
   -- /usr/local/bin/agent
 ```
 
+For a developer, the integration contract is deliberately small:
+
+1. Package the existing agent as a digest-pinned OCI image.
+2. Make its command read the retained task at `$VOUCH_TASK_PATH`.
+3. Let it edit only `/workspace` and return a normal process exit code.
+4. Start it with `vouch run`; do not give the container the daemon socket,
+   repository credentials or downstream production credentials.
+5. Inspect the transaction and its hash-chained events before verification,
+   approval and release.
+
+For example, an agent entrypoint can begin with:
+
+```sh
+#!/bin/sh
+set -eu
+test "$VOUCH_RUNTIME_ROLE" = agent
+test -r "$VOUCH_TASK_PATH"
+cd /workspace
+
+# Invoke your existing agent loop here. All intended file effects stay in this
+# detached transaction worktree.
+exec /opt/my-agent --task-file "$VOUCH_TASK_PATH"
+```
+
 For repeatable integrations, define a strict, repository-owned
 `.vouch/agent-profiles.json` and select it by name:
 
@@ -145,6 +173,33 @@ into a durable task envelope. Before launch, `vouchd` atomically admits that
 task with its derived execution contract, real run, initial grants and
 transaction. Daemon-owned OCI agents receive the task envelope read-only at
 `/vouch/task.json`.
+
+Model egress is absent unless the task explicitly requests the configured
+daemon broker, for example with `--model-provider openai`. The provider
+credential never enters the agent container:
+
+```sh
+# No model authority: network=none and no model credential in the container.
+vouch --repo /path/to/service run \
+  --socket /tmp/vouch-service/vouchd.sock \
+  --intent "Apply the deterministic migration" \
+  --agent migration-agent
+
+# Explicit model authority: only the configured OpenAI-compatible broker is
+# reachable. OPENAI_API_KEY is a transaction-scoped broker token, not the
+# provider credential.
+vouch --repo /path/to/service run \
+  --socket /tmp/vouch-service/vouchd.sock \
+  --intent "Fix the failing authentication test" \
+  --agent coding-agent \
+  --model-provider openai
+```
+
+At launch, the kernel derives the run identity, image, command, workspace
+access, broker access and deadline from live admitted state. A stale run, an
+expired grant, a changed image or command, a narrower unsupported workspace
+grant, or an ungranted model provider fails before any broker or agent
+container starts.
 
 `vouch run` then creates the isolated worktree, runs the agent, freezes its Git
 effects, and performs deterministic sequence validation. Inspect the result

--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ expired grant, a changed image or command, a narrower unsupported workspace
 grant, or an ungranted model provider fails before any broker or agent
 container starts.
 
+For concrete scenarios rather than placeholders, see
+[Real-world Runtime examples](docs/EXAMPLES.md). It includes a fully runnable
+authentication-hotfix repository and agent image, a production
+model-assisted coding flow, a networkless migration generator, and an explicit
+description of which enterprise connector examples are not implemented yet.
+
 `vouch run` then creates the isolated worktree, runs the agent, freezes its Git
 effects, and performs deterministic sequence validation. Inspect the result
 with:

--- a/README.md
+++ b/README.md
@@ -4,13 +4,28 @@
 
 # Vouch
 
-Vouch is the transaction operating layer between autonomous agents and
-enterprise systems. Agents may propose work, but a deterministic enforcement
-runtime controls which exact effects may become real.
+Vouch is an enforcement kernel and transaction Runtime for autonomous agents.
+Agents may propose work, but Vouch controls the boundary between that proposal
+and an exact effect.
 
 Vouch does not replace an agent framework, model provider, identity provider,
 container runtime, Kubernetes or the host operating system. It controls the
 authority and transaction boundary around agent work.
+
+One kernel serves two product experiences:
+
+- **Vouch Developer Runtime** is the local experience for developers who want
+  to run an existing coding agent in an isolated Git transaction, inspect its
+  exact effects and control release. A low-level, manually operated local-Git
+  integration exists today; the self-serve developer preview is still a
+  milestone.
+- **Vouch Agent OS** is the target enterprise experience: the same `vouchd`
+  kernel plus non-bypassable action connectors, cross-run policy and a Control
+  Plane for a fleet of Runtimes. Those fleet and remote-system capabilities
+  are planned, not implemented.
+
+These are not separate engines. Developer adoption exercises the same kernel
+semantics that future enterprise deployments require.
 
 ## Architecture: where the OS, Runtime and kernel sit
 
@@ -35,35 +50,39 @@ task   |  +------- Vouch Runtime [customer-side] ------+  |
 ------>|  | customer-side enforcement boundary         |  |
        |  |                                             |  |
        |  |              vouchd kernel                  |  |
-       |  |  admission | identity and lineage          |  |
-       |  |  lifecycle | capabilities | budgets        |  |
-       |  |  action broker | sequence policy           |  |
-       |  |  transaction journal | verification        |  |
-       |  |  approvals | commit | reconciliation       |  |
-       |  |       | launches          ^        |        |  |
-       |  |       v                   |        v        |  |
-       |  |  agent sandbox ------ ActionRequest ------  |  |
-       |  |  + agent adapter          |   connector     |  |
-       |  |  untrusted; no            +-> driver        |  |
-       |  |  downstream credentials       scoped creds  |  |
+       |  |  admission | live authority | Git journal  |  |
+       |  |  Git effects | sequence policy | approval  |  |
+       |  |  local-ref commit                  [current]|  |
+       |  |                                             |  |
+       |  |  paired lifecycle | durable budgets        |  |
+       |  |  action broker | cross-run policy          |  |
+       |  |  reconciliation                    [planned]|  |
+       |  |       | launches                           |  |
+       |  |       v                                    |  |
+       |  |  agent sandbox ---> private Git worktree   |  |
+       |  |  + agent adapter                 [current]  |  |
+       |  |       |                                     |  |
+       |  |       +-- ActionRequest -> connector API    |  |
+       |  |                                  [planned]  |  |
        |  +--------------------------------------|------+  |
        +-----------------------------------------|---------+
                                                  v
-                    GitHub | Kubernetes | PostgreSQL
-                    SAP | Salesforce | cloud | email
+             external systems via planned drivers:
+             GitHub | Kubernetes | PostgreSQL | SAP | cloud
 ```
 
 The operating-system analogy is precise:
 
 | Name | Meaning | Status |
 | --- | --- | --- |
-| **Vouch Agent OS** | The complete target architecture: Control Plane, Runtime fleet, transaction protocol and connector model. It is an umbrella, not a process. | Product direction |
+| **Vouch Developer Runtime** | The local product experience around one Runtime: package an agent, execute it in an isolated Git transaction, inspect exact effects and control release. | Low-level integration, Runtime profile initialization and diagnostics implemented; packaged adapters, `watch`, live cancellation and review UX planned |
+| **Vouch Agent OS** | The enterprise product experience and complete target architecture: Control Plane, Runtime fleet, transaction protocol and connector model. It is an umbrella, not a process. | Product direction |
 | **Vouch Control Plane** | Organization-wide fleet, policy, approval, audit and incident management. It manages Runtimes but does not execute agent actions. | Planned |
 | **Vouch Runtime** | The deployable enforcement boundary installed in a customer environment. It contains `vouchd`, agent sandboxes, local durable state and connector drivers. | Narrow single-node local-Git profile implemented |
 | **`vouchd` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Atomic task admission, live OCI authority preflight and head-pinned launch claim implemented; paired lifecycle and action enforcement are still converging |
 | **Agent sandbox** | The isolated, untrusted environment in which an agent loop executes. It receives no downstream production credentials. | OCI implementation available |
 | **Agent adapter** | Connects an existing agent framework or command to the kernel. It may request work and actions but cannot authorize itself or create receipts. | Command/profile and lower-level integration exist; supported broker API planned |
-| **Connector driver** | Performs typed operations against one downstream system after kernel authorization and reconciles external state. `vouchd` records authoritative receipts and coordinates recovery. | Rooted filesystem and local Git exist; common interface and remote connectors planned |
+| **Connector driver** | Performs typed operations against one downstream system after kernel authorization and reconciles external state. `vouchd` records authoritative receipts and coordinates recovery. | Generic interface and remote drivers planned. Local Git currently uses a dedicated transaction path, not that future interface |
 | **Vouch Contracts** | Optional verification module that turns human-owned intent into evidence obligations used by Runtime policy. | Beta |
 
 The diagram states the intended ownership boundary, not a completion claim.
@@ -76,7 +95,7 @@ starting any broker or agent workload. Execution still advances only the
 transaction ledger; paired run lifecycle and durable budget charging are the
 next Runtime milestone.
 
-Every consequential action must follow one authority path:
+The target remote-effect path is:
 
 ```text
 agent proposes an action
@@ -88,47 +107,70 @@ agent proposes an action
   -> commit | compensate | reconcile | require manual recovery
 ```
 
-An agent with direct downstream credentials can bypass Vouch. A deployment is
-therefore enforcement-grade only when production credentials and network paths
-are available exclusively through Vouch connector drivers.
+This broker-and-connector path is not implemented in the current production
+profile; the older action endpoints are disabled there. Today the contained
+effect boundary is mutation of a private Git worktree followed by exact
+inspection, verification, approval and a local-ref compare-and-swap.
 
-The current local-Git transaction is the first kernel and connector slice. A
-complete Vouch Agent OS external claim requires both non-bypassable,
+An agent with direct downstream credentials can bypass Vouch. A future
+multi-system deployment is therefore enforcement-grade only when production
+credentials and network paths are available exclusively through Vouch
+connector drivers.
+
+The current local-Git transaction is the first kernel transaction-and-effect
+slice. A complete Vouch Agent OS external claim requires both non-bypassable,
 multi-system Runtime enforcement and a Vouch Control Plane managing a fleet of
 those Runtimes.
 
-## Runtime quick start
+## Developer Runtime: current local-Git integration
 
 The current runtime requires Git, an OCI engine such as Docker, a running
 `vouchd`, and a digest-pinned agent image.
 
-Build the local binaries:
+This is a low-level developer integration, not yet a self-serve desktop agent
+environment. `vouch runtime init` creates a strict repository-owned profile and
+`vouch doctor` diagnoses Git, OCI, profile, local-image and daemon readiness.
+Packaged adapters, daemon supervision, `watch`, live cancellation and a
+friendly diff/apply flow remain roadmap work.
+
+Build the CLI from source:
 
 ```sh
-go install ./cmd/vouch ./cmd/vouchd
+go install ./cmd/vouch
 ```
 
-Start a development daemon for one repository:
+In a Git repository with a `HEAD` commit, register an agent image that is
+already present in the local OCI engine:
 
 ```sh
-vouchd \
-  --repo /path/to/service \
-  --db /tmp/vouch-service/kernel.db \
-  --socket /tmp/vouch-service/vouchd.sock \
-  --transaction-root /tmp/vouch-service/transactions
-```
-
-Run an agent in an isolated transaction:
-
-```sh
-vouch --repo /path/to/service run \
-  --socket /tmp/vouch-service/vouchd.sock \
-  --namespace local \
-  --intent "Fix authentication without changing public behavior" \
-  --runtime oci \
+vouch --repo /path/to/service runtime init \
+  --agent coding-agent \
   --image registry.example/coding-agent@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --source-digest sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
   -- /usr/local/bin/agent
 ```
+
+`--source-digest` identifies the source or build input used for that image; it
+is deliberately not invented by Vouch. Start the repository-local development
+daemon in one terminal:
+
+```sh
+vouch --repo /path/to/service daemon
+```
+
+In another terminal, diagnose the selected integration and run it:
+
+```sh
+vouch --repo /path/to/service doctor --agent coding-agent
+
+vouch --repo /path/to/service run \
+  --intent "Fix authentication without changing public behavior" \
+  --agent coding-agent
+```
+
+Doctor warnings, such as an intentionally stopped daemon or omitting
+`--agent`, do not make the command fail. A selected missing image, invalid
+profile, unavailable OCI engine or unready existing daemon does.
 
 For a developer, the integration contract is deliberately small:
 
@@ -154,12 +196,11 @@ cd /workspace
 exec /opt/my-agent --task-file "$VOUCH_TASK_PATH"
 ```
 
-For repeatable integrations, define a strict, repository-owned
-`.vouch/agent-profiles.json` and select it by name:
+`vouch runtime init` writes the strict, repository-owned
+`.vouch/agent-profiles.json`. Select that profile by name:
 
 ```sh
 vouch --repo /path/to/service run \
-  --socket /tmp/vouch-service/vouchd.sock \
   --intent "Fix authentication without changing public behavior" \
   --agent coding-agent
 ```
@@ -181,7 +222,6 @@ credential never enters the agent container:
 ```sh
 # No model authority: network=none and no model credential in the container.
 vouch --repo /path/to/service run \
-  --socket /tmp/vouch-service/vouchd.sock \
   --intent "Apply the deterministic migration" \
   --agent migration-agent
 
@@ -189,7 +229,6 @@ vouch --repo /path/to/service run \
 # reachable. OPENAI_API_KEY is a transaction-scoped broker token, not the
 # provider credential.
 vouch --repo /path/to/service run \
-  --socket /tmp/vouch-service/vouchd.sock \
   --intent "Fix the failing authentication test" \
   --agent coding-agent \
   --model-provider openai
@@ -202,10 +241,10 @@ grant, or an ungranted model provider fails before any broker or agent
 container starts.
 
 For concrete scenarios rather than placeholders, see
-[Real-world Runtime examples](docs/EXAMPLES.md). It includes a fully runnable
-authentication-hotfix repository and agent image, a production
-model-assisted coding flow, a networkless migration generator, and an explicit
-description of which enterprise connector examples are not implemented yet.
+[Runtime examples](docs/EXAMPLES.md). It includes a runnable deterministic
+authentication-hotfix fixture, illustrative model-assisted and networkless
+deployment patterns, and an explicit description of which enterprise
+connector examples are not implemented.
 
 `vouch run` then creates the isolated worktree, runs the agent, freezes its Git
 effects, and performs deterministic sequence validation. Inspect the result
@@ -213,15 +252,13 @@ with:
 
 ```sh
 vouch --repo /path/to/service status <transaction-id> \
-  --socket /tmp/vouch-service/vouchd.sock
+  --namespace local
 
 # Advanced compatibility surface:
 vouch --repo /path/to/service tx effects \
-  --socket /tmp/vouch-service/vouchd.sock \
   --namespace local --id <transaction-id>
 
 vouch --repo /path/to/service tx events \
-  --socket /tmp/vouch-service/vouchd.sock \
   --namespace local --id <transaction-id>
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,10 +10,19 @@ connector model. It is not a separate daemon.
 **`vouchd` kernel** lives inside each Runtime and owns authority, durable
 transaction state, policy decisions, approvals and commit coordination.
 
-The current external product message is:
+One kernel supports two product experiences:
 
-> **Vouch Runtime — stateful transaction and outcome integrity for actions
-> proposed by autonomous agents.**
+| Experience | User promise | Current truth |
+| --- | --- | --- |
+| **Vouch Developer Runtime** | Run an existing agent locally with bounded authority, isolated effects, review and recovery. | A manually operated local-Git path plus profile initialization and diagnostics exists. Packaging, maintained adapters, live supervision and review UX need product work. |
+| **Vouch Agent OS** | Govern consequential agent actions across customer systems and a fleet of Runtimes. | Enterprise experience and full target architecture only. The action protocol, remote connectors, cross-run policy and Control Plane are planned. |
+
+The experiences are different packaging and operations around the same
+enforcement semantics, not separate kernels. The honest current external
+product message is:
+
+> **Vouch Runtime — stateful transaction and outcome integrity for local Git
+> actions proposed by autonomous agents.**
 
 The market problem is real, but generic identity, policy gateways, durable
 agent runtimes, workflow orchestration and fleet control planes are already
@@ -58,6 +67,9 @@ The repository contains a substantial foundation:
 
 The supported profile remains one node, one security tenant and publication to
 an allowed local Git ref. It does not yet control a remote enterprise system.
+Its developer integration is also low-level: the user must operate the daemon,
+provide a digest-pinned OCI image and use transaction-oriented inspection
+commands.
 
 ### Next architecture gap
 
@@ -102,51 +114,56 @@ production profile.
 8. **Commercial evidence gates breadth.** A merged feature is not product
    validation.
 
-## Next mergeable changes
+## Execution workstreams
 
-Each item is a bounded workstream. Deliver it through short, independently
-reviewable pull requests; do not bundle an entire row into one pull request.
+Each item is a bounded workstream delivered through short, independently
+reviewable pull requests. Status describes the current repository, not market
+validation.
 
-| Change | Deliverable | Required acceptance |
-| --- | --- | --- |
-| **OS-0: architecture truth** | README architecture and glossary; evidence-backed product validation; this executable roadmap; terminology cleanup in kernel docs. | Every architecture box maps to implemented code or is clearly marked planned or external. Documentation makes no unsupported production claim. |
-| **OS-1: focused validation lanes** | At most three required PR lanes: Go checks, affected acceptance and documentation when changed. Run the full race, vulnerability and benchmark collections on `main`, nightly and release. Retain production OCI acceptance for security-critical Runtime changes. | Normal PR gate completes in a bounded target such as 12 minutes. Path rules cannot skip production acceptance when kernel, sandbox, identity, approval, release or connector code changes. |
-| **OS-2: atomic task admission** | One daemon-owned, idempotent endpoint persists the exact task, `ExecutionContract`, real `AgentRun`, initial capability grants and `AgentTransaction` in one database transaction. The server authors authoritative events and digests. | Fault injection after every persistence step creates no orphan resources. Identical idempotency retry returns the same admission; a changed retry conflicts. Every transaction references a digest-matching run and contract. |
-| **OS-3: bind execution authority and data boundaries** | OCI execution transitions the admitted `AgentRun`. Identity, sponsor and parent lineage, contract, capabilities, deadline, allowed resources, data classes, model egress and budgets become authoritative. Task limits may narrow daemon ceilings but never widen them. | Run and transaction state cannot diverge after success, failure or injected crash. Expired authority prevents start. Time, model, tool and cost limits fail closed and are durably charged across restart. Denied mounts, connector reads, resource classes and model-egress destinations are inaccessible rather than merely recorded. |
-| **OS-4: durable supervisor and circuit breaker** | Asynchronous workload start, durable desired state and execution lease; functional `watch`, `cancel`, kill and revocation. “Pause” means stop at a declared safe boundary, not arbitrary process snapshotting. | Repeated start creates one workload. Cancel terminates the agent and broker within a bounded interval and prevents release. No new effect executes after revocation. Restart produces one reconciled outcome. |
-| **OS-5: connector interface and transaction coordinator** | Introduce `Plan → Stage/Hold → Inspect → Verify → Commit → Reconcile → Compensate`; add a connector registry plus a durable dependency-ordered coordinator. Each connector persists preparation state, commit state and receipts. Unknown results stop dependent work; restart performs reconciliation before retry or compensation. Move local Git behind the interface only after the generic harness passes. | Two fake connectors prove dependency-ordered prepare/commit, stop-on-unknown, restart recovery, reverse compensation and manual-recovery escalation. Faults are injected before dispatch, during dispatch and after an external effect but before its receipt. Connectors cannot mint authority. Existing local-Git production acceptance remains behaviorally unchanged. |
-| **OS-6: versioned Runtime action protocol and broker** | Replace or converge the legacy broker behind a supported `ActionRequest → decision/approval → receipt` protocol. A transaction-scoped workload credential binds sandbox transport, task, run, transaction, delegated identity, capability, deadline and idempotency key. Publish stable status/event cursors, error semantics and one maintained Go client. Direct private-worktree mutation remains an explicitly contained, stageable boundary. | Local transport rejects forged, cross-run, expired and replayed credentials. Approval resumes only the exact immutable request after restart. A fake connector proves allow, deny, approval, expiry and revocation without exposing its credential. N/N-1 protocol and adapter-conformance fixtures pass; every attempted external effect is attributable. |
-| **OS-7: lineage-aware temporal policy** | Persist immutable identity, delegation, action and effect facts across runs and transactions. Evaluate bounded temporal and separation-of-duties rules across sessions, systems, child agents and a shared sponsor lineage. Ordinary stateless decisions may use an ACS/Cedar/OPA adapter, but Vouch remains authoritative for history and commit. | An AP-style fixture spanning separate sessions and delegated identities is denied for the composed sequence while individually valid actions remain allowed. Restart yields the same decision. Retention and query bounds are explicit, and the policy adapter cannot authorize or commit an effect outside the Runtime transaction. |
-| **GH-1: GitHub ref driver** | After OS-7, add daemon-owned GitHub App authentication, installation/repository allowlist, exact-base branch publication and reconciliation. No pull request or merge yet. | Credentials never enter the task, sandbox, events or logs. Retry is idempotent, stale base fails, and a simulated timeout after remote mutation reconciles to the exact commit without another mutation. |
-| **GH-2: protected PR driver** | Idempotent create/update, transaction marker, exact head/base binding and a concise reviewer summary. Material updates invalidate prepared authority. | Retry creates no duplicate PR. Foreign or stale heads fail closed. Summary explains intent, material effects, verification, risk and required authority without dumping the internal ledger. |
-| **GH-3: exact-SHA merge** | Recheck head SHA, required checks, review policy, approval package and releaser separation immediately before merge; reconcile ambiguous outcomes. | Mutated head, failed check, expired approval and approver-as-releaser fail. Injected timeout yields at most one merge. Receipt identifies the exact reviewed and merged SHA. |
-| **OPS-1: install, API and evidence** | Versioned Runtime configuration and local API contract, binary/container release, service definition, `doctor`, `watch`, audit-bundle export and compatibility/upgrade policy. | A clean supported VM completes the documented transaction. N/N-1 API/config compatibility, restart, backup and restore pass. JSON and Markdown evidence replay to the authoritative projection. |
-| **CP-1: pilot Vouch Control Plane** | Runtime enrollment and health, signed policy distribution, approval routing, central receipt collection and fleet kill/revocation. Build only after paid-pilot evidence. | Vouch Control Plane loss cannot duplicate effects or erase local receipts. Cached-policy behavior is explicit and fails safely. One partner operates multiple Runtimes. |
+| Change | Status | Deliverable | Required acceptance |
+| --- | --- | --- | --- |
+| **OS-0: architecture truth** | Complete | README architecture and glossary; evidence-backed product validation; this executable roadmap; terminology cleanup in kernel docs. | Every architecture box maps to implemented code or is clearly marked planned or external. Documentation makes no unsupported production claim. |
+| **OS-1: focused validation lanes** | Complete | At most three required PR lanes: Go checks, affected acceptance and documentation when changed. Run the full race, vulnerability and benchmark collections on `main`, nightly and release. Retain production OCI acceptance for security-critical Runtime changes. | Normal PR gate completes in a bounded target such as 12 minutes. Path rules cannot skip production acceptance when kernel, sandbox, identity, approval, release or connector code changes. |
+| **OS-2: atomic task admission** | Complete | One daemon-owned, idempotent endpoint persists the exact task, `ExecutionContract`, real `AgentRun`, initial capability grants and `AgentTransaction` in one database transaction. The server authors authoritative events and digests. | Fault injection after every persistence step creates no orphan resources. Identical idempotency retry returns the same admission; a changed retry conflicts. Every transaction references a digest-matching run and contract. |
+| **OS-3: bind execution authority and data boundaries** | In progress | OCI execution transitions the admitted `AgentRun`. Identity, sponsor and parent lineage, contract, capabilities, deadline, allowed resources, data classes, model egress and budgets become authoritative. Task limits may narrow daemon ceilings but never widen them. | Run and transaction state cannot diverge after success, failure or injected crash. Expired authority prevents start. Time, model, tool and cost limits fail closed and are durably charged across restart. Denied mounts, connector reads, resource classes and model-egress destinations are inaccessible rather than merely recorded. |
+| **OS-4: durable supervisor and circuit breaker** | Planned | Asynchronous workload start, durable desired state and execution lease; functional `watch`, `cancel`, kill and revocation. “Pause” means stop at a declared safe boundary, not arbitrary process snapshotting. | Repeated start creates one workload. Cancel terminates the agent and broker within a bounded interval and prevents release. No new effect executes after revocation. Restart produces one reconciled outcome. |
+| **DX-1: Developer Runtime onboarding** | In progress | Runtime-aware project setup and diagnostics, a versioned CLI release, one maintained coding-agent profile and local daemon setup. Keep generated configuration explicit and repository-owned. | On a clean supported machine, a developer can install Vouch, initialize a repository, diagnose prerequisites and start one maintained agent without hand-authoring kernel configuration. |
+| **DX-2: Developer review shell** | Planned | Readable status and diff plus explicit apply/reject, preserving the exact underlying transaction and evidence IDs. Reuse OS-4 for `watch` and real cancellation. | A developer can inspect the exact diff and evidence, then apply or reject it without low-level `tx` commands or database access. |
+| **OS-5: connector interface and transaction coordinator** | Planned | Introduce `Plan → Stage/Hold → Inspect → Verify → Commit → Reconcile → Compensate`; add a connector registry plus a durable dependency-ordered coordinator. Each connector persists preparation state, commit state and receipts. Unknown results stop dependent work; restart performs reconciliation before retry or compensation. Move local Git behind the interface only after the generic harness passes. | Two fake connectors prove dependency-ordered prepare/commit, stop-on-unknown, restart recovery, reverse compensation and manual-recovery escalation. Faults are injected before dispatch, during dispatch and after an external effect but before its receipt. Connectors cannot mint authority. Existing local-Git production acceptance remains behaviorally unchanged. |
+| **OS-6: versioned Runtime action protocol and broker** | Planned | Replace or converge the legacy broker behind a supported `ActionRequest → decision/approval → receipt` protocol. A transaction-scoped workload credential binds sandbox transport, task, run, transaction, delegated identity, capability, deadline and idempotency key. Publish stable status/event cursors, error semantics and one maintained Go client. Direct private-worktree mutation remains an explicitly contained, stageable boundary. | Local transport rejects forged, cross-run, expired and replayed credentials. Approval resumes only the exact immutable request after restart. A fake connector proves allow, deny, approval, expiry and revocation without exposing its credential. N/N-1 protocol and adapter-conformance fixtures pass; every attempted external effect is attributable. |
+| **OS-7: lineage-aware temporal policy** | Planned | Persist immutable identity, delegation, action and effect facts across runs and transactions. Evaluate bounded temporal and separation-of-duties rules across sessions, systems, child agents and a shared sponsor lineage. Ordinary stateless decisions may use an ACS/Cedar/OPA adapter, but Vouch remains authoritative for history and commit. | An AP-style fixture spanning separate sessions and delegated identities is denied for the composed sequence while individually valid actions remain allowed. Restart yields the same decision. Retention and query bounds are explicit, and the policy adapter cannot authorize or commit an effect outside the Runtime transaction. |
+| **GH-1: GitHub ref driver** | Planned | After OS-5 and OS-6, add daemon-owned GitHub App authentication, installation/repository allowlist, exact-base branch publication and reconciliation. No pull request or merge yet. | Credentials never enter the task, sandbox, events or logs. Retry is idempotent, stale base fails, and a simulated timeout after remote mutation reconciles to the exact commit without another mutation. |
+| **GH-2: protected PR driver** | Planned | Idempotent create/update, transaction marker, exact head/base binding and a concise reviewer summary. Material updates invalidate prepared authority. | Retry creates no duplicate PR. Foreign or stale heads fail closed. Summary explains intent, material effects, verification, risk and required authority without dumping the internal ledger. |
+| **GH-3: exact-SHA merge** | Planned | Recheck head SHA, required checks, review policy, approval package and releaser separation immediately before merge; reconcile ambiguous outcomes. | Mutated head, failed check, expired approval and approver-as-releaser fail. Injected timeout yields at most one merge. Receipt identifies the exact reviewed and merged SHA. |
+| **OPS-1: release, API and evidence** | Planned | Versioned Runtime configuration and local API contract, daemon container/service definition, audit-bundle export and compatibility/upgrade policy. | A clean supported VM completes the documented transaction. N/N-1 API/config compatibility, restart, backup and restore pass. JSON and Markdown evidence replay to the authoritative projection. |
+| **CP-1: pilot Vouch Control Plane** | Planned | Runtime enrollment and health, signed policy distribution, approval routing, central receipt collection and fleet kill/revocation. Build only after paid-pilot evidence. | Vouch Control Plane loss cannot duplicate effects or erase local receipts. Cached-policy behavior is explicit and fails safely. One partner operates multiple Runtimes. |
 
 ## Product milestones
 
-### Milestone A: Vouch Runtime developer preview
+### Milestone A: Vouch Developer Runtime preview
 
-Complete **OS-0 through OS-7**.
+Complete **OS-0 through OS-4**, **DX-1** and **DX-2**. OS-5 through OS-7 are
+required for the enterprise connector path, not for an honest local developer
+preview.
 
 Exit criteria:
 
-- one task creates one durable, authoritative chain from sponsor and contract
-  through run, actions, effects, verification, approval and outcome;
-- an agent cannot exercise connector authority outside that chain;
-- budgets, expiry, cancel and revocation affect the real production workload;
-- a second connector can implement the interface without changing kernel
-  transaction semantics;
-- the supported action protocol authenticates the sandbox and preserves exact
-  approval and receipt scope;
-- lineage-aware policy produces the same bounded decision across restart.
+- one maintained agent integration runs through the documented local setup;
+- one task creates one durable chain through run, Git effects, verification,
+  approval and local-ref outcome;
+- expiry and cancellation affect the real workload;
+- the developer can inspect the exact diff and evidence, then explicitly apply
+  or reject it without database surgery;
+- the documentation names the single-node, local-Git and full-workspace limits.
 
-At this point Vouch may describe the deliverable as a **Vouch Runtime developer
+At this point Vouch may describe the deliverable as a **Vouch Developer Runtime
 preview**, not a complete Vouch Agent OS.
 
 ### Milestone B: Vouch Runtime GitHub pilot
 
-Complete **GH-1 through GH-3** and **OPS-1**.
+Complete **OS-5**, **OS-6**, **GH-1 through GH-3** and **OPS-1**. Complete
+**OS-7** before the multi-system production pilot; it may proceed in parallel
+with the first GitHub connector proof.
 
 GitHub is a technical proving ground, not an assumed standalone market. Native
 GitHub agent controls already provide isolated execution, safe write outputs,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -66,12 +66,22 @@ operation to persist the exact `AgentTask`, content-bound
 `ExecutionContract`, real `AgentRun`, initial capability grants and
 `AgentTransaction` in one SQLite transaction.
 
-Execution is not yet the same authority lifecycle. The OCI workload advances
-the transaction without advancing the admitted run or consuming its grants,
-budgets and data boundaries. The older brokered `ActionRequest` endpoints also
-remain disabled by the production profile. OS-3 must close that gap before
-remote connectors are added, or connector behavior would form a second
-authority path around the kernel.
+Immediately before OCI launch, `vouchd` now reloads a consistent live snapshot
+of those resources and compiles a fail-closed execution plan. Caller-supplied
+image and command material must match admitted digests; only full-workspace
+read/write and explicitly granted provider-scoped model brokering are
+currently supported. Expired, terminal, narrowed or otherwise unsupported
+authority starts no workload.
+
+Before any broker or agent workload starts, `vouchd` now atomically verifies
+that both snapshot heads are still current and records execution start in the
+transaction ledger. A concurrent run or transaction change therefore starts
+no workload. Execution is not yet one paired lifecycle: the OCI workload
+advances the transaction without advancing the admitted run, and usage is not
+yet durably charged to run budgets. OS-3 must next pair execution start,
+settlement and recovery across both ledgers before remote connectors are
+added. The older brokered `ActionRequest` endpoints remain disabled by the
+production profile.
 
 ## Execution principles
 

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,0 +1,361 @@
+# Real-world Runtime examples
+
+Vouch's implemented production boundary today is a Git repository on one
+trusted node. These examples therefore use software-delivery work rather than
+pretending that the current repository can already control SAP, Salesforce or
+bank transfers.
+
+## 1. Run the shipped production scenario
+
+The fastest complete example is the same acceptance flow used before release.
+It requires Git, Go, Docker, `jq`, and `curl`:
+
+```sh
+go test ./...
+
+AGENT_IMAGE="$(
+  scripts/vouchproductionfixture.sh \
+    --tag vouch-production-fixture:example
+)"
+VOUCH_PRODUCTION_IMAGE="$AGENT_IMAGE" \
+  scripts/vouchproductionbench.sh
+```
+
+It creates a temporary authentication repository, production OIDC identities,
+an operator/releaser plus an independent reviewer, a policy-controlled model
+broker, daemon-owned agent and verifier containers, a frozen approval package,
+and an allowed release ref. A successful run ends with output like:
+
+```text
+production runtime acceptance passed
+transaction=tx:production-bench
+state=committed
+model_calls=1
+model_unknown_calls=1
+```
+
+The provider call intentionally receives a test upstream failure, so the
+receipt records an unknown call rather than pretending it succeeded. The
+scenario also proves that the provider credential never reaches the agent and
+that direct agent Internet egress is blocked.
+
+## 2. Runnable example: authentication hotfix
+
+This example creates a small payments-service repository and a digest-pinned
+agent image. The agent changes authentication code and its test inside a Vouch
+transaction. The source checkout remains unchanged.
+
+Run the example as a non-root user with Git, Go, Docker, and `jq` installed.
+
+### Create the service repository
+
+```sh
+EXAMPLE_ROOT="$(mktemp -d)"
+REPO="$EXAMPLE_ROOT/payments-api"
+mkdir -p "$REPO/internal/auth"
+
+git -C "$REPO" init --initial-branch=main
+printf 'package auth\n\nfunc RefreshAllowed() bool { return false }\n' \
+  > "$REPO/internal/auth/refresh.go"
+printf 'package auth\n\nfunc TestRefreshAllowed() {}\n' \
+  > "$REPO/internal/auth/refresh_test.go"
+git -C "$REPO" add -- internal/auth
+git -C "$REPO" \
+  -c user.name='Example Developer' \
+  -c user.email='developer@example.invalid' \
+  commit -m 'initial payments service'
+```
+
+### Build the example agent
+
+The program below is intentionally deterministic so the example is
+reproducible. A real coding-agent image follows the same contract: read
+`$VOUCH_TASK_PATH`, edit `/workspace`, and exit.
+
+```sh
+AGENT_SRC="$EXAMPLE_ROOT/auth-hotfix-agent"
+mkdir -p "$AGENT_SRC"
+
+cat > "$AGENT_SRC/main.go" <<'GO'
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+)
+
+func replace(path, before, after string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	updated := bytes.Replace(data, []byte(before), []byte(after), 1)
+	if bytes.Equal(data, updated) {
+		return fmt.Errorf("%s did not contain the expected text", path)
+	}
+	return os.WriteFile(path, updated, 0o600)
+}
+
+func main() {
+	if _, err := os.ReadFile(os.Getenv("VOUCH_TASK_PATH")); err != nil {
+		panic(err)
+	}
+	if err := replace(
+		"/workspace/internal/auth/refresh.go",
+		"return false",
+		"return true",
+	); err != nil {
+		panic(err)
+	}
+	if err := replace(
+		"/workspace/internal/auth/refresh_test.go",
+		"func TestRefreshAllowed() {}",
+		"func TestRefreshAllowed() { /* independently verified later */ }",
+	); err != nil {
+		panic(err)
+	}
+}
+GO
+
+ENGINE_ARCH="$(docker version --format '{{.Server.Arch}}')"
+CGO_ENABLED=0 GOOS=linux GOARCH="$ENGINE_ARCH" \
+  go build -trimpath \
+  -o "$AGENT_SRC/auth-hotfix-agent" \
+  "$AGENT_SRC/main.go"
+
+cat > "$AGENT_SRC/Dockerfile" <<'DOCKER'
+FROM scratch
+COPY auth-hotfix-agent /auth-hotfix-agent
+DOCKER
+
+docker build \
+  --network=none \
+  --pull=false \
+  --tag vouch-example-auth-agent:local \
+  "$AGENT_SRC"
+AGENT_IMAGE="$(
+  docker image inspect \
+    --format '{{.Id}}' \
+    vouch-example-auth-agent:local
+)"
+```
+
+`AGENT_IMAGE` is the immutable local `sha256:...` image ID. Production
+deployments normally use a registry reference of the form
+`registry.example/agent@sha256:...`.
+
+### Start the Runtime and run the task
+
+```sh
+go install ./cmd/vouch ./cmd/vouchd
+
+RUNTIME="$EXAMPLE_ROOT/runtime"
+SOCKET="$RUNTIME/vouchd.sock"
+mkdir -p "$RUNTIME"
+
+vouchd \
+  --repo "$REPO" \
+  --db "$RUNTIME/kernel.db" \
+  --socket "$SOCKET" \
+  --transaction-root "$RUNTIME/transactions" \
+  >"$RUNTIME/vouchd.log" 2>&1 &
+DAEMON_PID=$!
+
+while [ ! -S "$SOCKET" ]; do
+  sleep 0.1
+done
+
+vouch --repo "$REPO" --json run \
+  --socket "$SOCKET" \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --run run:pay-1842 \
+  --intent "Fix PAY-1842: valid refresh tokens are rejected" \
+  --runtime oci \
+  --image "$AGENT_IMAGE" \
+  -- /auth-hotfix-agent \
+  > "$EXAMPLE_ROOT/run.json"
+
+jq '{
+  transaction: .projection.transaction.id,
+  state: .projection.transaction.state,
+  execution: .execution.status,
+  effects: (.projection.effects | length),
+  decision: .decision.outcome
+}' "$EXAMPLE_ROOT/run.json"
+```
+
+The result is:
+
+```json
+{
+  "transaction": "tx:pay-1842",
+  "state": "validating",
+  "execution": "succeeded",
+  "effects": 2,
+  "decision": "require_approval"
+}
+```
+
+The response contains the detached workspace, daemon-authored execution
+receipt, normalized effects, and sequence decision. Inspect the durable state:
+
+```sh
+vouch --repo "$REPO" status tx:pay-1842 \
+  --socket "$SOCKET" \
+  --namespace payments
+
+vouch --repo "$REPO" tx effects \
+  --socket "$SOCKET" \
+  --namespace payments \
+  --id tx:pay-1842
+
+vouch --repo "$REPO" tx events \
+  --socket "$SOCKET" \
+  --namespace payments \
+  --id tx:pay-1842
+
+# The agent never edited the developer's source checkout.
+git -C "$REPO" diff --exit-code
+```
+
+Because authentication code and its test changed together, the baseline
+sequence policy routes this transaction to focused approval. It does not
+silently publish the change. Stop the example daemon with:
+
+```sh
+kill "$DAEMON_PID"
+```
+
+## 3. Production pattern: model-assisted coding agent
+
+Assume a payments team has:
+
+- repository `/srv/repos/payments-api`;
+- ticket file `tickets/PAY-1842.md`;
+- repository-owned agent profile `payments-coder`;
+- a daemon-configured `openai` broker policy;
+- independent verifier image and security approver.
+
+The operator uses its short-lived OIDC token for admission, execution,
+verification, and preparation:
+
+```sh
+export VOUCH_IDENTITY_TOKEN="$PAYMENTS_OPERATOR_TOKEN"
+```
+
+The allowed release ref must already exist at the transaction's exact base
+revision and must not be checked out:
+
+```sh
+git -C /srv/repos/payments-api \
+  branch agent-release/pay-1842 HEAD
+```
+
+The developer starts exactly one admitted task:
+
+```sh
+vouch --repo /srv/repos/payments-api run \
+  --socket /run/vouch/vouchd.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --run run:pay-1842 \
+  --intent-file tickets/PAY-1842.md \
+  --agent payments-coder \
+  --model-provider openai
+```
+
+The coding agent receives the task and detached worktree. It can reach only
+the transaction-specific model broker. `OPENAI_API_KEY` inside the container is
+a short-lived broker token; the provider key remains in `vouchd`. Direct
+Internet access, the source checkout, daemon socket, GitHub token and production
+database credentials are absent.
+
+After the agent exits, the team independently verifies the frozen tree:
+
+```sh
+VERIFIER_IMAGE="$(cat /etc/vouch/images/go-verifier.ref)"
+
+vouch --repo /srv/repos/payments-api tx verify \
+  --socket /run/vouch/vouchd.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --name auth-tests \
+  --image "$VERIFIER_IMAGE" \
+  -- /usr/local/bin/run-auth-tests
+
+vouch --repo /srv/repos/payments-api tx prepare \
+  --socket /run/vouch/vouchd.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --git-ref refs/heads/agent-release/pay-1842
+```
+
+The verifier image and command must exactly match a daemon-owned verifier
+profile. A security reviewer then signs the exact frozen approval package:
+
+```sh
+export VOUCH_IDENTITY_TOKEN="$PAYMENTS_REVIEWER_TOKEN"
+
+vouch --repo /srv/repos/payments-api tx approve \
+  --socket /run/vouch/vouchd.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --key /secure/payments-reviewer.key \
+  --key-id key:payments-reviewer \
+  --approver human:alice \
+  --issuer https://login.acme.example/ \
+  --class security-reviewer
+```
+
+The issuer must exactly match the trusted OIDC issuer. A different release
+identity performs release:
+
+```sh
+export VOUCH_IDENTITY_TOKEN="$PAYMENTS_RELEASER_TOKEN"
+
+vouch --repo /srv/repos/payments-api tx release \
+  --socket /run/vouch/vouchd.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --actor operator:payments-release \
+  --actor-kind operator
+```
+
+Release updates only the pre-existing allowed local Git ref with
+compare-and-swap. Vouch does not push or merge a remote pull request in the
+current profile. The trust setup is described in the
+[production operations guide](PRODUCTION.md).
+
+## 4. Production pattern: networkless migration generation
+
+A schema team can run a deterministic migration generator without any model
+authority:
+
+```sh
+vouch --repo /srv/repos/orders-api run \
+  --socket /run/vouch/vouchd.sock \
+  --namespace database \
+  --id tx:orders-297 \
+  --intent-file tickets/ORDERS-297.md \
+  --agent sql-migration-generator
+```
+
+Because `--model-provider` is absent, the agent container starts with
+`network=none` and no broker variables. It can create a migration and tests in
+the detached worktree, but it receives no database credentials and cannot
+apply the migration to production. Review, verification and release operate on
+the exact generated Git effects.
+
+## 5. What is not a current example
+
+The accounts-payable scenario—create vendor, change bank details, approve an
+invoice and transfer money—is the intended multi-system Agent OS direction,
+not an implemented connector in this repository. Today Vouch cannot honestly
+claim to execute or roll back SAP, Salesforce, cloud or bank operations.
+
+That future flow requires typed connector drivers, scoped downstream
+credentials, separation-of-duty policies, outcome reconciliation and
+compensation. The current Git Runtime supplies the kernel pattern those
+connectors will use, but the connector work remains on the roadmap.

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -1,14 +1,14 @@
-# Real-world Runtime examples
+# Runtime examples
 
 Vouch's implemented production boundary today is a Git repository on one
 trusted node. These examples therefore use software-delivery work rather than
 pretending that the current repository can already control SAP, Salesforce or
 bank transfers.
 
-## 1. Run the shipped production scenario
+## 1. Run the repository production-acceptance scenario
 
-The fastest complete example is the same acceptance flow used before release.
-It requires Git, Go, Docker, `jq`, and `curl`:
+The fastest end-to-end local-Git example is the same acceptance flow used
+before release. It requires Git, Go, Docker, `jq`, and `curl`:
 
 ```sh
 go test ./...
@@ -39,7 +39,7 @@ receipt records an unknown call rather than pretending it succeeded. The
 scenario also proves that the provider credential never reaches the agent and
 that direct agent Internet egress is blocked.
 
-## 2. Runnable example: authentication hotfix
+## 2. Runnable deterministic fixture: authentication hotfix
 
 This example creates a small payments-service repository and a digest-pinned
 agent image. The agent changes authentication code and its test inside a Vouch
@@ -228,7 +228,11 @@ silently publish the change. Stop the example daemon with:
 kill "$DAEMON_PID"
 ```
 
-## 3. Production pattern: model-assisted coding agent
+## 3. Illustrative deployment pattern: model-assisted coding agent
+
+Unlike the first two sections, this is not a self-contained shipped example.
+It assumes that the operator has supplied the named agent and verifier images,
+OIDC configuration and production trust material.
 
 Assume a payments team has:
 
@@ -328,7 +332,7 @@ compare-and-swap. Vouch does not push or merge a remote pull request in the
 current profile. The trust setup is described in the
 [production operations guide](PRODUCTION.md).
 
-## 4. Production pattern: networkless migration generation
+## 4. Illustrative deployment pattern: networkless migration generation
 
 A schema team can run a deterministic migration generator without any model
 authority:
@@ -348,7 +352,7 @@ the detached worktree, but it receives no database credentials and cannot
 apply the migration to production. Review, verification and release operate on
 the exact generated Git effects.
 
-## 5. What is not a current example
+## 5. Planned multi-system examples
 
 The accounts-payable scenario—create vendor, change bank details, approve an
 invoice and transfer money—is the intended multi-system Agent OS direction,
@@ -357,5 +361,5 @@ claim to execute or roll back SAP, Salesforce, cloud or bank operations.
 
 That future flow requires typed connector drivers, scoped downstream
 credentials, separation-of-duty policies, outcome reconciliation and
-compensation. The current Git Runtime supplies the kernel pattern those
-connectors will use, but the connector work remains on the roadmap.
+compensation. The current Git Runtime proves transaction primitives intended to
+support those future connectors, but the connector work remains on the roadmap.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -3,12 +3,15 @@
 Vouch's production profile is a single-node Vouch Runtime for autonomous
 software changes released through local Git refs. It enforces the Runtime
 boundary; it does not turn the current implementation into a multi-tenant or
-highly available Vouch Control Plane. This narrow, single-tenant Git profile is
-supported only for revisions that pass the mandatory Go formatting,
+highly available Vouch Agent OS. It is the hardened operator profile for the
+same kernel used by the Vouch Developer Runtime, not a fleet product. This
+narrow, single-tenant Git profile is supported only for revisions that pass the
+mandatory Go formatting,
 module, test, vet, and `govulncheck` checks; kernel race tests; VouchBench,
 VouchKernelBench, VouchTransactionBench, VouchRuntimeBench; and production OCI
-acceptance. Vouch Contracts, enterprise connector drivers, multi-tenancy and HA
-architecture remain beta.
+acceptance. Vouch Contracts has separate beta status. Enterprise connector
+drivers, multi-tenancy, HA and the Control Plane are not implemented in this
+profile.
 
 ## Enforced production boundary
 
@@ -257,7 +260,7 @@ account and uses that same numeric UID/GID for agent and verifier containers.
 Linux bind-mounted worktrees and broker receipt directories must have the same
 owner. Vouch refuses a mismatched non-root production configuration rather
 than starting containers that cannot write their staged state. A root-run
-daemon configuration is outside this narrow productionized boundary.
+daemon configuration is outside this narrow hardened execution boundary.
 
 Set the caller's short-lived access token for every CLI process:
 
@@ -425,9 +428,10 @@ acceptable:
   SQLite/WAL, bind-mounted transaction worktrees, immutable verifier
   materializations, and evidence. Host filesystem exhaustion is not contained
   by OCI resource flags.
-- One deeply implemented release connector: compare-and-swap updates of local
-  Git refs. There is no push, pull-request merge, deployment, or production
-  database connector.
+- One deeply implemented release primitive: compare-and-swap updates of local
+  Git refs. It is not yet behind the planned generic connector interface.
+  There is no push, pull-request merge, deployment, or production database
+  connector.
 - Static OIDC issuer/JWKS trust only. There is no discovery, automatic JWKS
   refresh, token revocation feed, Entra/Okta provisioning adapter, or SCIM
   lifecycle integration.
@@ -463,6 +467,8 @@ acceptable:
   atomic, version-checked Git-ref update.
 
 Within those limits and after all mandatory gates pass, the single-node,
-single-tenant Git runtime is the productionized profile. The compiler's wider
-product surface, additional effect connectors, enterprise administration,
-multi-tenancy, and HA remain beta.
+single-tenant Git runtime is the hardened production execution profile. This
+does not imply stable product packaging or fleet operations. The compiler's
+wider product surface remains experimental. Additional effect connectors,
+enterprise administration, multi-tenancy and HA are planned and unimplemented,
+not beta features of this profile.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -95,10 +95,12 @@ The production runtime:
   endpoints.
 - Permanently denies mediated filesystem reads and writes through any `.git`
   or `.vouch` path component, regardless of the requested capability.
-- Optionally gives an agent model access through a transaction-specific broker.
-  The agent receives no provider credential and has no direct Internet route;
-  the broker enforces the provider origin, model/tool allowlists, byte and token
-  budgets, stateless requests, and a durable hash-chained receipt ledger.
+- Gives an agent model access only when admission explicitly declares the
+  daemon provider, such as `vouch run --model-provider openai`. The
+  transaction-specific broker remains a daemon ceiling: the agent receives no
+  provider credential and has no direct Internet route; the broker enforces
+  the provider origin, model/tool allowlists, byte and token budgets, stateless
+  requests, and a durable hash-chained receipt ledger.
   Completed, failed, and unknown call counts are bound into the execution
   receipt. Missing/invalid provider usage is marked unknown and conservatively
   exhausts the input budget.
@@ -284,6 +286,20 @@ The initial broker supports only OpenAI-compatible `POST /v1/responses`. Its
 policy must use an HTTPS upstream and `force_store_false: true` in production.
 The agent sees a transaction-scoped broker credential as `OPENAI_API_KEY` and
 the internal broker URL as `OPENAI_BASE_URL`; it never sees the provider key.
+Model access is still absent by default. Admit it for one task with:
+
+```sh
+vouch --repo /srv/vouch/service run \
+  --socket /run/vouch/vouchd.sock \
+  --namespace engineering \
+  --intent "Fix the approved authentication regression" \
+  --agent coding-agent \
+  --model-provider openai
+```
+
+Omitting `--model-provider` produces a networkless agent container. Requesting
+a provider that does not exactly match the daemon broker policy is denied
+before a broker or agent workload starts.
 
 Use a dedicated release ref that is not checked out in the source repository.
 Vouch rejects publication to a checked-out ref because the worktree and index
@@ -438,6 +454,11 @@ acceptable:
   mutation APIs are disabled in production; transaction authority begins at
   atomic task admission. The mediated filesystem API cannot access `.git` or
   `.vouch` control state.
+- OCI launch revalidates live admission authority and atomically pins the
+  admitted run and transaction heads while recording execution start before
+  any workload. Run and transaction execution events are not yet advanced and
+  settled as one paired lifecycle, and run budget usage is not yet durably
+  charged. That is the remaining OS-3 boundary.
 - No claim of universal rollback. The implemented commit primitive is an
   atomic, version-checked Git-ref update.
 

--- a/docs/PRODUCT_VALIDATION.md
+++ b/docs/PRODUCT_VALIDATION.md
@@ -18,12 +18,24 @@ is not yet commercially validated.
 
 The strongest current positioning is:
 
-> **Vouch Runtime provides stateful transaction and outcome integrity for
-> actions proposed by autonomous agents.**
+> **Vouch Runtime provides stateful transaction and outcome integrity for local
+> Git actions proposed by autonomous agents.**
 
 “Vouch Agent OS” describes the complete architecture. It is not a
 differentiated market category by itself and should not be the primary external
 claim yet.
+
+One kernel can still support two experiences:
+
+- **Vouch Developer Runtime:** local isolation, exact Git effects and controlled
+  release for developers integrating an existing agent. This is the shortest
+  route to real usage and kernel feedback.
+- **Vouch Agent OS:** the enterprise experience with non-bypassable remote
+  connectors, cross-run policy and fleet administration. This remains
+  conditional on connector proof and paid design-partner evidence.
+
+Developer adoption validates usability and transaction semantics; it does not
+by itself validate the enterprise buying hypothesis.
 
 ## The customer problem
 
@@ -180,19 +192,21 @@ The repository proves meaningful ingredients:
 
 It does not yet prove the intended Runtime enforcement boundary:
 
-- atomic admission now binds the retained task, a content-digest
+- atomic admission binds the retained task, a content-digest
   `ExecutionContract`, a durable `AgentRun`, initial capability grants and the
-  transaction, but production OCI execution does not yet transition that run
-  or consume those grants;
-- budgets, lineage, data boundaries and release scope are therefore not yet
-  enforced as one synchronized execution lifecycle;
+  transaction; production OCI launch now reloads that authority and atomically
+  pins the run and transaction heads, but it does not yet advance the run
+  lifecycle or durably charge budget usage;
+- lineage, durable budgets, narrower data boundaries and release scope are not
+  yet enforced as one synchronized execution lifecycle;
 - lifecycle controls do not yet interrupt a running production OCI workload;
 - there is no connector driver interface or external production connector;
 - sequence policy does not span transactions, sessions or identity lineage;
 - there is no Runtime fleet or Vouch Control Plane.
 
-The current implementation is therefore a strong local mechanism prototype,
-not yet evidence that customers will adopt or pay for the broader system.
+The current implementation is therefore a strong local enforcement slice and
+mechanism proof, not yet evidence that customers will adopt or pay for the
+broader system.
 
 ## Falsifiable product hypotheses
 
@@ -215,12 +229,13 @@ or treat the receipts and recovery guarantees as compliance nice-to-haves.
 Proceed with:
 
 1. one coherent, stateful Runtime kernel path;
-2. an authenticated agent action protocol and durable connector coordinator;
-3. lineage-aware policy across runs, transactions and systems;
-4. GitHub as the first technical driver, not an assumed standalone market;
-5. rapid Kubernetes and PostgreSQL follow-through toward one cross-system
+2. a low-friction Developer Runtime shell around that same kernel;
+3. an authenticated agent action protocol and durable connector coordinator;
+4. lineage-aware policy across runs, transactions and systems;
+5. GitHub as the first technical driver, not an assumed standalone market;
+6. rapid Kubernetes and PostgreSQL follow-through toward one cross-system
    release transaction;
-6. customer discovery and paid-pilot tests in parallel.
+7. customer discovery and paid-pilot tests in parallel.
 
 Do not build the Vouch Control Plane, a new identity system, a new generic
 policy language, a workflow engine or a connector marketplace until the paid

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -169,6 +169,10 @@ The model name must also be allowed by daemon policy. Selecting an unconfigured
 provider, changing the admitted image or command, launching after expiry, or
 racing a run cancellation fails before any broker or agent workload starts.
 
+The [real-world examples guide](EXAMPLES.md) contains a complete runnable
+authentication-hotfix scenario plus production coding-agent and networkless
+migration workflows.
+
 Verification, preparation and authority remain explicit operations:
 
 ```sh

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -82,6 +82,93 @@ The agent should read the task from `VOUCH_TASK_PATH`. Do not put credentials
 or other secrets in task intent; the envelope is intentionally retained in the
 durable transaction history.
 
+## Agent integration contract
+
+An existing coding agent does not need to adopt a Vouch SDK. Its OCI entrypoint
+receives:
+
+```text
+/workspace                 writable detached Git worktree
+/vouch/task.json           read-only admitted AgentTask
+VOUCH_TASK_PATH            /vouch/task.json
+VOUCH_TASK_DIGEST          digest of that exact task
+VOUCH_TRANSACTION_ID       kernel transaction identity
+VOUCH_RUN_ID               kernel run identity
+VOUCH_RUNTIME_ROLE         agent
+```
+
+The process edits `/workspace` and exits. It must not receive the source
+repository, the `vouchd` socket, Git hosting credentials or downstream
+production credentials. Vouch re-inspects the worktree, freezes the exact
+effects and records the daemon-authored process receipt.
+
+Example entrypoint:
+
+```sh
+#!/bin/sh
+set -eu
+test "$VOUCH_RUNTIME_ROLE" = agent
+test -r "$VOUCH_TASK_PATH"
+cd /workspace
+exec /opt/acme-agent --task-file "$VOUCH_TASK_PATH"
+```
+
+### No model access
+
+Without `--model-provider`, the agent starts with `network=none`; model broker
+variables are absent:
+
+```sh
+vouch --repo /path/to/service run \
+  --namespace payments \
+  --intent "Apply the checked-in deterministic migration" \
+  --agent migration-agent
+```
+
+### Explicit model access
+
+If the daemon has a pinned broker image and policy for `openai`, request that
+provider in task admission:
+
+```sh
+vouch --repo /path/to/service run \
+  --namespace payments \
+  --intent "Fix the failing idempotency test" \
+  --agent coding-agent \
+  --model-provider openai
+```
+
+The agent then receives `OPENAI_BASE_URL` and a transaction-scoped
+`OPENAI_API_KEY` that authenticate only to the internal broker. The real
+provider credential remains in `vouchd`. The broker enforces the configured
+origin, model allowlist and request/token ceilings and writes a hash-chained
+receipt ledger.
+
+```python
+import json
+import os
+import urllib.request
+
+request = urllib.request.Request(
+    os.environ["OPENAI_BASE_URL"] + "/responses",
+    data=json.dumps({
+        "model": "policy-allowed-model",
+        "input": "Review the current worktree change.",
+        "store": False,
+    }).encode(),
+    headers={
+        "Authorization": "Bearer " + os.environ["OPENAI_API_KEY"],
+        "Content-Type": "application/json",
+    },
+)
+with urllib.request.urlopen(request, timeout=30) as response:
+    result = json.load(response)
+```
+
+The model name must also be allowed by daemon policy. Selecting an unconfigured
+provider, changing the admitted image or command, launching after expiry, or
+racing a run cancellation fails before any broker or agent workload starts.
+
 Verification, preparation and authority remain explicit operations:
 
 ```sh

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -4,7 +4,7 @@ Vouch Runtime provides the executable transaction path. Its development
 profile supports local exploration; its supported enforcement profile is
 deliberately limited to a single-node, single-tenant local-Git runtime.
 
-The complete implemented lifecycle is:
+The implemented local-Git transaction path is:
 
 ```text
 human intent + selected agent profile
@@ -22,6 +22,14 @@ human intent + selected agent profile
   -> compare-and-swap update of an allowed local Git ref
 ```
 
+This is the transaction-ledger path, not yet one fully paired execution
+lifecycle. Admission creates the associated `AgentRun`, and launch revalidates
+its live authority and atomically pins both ledger heads. The OCI workload
+currently advances and settles only the transaction ledger; the run lifecycle
+and durable budget usage are not yet advanced with it. A metadata cancellation
+before launch can prevent launch, but Vouch does not yet provide a supervisor
+that interrupts an already-running production workload.
+
 Vouch can create and publish the prepared commit to an allowed local Git ref.
 It does not push to a remote, merge a pull request, deploy software, or execute
 a production-database effect. Those connectors remain outside the implemented
@@ -29,22 +37,34 @@ profile.
 
 ## Walkthrough
 
-Start the local daemon. Its transaction root must be outside the repository:
+Create a strict profile for a digest-pinned image that is already loaded in the
+local OCI engine:
 
 ```sh
-vouch --repo /path/to/service daemon \
-  --transaction-root /tmp/vouch-service-transactions
+vouch --repo /path/to/service runtime init \
+  --agent coding-agent \
+  --image registry.example/agent@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --source-digest sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+  -- /usr/local/bin/agent
 ```
 
-Run a task through the primary runtime surface:
+Start the local daemon. The convenience command keeps its transaction root
+outside the repository:
 
 ```sh
+vouch --repo /path/to/service daemon
+```
+
+In another terminal, diagnose the selected profile and run a task through the
+primary Runtime surface:
+
+```sh
+vouch --repo /path/to/service doctor --agent coding-agent
+
 vouch --repo /path/to/service run \
   --namespace payments \
   --intent "Upgrade the service without changing authentication behavior" \
-  --runtime oci \
-  --image registry.example/agent@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-  -- /usr/local/bin/agent
+  --agent coding-agent
 ```
 
 `vouch run` creates and starts the transaction, creates its isolated worktree,
@@ -62,9 +82,8 @@ vouch --repo /path/to/service tx events \
   --namespace payments --id <transaction-id>
 ```
 
-For repeatable agent integrations, define `.vouch/agent-profiles.json` using
-the [public profile schema](../schemas/vouch.agent_profiles.v0.schema.json) and
-run with `--agent NAME` instead of supplying a raw image and command. The
+`vouch runtime init` writes `.vouch/agent-profiles.json` using the
+[public profile schema](../schemas/vouch.agent_profiles.v0.schema.json). The
 [checked-in fixture](../schemas/fixtures/runtime/valid/agent_profiles.json)
 shows the complete document shape.
 
@@ -166,12 +185,13 @@ with urllib.request.urlopen(request, timeout=30) as response:
 ```
 
 The model name must also be allowed by daemon policy. Selecting an unconfigured
-provider, changing the admitted image or command, launching after expiry, or
-racing a run cancellation fails before any broker or agent workload starts.
+provider, changing the admitted image or command, launching after expiry, or a
+terminal run transition that wins the atomic launch claim fails before any
+broker or agent workload starts.
 
-The [real-world examples guide](EXAMPLES.md) contains a complete runnable
-authentication-hotfix scenario plus production coding-agent and networkless
-migration workflows.
+The [Runtime examples guide](EXAMPLES.md) contains a runnable deterministic
+authentication-hotfix fixture plus illustrative coding-agent and networkless
+migration deployment patterns.
 
 Verification, preparation and authority remain explicit operations:
 
@@ -206,7 +226,8 @@ development profile. Existing-transaction operations such as
 `start|worktree|stage|validate` remain available for connector development,
 recovery and debugging. They do not replace the primary task-oriented path,
 and production transaction creation requires atomic task admission. Abort
-discards an unreleased isolated worktree:
+discards an unreleased isolated worktree after execution; it is not a live
+workload-cancellation command:
 
 ```sh
 vouch --repo /path/to/service tx abort \

--- a/docs/architecture/KERNEL_SEMANTICS.md
+++ b/docs/architecture/KERNEL_SEMANTICS.md
@@ -59,6 +59,30 @@ or later lifecycle progress. Reusing the key with changed authority fails with
 `KERNEL_IDEMPOTENCY_CONFLICT`. A failed persistence step leaves none of the
 admission resources behind.
 
+## Live execution authority
+
+Before daemon-owned OCI execution performs workspace ownership changes, starts
+a model broker or launches a container, `vouchd` reads one consistent
+transaction-keyed authority snapshot. It verifies the complete run and
+transaction event histories, then compiles an execution plan from the current
+task, contract, admitted run, grants and transaction.
+
+The image reference and command remain untrusted executable material: their
+digests must match the persisted task. The caller may narrow the timeout but
+cannot widen the live deadline. The current profile supports exactly
+`workspace/**` read/write and optional `model` `<provider>/*` `model.invoke`
+authority through the configured daemon broker. Narrower mounts, unsupported
+conditions and unimplemented budgets fail before workload creation.
+
+After preflight and non-workload preparation, launch is claimed in one SQLite
+transaction: the admitted run head and transaction head must still match the
+snapshot while `agent_execution.started` is appended. The authority deadline
+also bounds model-broker startup. A stale or expired plan therefore starts no
+broker or agent container.
+
+The claim does not yet advance and settle both lifecycle ledgers. That paired
+run/transaction mutation and durable usage charging are the next OS-3 step.
+
 ## Action lifecycle
 
 ```text

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -66,6 +66,30 @@ with `--agent NAME`; Vouch then binds the profile, pinned image, final command
 and exact intent into a durable task envelope mounted read-only at
 `/vouch/task.json`.
 
+An agent integration only needs to read `$VOUCH_TASK_PATH`, edit `/workspace`
+and exit. It should never receive the daemon socket or production credentials.
+Without explicit model authority the container has no network:
+
+```sh
+vouch --repo /path/to/service run \
+  --intent "Apply the deterministic migration" \
+  --agent migration-agent
+```
+
+When the daemon has a pinned provider broker, one task can request it
+explicitly:
+
+```sh
+vouch --repo /path/to/service run \
+  --intent "Fix the failing authentication test" \
+  --agent coding-agent \
+  --model-provider openai
+```
+
+The resulting `OPENAI_API_KEY` is a transaction-scoped broker token, not the
+provider credential. A stale run, expired authority or executable mismatch is
+rejected before any broker or agent workload starts.
+
 Read the
 [transaction guide](https://github.com/duriantaco/vouch/blob/main/docs/TRANSACTIONS.md)
 and

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,8 +1,8 @@
 # Vouch
 
-Vouch is the transaction operating layer for autonomous software agents. Its
-customer-side Runtime controls the boundary between an agent's proposal and a
-real effect:
+Vouch is an enforcement kernel and transaction Runtime for autonomous software
+agents. Its customer-side Runtime controls the boundary between an agent's
+proposal and an exact effect:
 
 ```text
 intent
@@ -20,9 +20,13 @@ transaction state, verification, policy decisions and commit coordination.
 
 ## Product hierarchy
 
-- **Vouch Agent OS** is the complete target architecture: the Control Plane,
-  Runtime fleet, transaction protocol and connector model. It is an umbrella,
-  not another process.
+- **Vouch Developer Runtime** is the local product experience: run an existing
+  coding agent in an isolated Git transaction, inspect its effects and control
+  release. A low-level, manually operated local-Git integration exists today;
+  the self-serve developer preview is still a milestone.
+- **Vouch Agent OS** is the planned enterprise product experience and complete
+  target architecture: the Control Plane, Runtime fleet, transaction protocol
+  and connector model. It is an umbrella, not another process.
 - **Vouch Control Plane** is the planned commercial management layer for
   Runtime fleets, organization policy, approvals, audit and incident response.
 - **Vouch Runtime** is the deployable customer-side enforcement boundary. A
@@ -31,40 +35,44 @@ transaction state, verification, policy decisions and commit coordination.
 - **Vouch Contracts** is an optional verification module that compiles release
   intent into obligations and maps evidence to them.
 
-## Try the runtime
+The Developer Runtime and enterprise **Vouch Agent OS** experience use the same
+`vouchd` kernel; they are not separate engines.
 
-The current development workflow requires Git, an OCI engine, a running daemon
-and a digest-pinned agent image:
+## Try the Developer Runtime
+
+The current development workflow requires Git, an OCI engine and a
+digest-pinned agent image that is already loaded locally:
 
 ```sh
-go install ./cmd/vouch ./cmd/vouchd
+go install ./cmd/vouch
 
-vouchd \
-  --repo /path/to/service \
-  --db /tmp/vouch-service/kernel.db \
-  --socket /tmp/vouch-service/vouchd.sock \
-  --transaction-root /tmp/vouch-service/transactions
+vouch --repo /path/to/service runtime init \
+  --agent coding-agent \
+  --image registry.example/coding-agent@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --source-digest sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+  -- /usr/local/bin/agent
+
+vouch --repo /path/to/service daemon
 ```
 
 In another terminal:
 
 ```sh
+vouch --repo /path/to/service doctor --agent coding-agent
+
 vouch --repo /path/to/service run \
-  --socket /tmp/vouch-service/vouchd.sock \
-  --namespace local \
   --intent "Fix authentication without changing public behavior" \
-  --runtime oci \
-  --image registry.example/coding-agent@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
-  -- /usr/local/bin/agent
+  --agent coding-agent
 ```
 
 This development command creates the isolated worktree, runs the agent, freezes
 its Git effects and performs sequence validation. Production verification,
 approval and local-ref release require the hardened runtime configuration.
-For repeatable integrations, select a strict repository-owned agent profile
-with `--agent NAME`; Vouch then binds the profile, pinned image, final command
-and exact intent into a durable task envelope mounted read-only at
-`/vouch/task.json`.
+Runtime initialization creates a strict repository-owned agent profile. Vouch
+binds that profile, pinned image, final command and exact intent into a durable
+task envelope mounted read-only at `/vouch/task.json`. Doctor reports warnings
+for optional or intentionally stopped components and fails on broken configured
+requirements; it does not prove that every future task will succeed.
 
 An agent integration only needs to read `$VOUCH_TASK_PATH`, edit `/workspace`
 and exit. It should never receive the daemon socket or production credentials.
@@ -90,10 +98,10 @@ The resulting `OPENAI_API_KEY` is a transaction-scoped broker token, not the
 provider credential. A stale run, expired authority or executable mismatch is
 rejected before any broker or agent workload starts.
 
-For a complete runnable payments-service example, including building the
-agent image, starting `vouchd`, inspecting effects, and understanding why an
+For a runnable deterministic payments-service fixture, including building the
+agent image, starting `vouchd`, inspecting effects and understanding why an
 authentication change requires approval, read the
-[real-world examples guide](https://github.com/duriantaco/vouch/blob/main/docs/EXAMPLES.md).
+[Runtime examples guide](https://github.com/duriantaco/vouch/blob/main/docs/EXAMPLES.md).
 
 Read the
 [transaction guide](https://github.com/duriantaco/vouch/blob/main/docs/TRANSACTIONS.md)
@@ -110,7 +118,9 @@ releaser and atomic publication to an allowed local Git ref.
 
 It does not push or merge remote changes, deploy software, coordinate database
 or Kubernetes effects, isolate multiple tenants, expose a remote control API or
-provide high availability. Stable versioned release packaging is pending.
+provide high availability. The generic action/connector path and Control Plane
+shown in the Agent OS architecture are planned. Stable versioned release
+packaging is pending.
 
 ## Vouch Contracts
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -90,6 +90,11 @@ The resulting `OPENAI_API_KEY` is a transaction-scoped broker token, not the
 provider credential. A stale run, expired authority or executable mismatch is
 rejected before any broker or agent workload starts.
 
+For a complete runnable payments-service example, including building the
+agent image, starting `vouchd`, inspecting effects, and understanding why an
+authentication change requires approval, read the
+[real-world examples guide](https://github.com/duriantaco/vouch/blob/main/docs/EXAMPLES.md).
+
 Read the
 [transaction guide](https://github.com/duriantaco/vouch/blob/main/docs/TRANSACTIONS.md)
 and

--- a/internal/kernel/api/execution_authority.go
+++ b/internal/kernel/api/execution_authority.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/authority"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/sandbox"
+	"github.com/duriantaco/vouch/internal/kernel/store"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+type liveExecutionAuthority struct {
+	Plan               authority.ExecutionPlan
+	RunSequence        int64
+	RunLastEventDigest string
+}
+
+func (s *Server) compileLiveExecutionAuthority(
+	ctx context.Context,
+	namespace, transactionID string,
+	current transactionreducer.Projection,
+	image string,
+	command []string,
+	timeoutSeconds int64,
+) (liveExecutionAuthority, error) {
+	snapshot, err := s.store.GetExecutionAuthority(
+		ctx,
+		namespace,
+		transactionID,
+	)
+	if err != nil {
+		var kernelErr *model.KernelError
+		if errors.As(err, &kernelErr) &&
+			kernelErr.Code == model.ErrorNotFound {
+			return liveExecutionAuthority{}, &model.KernelError{
+				Code:      model.ErrorCapabilityDenied,
+				Operation: "compile_execution_authority",
+				Resource:  transactionID,
+				Message:   "daemon-owned execution requires atomic task admission",
+				Cause:     err,
+			}
+		}
+		return liveExecutionAuthority{}, err
+	}
+	if snapshot.Transaction.Transaction.EventSequence !=
+		current.Transaction.EventSequence ||
+		snapshot.Transaction.LastEventDigest != current.LastEventDigest {
+		return liveExecutionAuthority{}, &model.KernelError{
+			Code:      model.ErrorConflict,
+			Operation: "compile_execution_authority",
+			Resource:  transactionID,
+			Message:   "transaction changed while execution authority was loaded",
+		}
+	}
+	ceilings, err := s.executionAuthorityCeilings(image)
+	if err != nil {
+		return liveExecutionAuthority{}, err
+	}
+	var callerTimeout *int64
+	if timeoutSeconds > 0 {
+		callerTimeout = &timeoutSeconds
+	}
+	plan, err := authority.Compile(authority.CompileInput{
+		Task:                 snapshot.Task,
+		Contract:             snapshot.Contract,
+		Run:                  snapshot.Run.Run,
+		Grants:               snapshot.Grants,
+		Transaction:          snapshot.Transaction.Transaction,
+		Executions:           append([]model.AgentExecution(nil), snapshot.Transaction.Executions...),
+		ImageReference:       image,
+		Command:              append([]string(nil), command...),
+		Ceilings:             ceilings,
+		CallerTimeoutSeconds: callerTimeout,
+		Now:                  s.now().UTC(),
+	})
+	if err != nil {
+		return liveExecutionAuthority{}, err
+	}
+	return liveExecutionAuthority{
+		Plan:               plan,
+		RunSequence:        snapshot.Run.Run.EventSequence,
+		RunLastEventDigest: snapshot.Run.LastEventDigest,
+	}, nil
+}
+
+func (s *Server) requireLiveExecutionAuthority(
+	ctx context.Context,
+	transactionID string,
+	notAfter time.Time,
+) error {
+	if !s.now().UTC().Before(notAfter) {
+		return &model.KernelError{
+			Code:      model.ErrorCapabilityExpired,
+			Operation: "claim_execution_authority",
+			Resource:  transactionID,
+			Message:   "execution authority expired before workload launch",
+		}
+	}
+	if err := ctx.Err(); err != nil {
+		return &model.KernelError{
+			Code:      model.ErrorCapabilityExpired,
+			Operation: "claim_execution_authority",
+			Resource:  transactionID,
+			Message:   "execution authority ended before workload launch",
+			Cause:     err,
+		}
+	}
+	return nil
+}
+
+func (s *Server) executionAuthorityCeilings(
+	requestedImage string,
+) (authority.DaemonCeilings, error) {
+	allowed := s.executionPolicy.AllowedAgentImageDigests
+	if allowed == nil {
+		allowed = s.executionPolicy.AllowedImageDigests
+	}
+	digests := make([]string, 0, len(allowed))
+	for digest := range allowed {
+		digests = append(digests, digest)
+	}
+	if len(digests) == 0 {
+		if s.executionPolicy.EnforcementProfile ==
+			store.EnforcementProfileProduction {
+			return authority.DaemonCeilings{}, &model.KernelError{
+				Code:      model.ErrorCapabilityDenied,
+				Operation: "compile_execution_authority",
+				Resource:  requestedImage,
+				Message:   "production execution requires an agent image allowlist",
+			}
+		}
+		digest, err := sandbox.ImageDigest(requestedImage)
+		if err != nil {
+			return authority.DaemonCeilings{}, &model.KernelError{
+				Code:      model.ErrorSchemaInvalid,
+				Operation: "compile_execution_authority",
+				Resource:  requestedImage,
+				Message:   "agent image must be digest pinned",
+				Cause:     err,
+			}
+		}
+		digests = append(digests, digest)
+	}
+	sort.Strings(digests)
+	ceilings := authority.DaemonCeilings{
+		MaxWallTimeSeconds:  s.executionPolicy.MaxAgentTimeoutSecs,
+		AllowedImageDigests: digests,
+	}
+	if broker := s.executionPolicy.ModelBroker; broker != nil {
+		imageDigest, err := sandbox.ImageDigest(broker.Image)
+		if err != nil {
+			return authority.DaemonCeilings{}, &model.KernelError{
+				Code:      model.ErrorSchemaInvalid,
+				Operation: "compile_execution_authority",
+				Resource:  broker.Image,
+				Message:   "model broker image must be digest pinned",
+				Cause:     err,
+			}
+		}
+		ceilings.ModelBroker = &authority.ModelBrokerCeiling{
+			Provider:                  broker.Policy.Provider,
+			AllowedModels:             append([]string(nil), broker.Policy.AllowedModels...),
+			ImageDigest:               imageDigest,
+			PolicyDigest:              broker.PolicyDigest,
+			MaxModelCalls:             broker.Policy.MaxRequests,
+			MaxInputTokens:            broker.Policy.MaxTotalInputTokens,
+			MaxOutputTokens:           broker.Policy.MaxTotalOutputTokens,
+			MaxOutputTokensPerRequest: broker.Policy.MaxOutputTokensPerRequest,
+		}
+	}
+	return ceilings, nil
+}

--- a/internal/kernel/api/execution_authority_race_test.go
+++ b/internal/kernel/api/execution_authority_race_test.go
@@ -1,0 +1,299 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/eventlog"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	"github.com/duriantaco/vouch/internal/kernel/store"
+)
+
+func TestRunAgentExecutionRejectsAuthorityExpiringDuringPrelaunch(t *testing.T) {
+	t.Parallel()
+	base := time.Now().UTC().Add(5 * time.Minute).Truncate(time.Second)
+	clock := &prelaunchExpiryClock{
+		valid:   base,
+		expired: base.Add(11 * time.Second),
+	}
+	fixture := newExecutionAuthorityRaceAPIFixture(
+		t,
+		"deadline-prelaunch",
+		clock.Now,
+		nil,
+	)
+
+	clock.Arm()
+	assertExecutionAuthorityRejectedBeforeWorkload(
+		t,
+		fixture,
+		model.ErrorCapabilityExpired,
+	)
+	if calls := clock.ArmedCalls(); calls < 2 {
+		t.Fatalf("prelaunch clock calls=%d want at least 2", calls)
+	}
+}
+
+func TestRunAgentExecutionRejectsRunHeadChangingBeforeLaunchClaim(t *testing.T) {
+	t.Parallel()
+	base := time.Now().UTC().Add(5 * time.Minute).Truncate(time.Second)
+	var racingStore *runHeadChangingStore
+	fixture := newExecutionAuthorityRaceAPIFixture(
+		t,
+		"run-head-claim",
+		func() time.Time { return base },
+		func(kernelStore store.Store) store.Store {
+			racingStore = &runHeadChangingStore{
+				Store: kernelStore,
+				actor: model.Principal{
+					ID:   "service:authority-race",
+					Kind: model.PrincipalService,
+				},
+			}
+			return racingStore
+		},
+	)
+
+	response := requestJSON(
+		t,
+		fixture.handler,
+		http.MethodPost,
+		fmt.Sprintf(
+			"/v0/namespaces/%s/transactions/%s/executions/run",
+			fixture.namespace,
+			fixture.transactionID,
+		),
+		runAgentExecutionRequest{
+			ExpectedSequence: fixture.transactionHead,
+			Actor:            fixture.actor,
+			Image:            fixture.image,
+			Command:          append([]string(nil), fixture.command...),
+			TimeoutSeconds:   1,
+		},
+	)
+	if mutationErr := racingStore.MutationError(); mutationErr != nil {
+		t.Fatalf("change admitted run head: %v", mutationErr)
+	}
+	if !racingStore.Mutated() {
+		t.Fatal("authority snapshot did not trigger the run-head race")
+	}
+	if response.Code != http.StatusConflict {
+		t.Fatalf(
+			"run-head claim status=%d want=%d body=%s",
+			response.Code,
+			http.StatusConflict,
+			response.Body.String(),
+		)
+	}
+	var kernelErr model.KernelError
+	decodeResponse(t, response, &kernelErr)
+	if kernelErr.Code != model.ErrorConflict {
+		t.Fatalf(
+			"run-head claim code=%q want=%q body=%s",
+			kernelErr.Code,
+			model.ErrorConflict,
+			response.Body.String(),
+		)
+	}
+	if _, err := os.Stat(fixture.engineMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stale run authority invoked OCI engine: %v", err)
+	}
+
+	ctx := context.Background()
+	transaction, err := fixture.kernelStore.GetTransaction(
+		ctx,
+		fixture.namespace,
+		fixture.transactionID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transactionEvents, err := fixture.kernelStore.TransactionEvents(
+		ctx,
+		fixture.namespace,
+		fixture.transactionID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transaction.Transaction.EventSequence != fixture.transactionHead ||
+		len(transactionEvents) != fixture.transactionSize ||
+		len(transaction.Executions) != 0 {
+		t.Fatalf(
+			"failed run-head claim changed transaction: sequence=%d events=%d executions=%d",
+			transaction.Transaction.EventSequence,
+			len(transactionEvents),
+			len(transaction.Executions),
+		)
+	}
+
+	run, err := fixture.kernelStore.GetRun(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runEvents, err := fixture.kernelStore.Events(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Run.State != model.RunCancelled ||
+		run.Run.EventSequence != fixture.runHead+1 ||
+		len(runEvents) != fixture.runSize+1 {
+		t.Fatalf(
+			"racing run mutation missing: state=%q sequence=%d events=%d",
+			run.Run.State,
+			run.Run.EventSequence,
+			len(runEvents),
+		)
+	}
+}
+
+type prelaunchExpiryClock struct {
+	mu      sync.Mutex
+	valid   time.Time
+	expired time.Time
+	armed   bool
+	calls   int
+}
+
+func (clock *prelaunchExpiryClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	if !clock.armed {
+		return clock.valid
+	}
+	clock.calls++
+	if clock.calls == 1 {
+		return clock.valid
+	}
+	return clock.expired
+}
+
+func (clock *prelaunchExpiryClock) Arm() {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.armed = true
+	clock.calls = 0
+}
+
+func (clock *prelaunchExpiryClock) ArmedCalls() int {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.calls
+}
+
+type runHeadChangingStore struct {
+	store.Store
+	actor model.Principal
+
+	once        sync.Once
+	mu          sync.Mutex
+	mutated     bool
+	mutationErr error
+}
+
+func (kernelStore *runHeadChangingStore) GetExecutionAuthority(
+	ctx context.Context,
+	namespace, transactionID string,
+) (store.ExecutionAuthoritySnapshot, error) {
+	snapshot, err := kernelStore.Store.GetExecutionAuthority(
+		ctx,
+		namespace,
+		transactionID,
+	)
+	if err != nil {
+		return store.ExecutionAuthoritySnapshot{}, err
+	}
+	kernelStore.once.Do(func() {
+		event, eventErr := eventlog.Next(
+			snapshot.Run,
+			reducer.EventRunStateChanged,
+			kernelStore.actor,
+			snapshot.Run.Run.UpdatedAt.Add(time.Second),
+			model.RunStateChangedPayload{
+				From:   snapshot.Run.Run.State,
+				To:     model.RunCancelled,
+				Reason: "simulate a concurrent lifecycle decision",
+			},
+		)
+		if eventErr == nil {
+			_, eventErr = kernelStore.Store.AppendEvent(
+				ctx,
+				namespace,
+				snapshot.Run.Run.EventSequence,
+				event,
+			)
+		}
+		kernelStore.mu.Lock()
+		defer kernelStore.mu.Unlock()
+		kernelStore.mutated = eventErr == nil
+		kernelStore.mutationErr = eventErr
+	})
+	return snapshot, nil
+}
+
+func (kernelStore *runHeadChangingStore) Mutated() bool {
+	kernelStore.mu.Lock()
+	defer kernelStore.mu.Unlock()
+	return kernelStore.mutated
+}
+
+func (kernelStore *runHeadChangingStore) MutationError() error {
+	kernelStore.mu.Lock()
+	defer kernelStore.mu.Unlock()
+	return kernelStore.mutationErr
+}
+
+func newExecutionAuthorityRaceAPIFixture(
+	t *testing.T,
+	suffix string,
+	clock func() time.Time,
+	decorateStore func(store.Store) store.Store,
+) *executionAuthorityAPIFixture {
+	t.Helper()
+	fixture := newExecutionAuthorityServerFixtureWithOptions(
+		t,
+		suffix,
+		clock().UTC(),
+		clock,
+		decorateStore,
+	)
+	admitted := admitExecutionAuthorityTask(
+		t,
+		fixture,
+		suffix,
+		model.ContractResource{
+			ID: "workspace",
+			Selector: model.ResourceSelector{
+				Kind:    "filesystem",
+				Pattern: "workspace/**",
+			},
+			Operations: []string{
+				"filesystem.read",
+				"filesystem.write",
+			},
+			Conditions: model.CapabilityConditions{
+				WorkspaceRoot: "workspace",
+			},
+		},
+	)
+	fixture.prepareRunningTransaction(t, admitted.Transaction)
+	fixture.captureEventHeads(t)
+	return fixture
+}

--- a/internal/kernel/api/execution_authority_test.go
+++ b/internal/kernel/api/execution_authority_test.go
@@ -1,0 +1,544 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/store"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+	"github.com/duriantaco/vouch/internal/kernel/transaction/gitstage"
+)
+
+func TestRunAgentExecutionRejectsExpiredAuthorityBeforeWorkload(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 7, 28, 1, 0, 0, 0, time.UTC)
+	fixture := newExecutionAuthorityAPIFixture(
+		t,
+		"expired",
+		base,
+		model.ContractResource{
+			ID: "workspace",
+			Selector: model.ResourceSelector{
+				Kind:    "filesystem",
+				Pattern: "workspace/**",
+			},
+			Operations: []string{"filesystem.read", "filesystem.write"},
+			Conditions: model.CapabilityConditions{
+				WorkspaceRoot: "workspace",
+			},
+		},
+	)
+
+	fixture.now = base.Add(11 * time.Second)
+	assertExecutionAuthorityRejectedBeforeWorkload(
+		t,
+		fixture,
+		model.ErrorCapabilityExpired,
+	)
+}
+
+func TestRunAgentExecutionRejectsNarrowWorkspaceBeforeWorkload(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 7, 28, 2, 0, 0, 0, time.UTC)
+	fixture := newExecutionAuthorityAPIFixture(
+		t,
+		"narrow-workspace",
+		base,
+		model.ContractResource{
+			ID: "workspace-source-only",
+			Selector: model.ResourceSelector{
+				Kind:    "filesystem",
+				Pattern: "workspace/src/**",
+			},
+			Operations: []string{"filesystem.read", "filesystem.write"},
+			Conditions: model.CapabilityConditions{
+				WorkspaceRoot: "workspace",
+			},
+		},
+	)
+
+	assertExecutionAuthorityRejectedBeforeWorkload(
+		t,
+		fixture,
+		model.ErrorCapabilityDenied,
+	)
+}
+
+func TestRunAgentExecutionRejectsLegacyTransactionBeforeWorkload(t *testing.T) {
+	t.Parallel()
+	base := time.Date(2026, 7, 28, 3, 0, 0, 0, time.UTC)
+	fixture := newLegacyExecutionAuthorityAPIFixture(t, base)
+
+	assertExecutionAuthorityRejectedBeforeWorkload(
+		t,
+		fixture,
+		model.ErrorCapabilityDenied,
+	)
+}
+
+type executionAuthorityAPIFixture struct {
+	handler         http.Handler
+	kernelStore     *store.SQLiteStore
+	now             time.Time
+	namespace       string
+	transactionID   string
+	runID           string
+	image           string
+	command         []string
+	actor           model.Principal
+	engineMarker    string
+	transactionHead int64
+	transactionSize int
+	runHead         int64
+	runSize         int
+}
+
+func newExecutionAuthorityAPIFixture(
+	t *testing.T,
+	suffix string,
+	now time.Time,
+	resource model.ContractResource,
+) *executionAuthorityAPIFixture {
+	t.Helper()
+	fixture := newExecutionAuthorityServerFixture(t, suffix, now)
+	admitted := admitExecutionAuthorityTask(t, fixture, suffix, resource)
+	fixture.prepareRunningTransaction(t, admitted.Transaction)
+	fixture.captureEventHeads(t)
+	return fixture
+}
+
+func admitExecutionAuthorityTask(
+	t *testing.T,
+	fixture *executionAuthorityAPIFixture,
+	suffix string,
+	resource model.ContractResource,
+) admission.Result {
+	t.Helper()
+	commandDigest, err := transactionreducer.ComputeCommandDigest(fixture.command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	maxWallTime := int64(10)
+	request := admission.Request{
+		Version:        admission.RequestVersion,
+		IdempotencyKey: "admission:" + suffix,
+		TransactionID:  fixture.transactionID,
+		RunID:          fixture.runID,
+		Intent:         "Exercise only the authority admitted for this task.",
+		AgentProfile: model.AgentTaskProfileBinding{
+			ID:            "agent-profile:" + suffix,
+			Digest:        testDigest("b"),
+			RuntimeClass:  "oci",
+			ImageDigest:   testDigest("a"),
+			CommandDigest: commandDigest,
+		},
+		Sponsor: model.Principal{
+			ID:   "human:sponsor-" + suffix,
+			Kind: model.PrincipalHuman,
+		},
+		Actor: fixture.actor,
+		Contract: admission.ContractSpec{
+			Risk:      "high",
+			Resources: []model.ContractResource{resource},
+			Budgets: model.BudgetLimits{
+				MaxWallTimeSeconds: &maxWallTime,
+			},
+		},
+	}
+	response := requestJSON(
+		t,
+		fixture.handler,
+		http.MethodPost,
+		fmt.Sprintf(
+			"/v0/namespaces/%s/task-admissions",
+			fixture.namespace,
+		),
+		request,
+	)
+	if response.Code != http.StatusCreated {
+		t.Fatalf(
+			"task admission status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var admitted admission.Result
+	decodeResponse(t, response, &admitted)
+	return admitted
+}
+
+func newLegacyExecutionAuthorityAPIFixture(
+	t *testing.T,
+	now time.Time,
+) *executionAuthorityAPIFixture {
+	t.Helper()
+	fixture := newExecutionAuthorityServerFixture(t, "legacy", now)
+	transaction := model.AgentTransaction{
+		Version:                model.AgentTransactionVersion,
+		ID:                     fixture.transactionID,
+		Namespace:              fixture.namespace,
+		IntentDigest:           testDigest("c"),
+		Sponsor:                fixture.actor,
+		AgentRunIDs:            []string{fixture.runID},
+		StageBindings:          []model.StageBinding{},
+		State:                  model.TransactionCreated,
+		EffectIDs:              []string{},
+		VerificationResultIDs:  []string{},
+		OutstandingApprovalIDs: []string{},
+		EventSequence:          1,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	event, err := transactionreducer.CreationEvent(transaction, fixture.actor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := fixture.kernelStore.CreateTransaction(
+		context.Background(),
+		event,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.prepareRunningTransaction(t, created)
+	fixture.captureEventHeads(t)
+	return fixture
+}
+
+func newExecutionAuthorityServerFixture(
+	t *testing.T,
+	suffix string,
+	now time.Time,
+) *executionAuthorityAPIFixture {
+	t.Helper()
+	return newExecutionAuthorityServerFixtureWithOptions(
+		t,
+		suffix,
+		now,
+		nil,
+		nil,
+	)
+}
+
+func newExecutionAuthorityServerFixtureWithOptions(
+	t *testing.T,
+	suffix string,
+	now time.Time,
+	clock func() time.Time,
+	decorateStore func(store.Store) store.Store,
+) *executionAuthorityAPIFixture {
+	t.Helper()
+	repository := executionAuthorityRepository(t)
+	kernelStore, err := store.OpenSQLite(filepath.Join(t.TempDir(), "kernel.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernelStore.Close() })
+	manager, err := gitstage.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	marker := filepath.Join(t.TempDir(), "oci-invoked")
+	engine := filepath.Join(t.TempDir(), "fake-oci-engine")
+	engineScript := fmt.Sprintf(
+		"#!/bin/sh\nprintf 'invoked\\n' >> %q\nexit 97\n",
+		marker,
+	)
+	if err := os.WriteFile(engine, []byte(engineScript), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	fixture := &executionAuthorityAPIFixture{
+		kernelStore:   kernelStore,
+		now:           now,
+		namespace:     "authority-api",
+		transactionID: "tx:" + suffix,
+		runID:         "run:" + suffix,
+		image: "registry.example.invalid/agent@" +
+			testDigest("a"),
+		command:      []string{"/bin/sh", "-c", "exit 0"},
+		actor:        model.Principal{ID: "operator:authority", Kind: model.PrincipalOperator},
+		engineMarker: marker,
+	}
+	if clock == nil {
+		clock = func() time.Time { return fixture.now }
+	}
+	serverStore := store.Store(kernelStore)
+	if decorateStore != nil {
+		serverStore = decorateStore(serverStore)
+	}
+	fixture.handler = NewServer(
+		serverStore,
+		WithClock(clock),
+		WithTransactionRuntime(
+			manager,
+			repository,
+			t.TempDir(),
+			transactionreducer.BaselinePolicy{},
+		),
+		WithExecutionRuntimePolicy(ExecutionRuntimePolicy{
+			AllowedAgentImageDigests: map[string]struct{}{
+				testDigest("a"): {},
+			},
+			EnginePath:          engine,
+			VerifierUID:         1000,
+			VerifierGID:         1000,
+			VerifierMemoryBytes: 512 << 20,
+			VerifierCPUMillis:   1000,
+			VerifierPIDsLimit:   64,
+			VerifierTmpfsBytes:  64 << 20,
+			MaxAgentTimeoutSecs: 60,
+		}),
+	).Handler()
+	return fixture
+}
+
+func (fixture *executionAuthorityAPIFixture) prepareRunningTransaction(
+	t *testing.T,
+	projection transactionreducer.Projection,
+) {
+	t.Helper()
+	path := fmt.Sprintf(
+		"/v0/namespaces/%s/transactions/%s",
+		fixture.namespace,
+		fixture.transactionID,
+	)
+	response := requestJSON(
+		t,
+		fixture.handler,
+		http.MethodPost,
+		path+"/start",
+		transactionMutationRequest{
+			ExpectedSequence: projection.Transaction.EventSequence,
+			Actor:            fixture.actor,
+		},
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf(
+			"start transaction status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	decodeResponse(t, response, &projection)
+
+	worktreeResponse := requestJSON(
+		t,
+		fixture.handler,
+		http.MethodPost,
+		path+"/git-worktree",
+		createWorktreeRequest{
+			ExpectedSequence: projection.Transaction.EventSequence,
+			Actor:            fixture.actor,
+		},
+	)
+	if worktreeResponse.Code != http.StatusCreated {
+		t.Fatalf(
+			"create worktree status=%d body=%s",
+			worktreeResponse.Code,
+			worktreeResponse.Body.String(),
+		)
+	}
+}
+
+func (fixture *executionAuthorityAPIFixture) captureEventHeads(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	projection, err := fixture.kernelStore.GetTransaction(
+		ctx,
+		fixture.namespace,
+		fixture.transactionID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	events, err := fixture.kernelStore.TransactionEvents(
+		ctx,
+		fixture.namespace,
+		fixture.transactionID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.transactionHead = projection.Transaction.EventSequence
+	fixture.transactionSize = len(events)
+	if _, err := fixture.kernelStore.GetRun(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+	); err != nil {
+		var kernelErr *model.KernelError
+		if errors.As(err, &kernelErr) &&
+			kernelErr.Code == model.ErrorNotFound {
+			return
+		}
+		t.Fatal(err)
+	}
+	run, err := fixture.kernelStore.GetRun(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runEvents, err := fixture.kernelStore.Events(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fixture.runHead = run.Run.EventSequence
+	fixture.runSize = len(runEvents)
+}
+
+func assertExecutionAuthorityRejectedBeforeWorkload(
+	t *testing.T,
+	fixture *executionAuthorityAPIFixture,
+	wantCode model.ErrorCode,
+) {
+	t.Helper()
+	response := requestJSON(
+		t,
+		fixture.handler,
+		http.MethodPost,
+		fmt.Sprintf(
+			"/v0/namespaces/%s/transactions/%s/executions/run",
+			fixture.namespace,
+			fixture.transactionID,
+		),
+		runAgentExecutionRequest{
+			ExpectedSequence: fixture.transactionHead,
+			Actor:            fixture.actor,
+			Image:            fixture.image,
+			Command:          append([]string(nil), fixture.command...),
+			TimeoutSeconds:   1,
+		},
+	)
+	if response.Code != http.StatusForbidden {
+		t.Fatalf(
+			"execution rejection status=%d body=%s",
+			response.Code,
+			response.Body.String(),
+		)
+	}
+	var kernelErr model.KernelError
+	decodeResponse(t, response, &kernelErr)
+	if kernelErr.Code != wantCode {
+		t.Fatalf(
+			"execution rejection code=%q want=%q body=%s",
+			kernelErr.Code,
+			wantCode,
+			response.Body.String(),
+		)
+	}
+	if _, err := os.Stat(fixture.engineMarker); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("rejected authority invoked OCI engine: %v", err)
+	}
+
+	ctx := context.Background()
+	transaction, err := fixture.kernelStore.GetTransaction(
+		ctx,
+		fixture.namespace,
+		fixture.transactionID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transactionEvents, err := fixture.kernelStore.TransactionEvents(
+		ctx,
+		fixture.namespace,
+		fixture.transactionID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if transaction.Transaction.EventSequence != fixture.transactionHead ||
+		len(transactionEvents) != fixture.transactionSize ||
+		len(transaction.Executions) != 0 {
+		t.Fatalf(
+			"rejected authority changed transaction: sequence=%d events=%d executions=%d",
+			transaction.Transaction.EventSequence,
+			len(transactionEvents),
+			len(transaction.Executions),
+		)
+	}
+	if fixture.runHead == 0 {
+		return
+	}
+	run, err := fixture.kernelStore.GetRun(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runEvents, err := fixture.kernelStore.Events(
+		ctx,
+		fixture.namespace,
+		fixture.runID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Run.EventSequence != fixture.runHead ||
+		len(runEvents) != fixture.runSize {
+		t.Fatalf(
+			"rejected authority changed run: sequence=%d events=%d",
+			run.Run.EventSequence,
+			len(runEvents),
+		)
+	}
+}
+
+func executionAuthorityRepository(t *testing.T) string {
+	t.Helper()
+	repository := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repository, "src"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(repository, "src", "main.go"),
+		[]byte("package main\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	executionAuthorityGit(t, repository, "init", "--initial-branch=main")
+	executionAuthorityGit(t, repository, "add", "--", "src/main.go")
+	executionAuthorityGit(
+		t,
+		repository,
+		"-c",
+		"user.name=Vouch Test",
+		"-c",
+		"user.email=vouch@example.invalid",
+		"commit",
+		"-m",
+		"fixture",
+	)
+	return repository
+}
+
+func executionAuthorityGit(t *testing.T, repository string, arguments ...string) {
+	t.Helper()
+	command := exec.Command("git", append([]string{"-C", repository}, arguments...)...)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", arguments, err, output)
+	}
+}

--- a/internal/kernel/api/transaction_handlers.go
+++ b/internal/kernel/api/transaction_handlers.go
@@ -84,10 +84,9 @@ type finishAgentExecutionRequest struct {
 type runAgentExecutionRequest struct {
 	ExpectedSequence int64           `json:"expected_sequence"`
 	Actor            model.Principal `json:"actor"`
-	RunID            string          `json:"run_id"`
 	Image            string          `json:"image"`
 	Command          []string        `json:"command"`
-	TimeoutSeconds   int64           `json:"timeout_seconds"`
+	TimeoutSeconds   int64           `json:"timeout_seconds,omitempty"`
 }
 
 type runAgentExecutionResponse struct {
@@ -423,31 +422,12 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	if !model.IsIdentifier(request.RunID) ||
-		len(request.Command) == 0 ||
+	if len(request.Command) == 0 ||
 		request.Image == "" ||
-		request.TimeoutSeconds < 1 ||
+		request.TimeoutSeconds < 0 ||
 		s.executionPolicy.MaxAgentTimeoutSecs < 1 ||
-		request.TimeoutSeconds > s.executionPolicy.MaxAgentTimeoutSecs ||
 		s.executionPolicy.EnginePath == "" {
 		writeError(w, schemaError("daemon-run agent request or runtime policy is invalid", nil))
-		return
-	}
-	imageDigest, err := sandbox.ImageDigest(request.Image)
-	if err != nil {
-		writeError(w, schemaError("agent image must be digest-pinned", err))
-		return
-	}
-	if !s.executionPolicy.agentImageAllowed(imageDigest) {
-		writeError(w, &model.KernelError{
-			Code: model.ErrorCapabilityDenied, Operation: "run_agent_execution",
-			Resource: imageDigest, Message: "agent image digest is not allowed by daemon policy",
-		})
-		return
-	}
-	commandDigest, err := transactionreducer.ComputeCommandDigest(request.Command)
-	if err != nil {
-		writeError(w, schemaError("compute agent command digest", err))
 		return
 	}
 	namespace := r.PathValue("namespace")
@@ -465,33 +445,29 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		writeError(w, transactionTransitionError("agent execution requires a running transaction with one stage boundary"))
 		return
 	}
-	if err := taskAuthorizesDaemonExecution(
-		projection.Transaction.Task,
-		request.RunID,
-		"oci",
-		imageDigest,
-		commandDigest,
-	); err != nil {
+	liveAuthority, err := s.compileLiveExecutionAuthority(
+		r.Context(),
+		namespace,
+		transactionID,
+		projection,
+		request.Image,
+		request.Command,
+		request.TimeoutSeconds,
+	)
+	if err != nil {
 		writeError(w, err)
 		return
 	}
-	entrypoint := ""
-	command := append([]string(nil), request.Command...)
-	if task := projection.Transaction.Task; task != nil &&
-		task.AgentProfile.Entrypoint != "" {
-		if request.Command[0] != task.AgentProfile.Entrypoint {
-			writeError(w, &model.KernelError{
-				Code:      model.ErrorCapabilityDenied,
-				Operation: "run_agent_execution",
-				Resource:  transactionID,
-				Message:   "persisted task entrypoint does not match the requested command",
-			})
-			return
-		}
-		entrypoint = task.AgentProfile.Entrypoint
-		command = append([]string(nil), request.Command[1:]...)
-	}
-	workspace, err := s.transactionWorkspace(r, projection)
+	executionPlan := liveAuthority.Plan
+	authorityContext, cancelAuthority := context.WithDeadline(
+		r.Context(),
+		executionPlan.NotAfter,
+	)
+	defer cancelAuthority()
+	workspace, err := s.transactionWorkspace(
+		r.WithContext(authorityContext),
+		projection,
+	)
 	if err != nil {
 		writeError(w, err)
 		return
@@ -519,23 +495,26 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 	}
 	config := sandbox.OCIConfig{
 		EnginePath:    s.executionPolicy.EnginePath,
-		Image:         request.Image,
+		Image:         executionPlan.ImageReference,
 		Workspace:     workspace.Path,
 		TransactionID: transactionID,
-		RunID:         request.RunID,
-		Entrypoint:    entrypoint,
-		Command:       command,
+		RunID:         executionPlan.RunID,
+		Entrypoint:    executionPlan.Entrypoint,
+		Command:       append([]string(nil), executionPlan.Command...),
 		UID:           s.executionPolicy.VerifierUID,
 		GID:           s.executionPolicy.VerifierGID,
 		MemoryBytes:   s.executionPolicy.VerifierMemoryBytes,
 		CPUMillis:     s.executionPolicy.VerifierCPUMillis,
 		PIDsLimit:     s.executionPolicy.VerifierPIDsLimit,
 		TmpfsBytes:    s.executionPolicy.VerifierTmpfsBytes,
-		ContainerName: sandbox.ContainerName(transactionID, request.RunID),
+		ContainerName: sandbox.ContainerName(
+			transactionID,
+			executionPlan.RunID,
+		),
 		Role:          "agent",
 		WorkspaceMode: "transaction_rw",
 	}
-	taskDigest := ""
+	taskDigest := executionPlan.TaskDigest
 	if projection.Transaction.Task != nil {
 		taskDirectory, cleanupTask, taskErr := materializeAgentTask(
 			s.transactionStaging,
@@ -547,12 +526,22 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		}
 		defer func() { _ = cleanupTask() }()
 		config.TaskDirectory = taskDirectory
-		config.TaskDigest = projection.Transaction.Task.Digest
-		taskDigest = projection.Transaction.Task.Digest
+		config.TaskDigest = executionPlan.TaskDigest
 	}
 	var brokerSession *sandbox.ModelBrokerSession
 	var brokerExecution *model.ModelBrokerExecution
-	if brokerPolicy := s.executionPolicy.ModelBroker; brokerPolicy != nil {
+	var brokerConfig *sandbox.ModelBrokerConfig
+	if executionPlan.ModelBroker != nil {
+		brokerPolicy := s.executionPolicy.ModelBroker
+		if brokerPolicy == nil {
+			writeError(w, &model.KernelError{
+				Code:      model.ErrorInternal,
+				Operation: "run_agent_execution",
+				Resource:  transactionID,
+				Message:   "compiled model authority has no daemon broker",
+			})
+			return
+		}
 		agentToken, tokenErr := randomBrokerToken()
 		if tokenErr != nil {
 			writeError(w, &model.KernelError{
@@ -565,48 +554,43 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		receiptDirectory := filepath.Join(
 			s.transactionStaging,
 			".vouch-model-evidence",
-			sandbox.ModelBrokerContainerName(transactionID, request.RunID),
+			sandbox.ModelBrokerContainerName(
+				transactionID,
+				executionPlan.RunID,
+			),
 		)
-		startedBroker, brokerErr := sandbox.StartModelBroker(
-			r.Context(),
-			sandbox.ModelBrokerConfig{
-				EnginePath: s.executionPolicy.EnginePath,
-				Image:      brokerPolicy.Image, PolicyPath: brokerPolicy.PolicyPath,
-				PolicyDigest:     brokerPolicy.PolicyDigest,
-				ReceiptDirectory: receiptDirectory,
-				TransactionID:    transactionID, RunID: request.RunID,
-				AgentToken:          agentToken,
-				ProviderBearerToken: brokerPolicy.ProviderBearerToken,
-				UID:                 s.executionPolicy.VerifierUID, GID: s.executionPolicy.VerifierGID,
-				MemoryBytes: 512 << 20, CPUMillis: 1000,
-				PIDsLimit: 64, TmpfsBytes: 64 << 20,
-			},
-		)
-		if brokerErr != nil {
-			writeError(w, &model.KernelError{
-				Code: model.ErrorDriverUnavailable, Operation: "start_model_broker",
-				Resource: transactionID, Message: "start policy-controlled model egress",
-				Cause: brokerErr,
-			})
-			return
+		brokerConfig = &sandbox.ModelBrokerConfig{
+			EnginePath: s.executionPolicy.EnginePath,
+			Image:      brokerPolicy.Image, PolicyPath: brokerPolicy.PolicyPath,
+			PolicyDigest:        brokerPolicy.PolicyDigest,
+			ReceiptDirectory:    receiptDirectory,
+			TransactionID:       transactionID,
+			RunID:               executionPlan.RunID,
+			AgentToken:          agentToken,
+			ProviderBearerToken: brokerPolicy.ProviderBearerToken,
+			UID:                 s.executionPolicy.VerifierUID, GID: s.executionPolicy.VerifierGID,
+			MemoryBytes: 512 << 20, CPUMillis: 1000,
+			PIDsLimit: 64, TmpfsBytes: 64 << 20,
 		}
-		brokerSession = &startedBroker
 		brokerExecution = &model.ModelBrokerExecution{
-			Provider:     brokerPolicy.Policy.Provider,
-			ImageDigest:  startedBroker.ImageDigest,
-			PolicyDigest: startedBroker.PolicyDigest,
+			Provider:     executionPlan.ModelBroker.Provider,
+			ImageDigest:  executionPlan.ModelBroker.ImageDigest,
+			PolicyDigest: executionPlan.ModelBroker.PolicyDigest,
 		}
 		tokenDigest := sha256.Sum256([]byte(agentToken))
-		config.NetworkName = startedBroker.NetworkName
+		config.NetworkName = sandbox.ModelBrokerNetworkName(
+			transactionID,
+			executionPlan.RunID,
+		)
 		config.ModelBroker = &sandbox.ModelBrokerBinding{
 			URL:   "http://vouch-model-broker:8080/v1",
-			Token: agentToken, ImageDigest: startedBroker.ImageDigest,
-			PolicyDigest:      startedBroker.PolicyDigest,
+			Token: agentToken, ImageDigest: executionPlan.ModelBroker.ImageDigest,
+			PolicyDigest:      executionPlan.ModelBroker.PolicyDigest,
 			TokenDigest:       "sha256:" + hex.EncodeToString(tokenDigest[:]),
-			ReceiptLedgerHint: startedBroker.ReceiptPath,
+			ReceiptLedgerHint: filepath.Join(receiptDirectory, "model-calls.jsonl"),
 		}
 	}
-	brokerStopped := brokerSession == nil
+	brokerStopped := false
 	defer func() {
 		if brokerStopped || brokerSession == nil {
 			return
@@ -624,18 +608,26 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 	if !model.IsIdentifier(program) {
 		program = "agent-command"
 	}
+	if err := s.requireLiveExecutionAuthority(
+		authorityContext,
+		transactionID,
+		executionPlan.NotAfter,
+	); err != nil {
+		writeError(w, err)
+		return
+	}
 	now := s.now().UTC()
 	execution := model.AgentExecution{
 		Version:             model.AgentExecutionVersion,
 		ID:                  transactionreducer.ExecutionID(transactionID, request.ExpectedSequence+1),
 		TransactionID:       transactionID,
-		RunID:               request.RunID,
-		StageBindingID:      projection.Transaction.StageBindings[0].ID,
+		RunID:               executionPlan.RunID,
+		StageBindingID:      executionPlan.StageBindingID,
 		Program:             program,
-		CommandDigest:       commandDigest,
+		CommandDigest:       executionPlan.CommandDigest,
 		RuntimeClass:        "oci",
 		RuntimeConfigDigest: runtimeDigest,
-		ImageDigest:         imageDigest,
+		ImageDigest:         executionPlan.ImageDigest,
 		TaskDigest:          taskDigest,
 		ModelBroker:         brokerExecution,
 		Status:              model.AgentExecutionRunning,
@@ -650,20 +642,60 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	projection, err = s.store.AppendTransactionEvents(
-		r.Context(), namespace, request.ExpectedSequence, []model.TransactionEvent{started},
+	projection, err = s.store.AppendTransactionEventsIfRunCurrent(
+		authorityContext,
+		namespace,
+		request.ExpectedSequence,
+		liveAuthority.RunSequence,
+		liveAuthority.RunLastEventDigest,
+		[]model.TransactionEvent{started},
 	)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
-	processContext, cancel := context.WithTimeout(
-		r.Context(), time.Duration(request.TimeoutSeconds)*time.Second,
-	)
-	defer cancel()
-	outcome, runErr := (verification.Runner{
-		EvidenceRoot: filepath.Join(s.transactionStaging, ".vouch-agent-evidence"),
-	}).Run(processContext, config, execution.ID)
+	var outcome verification.Outcome
+	var runErr error
+	runOperation := "run_agent_execution"
+	runMessage := "execute daemon-owned OCI agent"
+	if brokerConfig != nil {
+		startedBroker, brokerErr := sandbox.StartModelBroker(
+			authorityContext,
+			*brokerConfig,
+		)
+		if brokerErr != nil {
+			runErr = brokerErr
+			if authorityErr := s.requireLiveExecutionAuthority(
+				authorityContext,
+				transactionID,
+				executionPlan.NotAfter,
+			); authorityErr != nil {
+				runErr = authorityErr
+			}
+			runOperation = "start_model_broker"
+			runMessage = "start policy-controlled model egress"
+		} else {
+			brokerSession = &startedBroker
+			if startedBroker.ImageDigest != executionPlan.ModelBroker.ImageDigest ||
+				startedBroker.PolicyDigest != executionPlan.ModelBroker.PolicyDigest {
+				runErr = errors.New("started model broker does not match execution authority")
+				runOperation = "start_model_broker"
+				runMessage = "start policy-controlled model egress"
+			}
+		}
+	}
+	if runErr == nil {
+		runErr = s.requireLiveExecutionAuthority(
+			authorityContext,
+			transactionID,
+			executionPlan.NotAfter,
+		)
+	}
+	if runErr == nil {
+		outcome, runErr = (verification.Runner{
+			EvidenceRoot: filepath.Join(s.transactionStaging, ".vouch-agent-evidence"),
+		}).Run(authorityContext, config, execution.ID)
+	}
 	if brokerSession != nil {
 		cleanupContext, stopBroker := context.WithTimeout(context.Background(), 10*time.Second)
 		brokerErr := sandbox.RemoveModelBroker(
@@ -683,8 +715,8 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		summary, summaryErr := kernelmodelbroker.FinalizeLedger(
 			brokerSession.ReceiptPath,
 			transactionID,
-			request.RunID,
-			s.executionPolicy.ModelBroker.Policy.Provider,
+			executionPlan.RunID,
+			executionPlan.ModelBroker.Provider,
 		)
 		if summaryErr != nil {
 			writeError(w, &model.KernelError{
@@ -722,9 +754,9 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 			Version:             "vouch.verification_process_receipt.v0",
 			Name:                execution.ID,
 			Status:              model.AgentExecutionStartFailed,
-			CommandDigest:       commandDigest,
+			CommandDigest:       executionPlan.CommandDigest,
 			RuntimeConfigDigest: runtimeDigest,
-			ImageDigest:         imageDigest,
+			ImageDigest:         executionPlan.ImageDigest,
 			StdoutDigest:        emptySHA256Digest,
 			StderrDigest:        emptySHA256Digest,
 			CompletedAt:         s.now().UTC(),
@@ -759,9 +791,14 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 	}
 	execution = projection.Executions[len(projection.Executions)-1]
 	if runErr != nil {
+		var kernelErr *model.KernelError
+		if errors.As(runErr, &kernelErr) {
+			writeError(w, runErr)
+			return
+		}
 		writeError(w, &model.KernelError{
-			Code: model.ErrorDriverUnavailable, Operation: "run_agent_execution",
-			Resource: transactionID, Message: "execute daemon-owned OCI agent", Cause: runErr,
+			Code: model.ErrorDriverUnavailable, Operation: runOperation,
+			Resource: transactionID, Message: runMessage, Cause: runErr,
 		})
 		return
 	}
@@ -769,22 +806,6 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		Projection: projection, Execution: execution,
 		Process: outcome.Receipt, EvidenceDirectory: outcome.EvidenceDirectory,
 	})
-}
-
-func taskAuthorizesDaemonExecution(
-	task *model.AgentTask,
-	runID, runtimeClass, imageDigest, commandDigest string,
-) error {
-	if task == nil {
-		return &model.KernelError{
-			Code:      model.ErrorCapabilityDenied,
-			Operation: "run_agent_execution",
-			Message:   "daemon-owned agent execution requires a persisted task envelope",
-		}
-	}
-	return taskAuthorizesExecution(
-		task, runID, runtimeClass, imageDigest, commandDigest,
-	)
 }
 
 func taskAuthorizesExecution(

--- a/internal/kernel/api/transaction_handlers_test.go
+++ b/internal/kernel/api/transaction_handlers_test.go
@@ -101,18 +101,6 @@ func TestPersistedTaskAuthorizesExactAgentProfileAndMaterializesReadOnly(t *test
 	); err != nil {
 		t.Fatal(err)
 	}
-	if err := taskAuthorizesDaemonExecution(
-		&task, task.RunID, "oci", imageDigest, commandDigest,
-	); err != nil {
-		t.Fatal(err)
-	}
-	err = taskAuthorizesDaemonExecution(
-		nil, task.RunID, "oci", imageDigest, commandDigest,
-	)
-	kernelErr, ok := err.(*model.KernelError)
-	if !ok || kernelErr.Code != model.ErrorCapabilityDenied {
-		t.Fatalf("taskless daemon execution was not denied: %v", err)
-	}
 	if err := taskAuthorizesExecution(
 		&task, task.RunID, "oci", imageDigest, testDigest("f"),
 	); err == nil {

--- a/internal/kernel/authority/authority.go
+++ b/internal/kernel/authority/authority.go
@@ -1,0 +1,486 @@
+// Package authority lowers live kernel authority into an exact OCI execution
+// plan. It is pure: it performs no I/O and starts no workloads.
+package authority
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/sandbox"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+const (
+	WorkspaceReadWrite = "rw"
+	NetworkNone        = "none"
+	NetworkModelBroker = "internal_model_broker"
+	ModelResourceKind  = "model"
+	ModelInvoke        = "model.invoke"
+)
+
+// ModelBrokerCeiling is the daemon's already-enforced static broker policy.
+// Finite contract budgets must be at least as restrictive as this policy.
+type ModelBrokerCeiling struct {
+	Provider                  string
+	AllowedModels             []string
+	ImageDigest               string
+	PolicyDigest              string
+	MaxModelCalls             int64
+	MaxInputTokens            int64
+	MaxOutputTokens           int64
+	MaxOutputTokensPerRequest int64
+}
+
+// DaemonCeilings may narrow persisted authority, never widen it.
+type DaemonCeilings struct {
+	MaxWallTimeSeconds  int64
+	AllowedImageDigests []string
+	ModelBroker         *ModelBrokerCeiling
+}
+
+// CompileInput combines authoritative stored objects with untrusted executable
+// material. ImageReference and Command carry bytes to execute; their admitted
+// digests remain the authority.
+type CompileInput struct {
+	Task        model.AgentTask
+	Contract    model.ExecutionContract
+	Run         model.AgentRun
+	Grants      []model.CapabilityGrant
+	Transaction model.AgentTransaction
+	Executions  []model.AgentExecution
+
+	ImageReference       string
+	Command              []string
+	Ceilings             DaemonCeilings
+	CallerTimeoutSeconds *int64
+	Now                  time.Time
+}
+
+type ModelBrokerPlan struct {
+	Provider                  string
+	AllowedModels             []string
+	ImageDigest               string
+	PolicyDigest              string
+	MaxModelCalls             int64
+	MaxInputTokens            int64
+	MaxOutputTokens           int64
+	MaxOutputTokensPerRequest int64
+}
+
+// ExecutionPlan is directly consumable by the current OCI handler. If
+// Entrypoint is set, Command excludes that first executable argument.
+type ExecutionPlan struct {
+	Namespace      string
+	TransactionID  string
+	StageBindingID string
+	TaskID         string
+	TaskDigest     string
+	ContractID     string
+	ContractDigest string
+	RunID          string
+	CapabilityIDs  []string
+
+	ImageReference string
+	ImageDigest    string
+	CommandDigest  string
+	Entrypoint     string
+	Command        []string
+
+	WorkspaceAccess string
+	NetworkAccess   string
+	ModelBroker     *ModelBrokerPlan
+	CompiledAt      time.Time
+	NotAfter        time.Time
+	TimeoutSeconds  int64
+}
+
+// Compile verifies live admission lineage, active grants, executable digests,
+// daemon ceilings, and deadlines before producing a launch plan.
+func Compile(input CompileInput) (ExecutionPlan, error) {
+	now := input.Now.UTC()
+	if now.IsZero() {
+		return ExecutionPlan{}, deny(model.ErrorSchemaInvalid, input.Run.ID, "daemon clock is required", nil)
+	}
+	if err := validateObjects(input); err != nil {
+		return ExecutionPlan{}, err
+	}
+	if err := validateBindings(input); err != nil {
+		return ExecutionPlan{}, err
+	}
+	if err := validateCeilings(input.Ceilings); err != nil {
+		return ExecutionPlan{}, err
+	}
+
+	imageDigest, err := sandbox.ImageDigest(input.ImageReference)
+	if err != nil {
+		return ExecutionPlan{}, deny(model.ErrorSchemaInvalid, input.Task.ID, "image must be digest pinned", err)
+	}
+	if imageDigest != input.Task.AgentProfile.ImageDigest ||
+		imageDigest != input.Run.ImageDigest {
+		return ExecutionPlan{}, deny(model.ErrorCapabilityDenied, input.Run.ID, "image digest does not match admission", nil)
+	}
+	if !contains(input.Ceilings.AllowedImageDigests, imageDigest) {
+		return ExecutionPlan{}, deny(model.ErrorCapabilityDenied, imageDigest, "image is outside the daemon ceiling", nil)
+	}
+
+	commandDigest, err := commandDigest(input.Command)
+	if err != nil {
+		return ExecutionPlan{}, deny(model.ErrorSchemaInvalid, input.Task.ID, "command is invalid", err)
+	}
+	if commandDigest != input.Task.AgentProfile.CommandDigest {
+		return ExecutionPlan{}, deny(model.ErrorCapabilityDenied, input.Run.ID, "command digest does not match admission", nil)
+	}
+	entrypoint := input.Task.AgentProfile.Entrypoint
+	command := append([]string(nil), input.Command...)
+	if entrypoint != "" {
+		if input.Command[0] != entrypoint {
+			return ExecutionPlan{}, deny(model.ErrorCapabilityDenied, input.Run.ID, "command does not match admitted entrypoint", nil)
+		}
+		command = append([]string(nil), input.Command[1:]...)
+	}
+
+	modelPlan, network, err := validateGrants(input, now)
+	if err != nil {
+		return ExecutionPlan{}, err
+	}
+	notAfter, timeout, err := timeoutBoundary(input, now)
+	if err != nil {
+		return ExecutionPlan{}, err
+	}
+	return ExecutionPlan{
+		Namespace: input.Task.Namespace, TransactionID: input.Transaction.ID,
+		StageBindingID: input.Transaction.StageBindings[0].ID,
+		TaskID:         input.Task.ID, TaskDigest: input.Task.Digest,
+		ContractID: input.Contract.ID, ContractDigest: input.Contract.Digest,
+		RunID:          input.Run.ID,
+		CapabilityIDs:  append([]string(nil), input.Run.CapabilityIDs...),
+		ImageReference: input.ImageReference, ImageDigest: imageDigest,
+		CommandDigest: commandDigest, Entrypoint: entrypoint, Command: command,
+		WorkspaceAccess: WorkspaceReadWrite, NetworkAccess: network,
+		ModelBroker: cloneModelPlan(modelPlan),
+		CompiledAt:  now, NotAfter: notAfter, TimeoutSeconds: timeout,
+	}, nil
+}
+
+func validateObjects(input CompileInput) error {
+	if err := input.Task.Validate(); err != nil {
+		return err
+	}
+	if err := input.Contract.Validate(); err != nil {
+		return err
+	}
+	if err := input.Run.Validate(); err != nil {
+		return err
+	}
+	if err := input.Transaction.Validate(); err != nil {
+		return err
+	}
+	digest, err := model.ComputeExecutionContractDigest(input.Contract)
+	if err != nil {
+		return deny(model.ErrorInternal, input.Contract.ID, "digest contract", err)
+	}
+	if digest != input.Contract.Digest {
+		return deny(model.ErrorEventChain, input.Contract.ID, "contract content digest is invalid", nil)
+	}
+	for index := range input.Grants {
+		if err := input.Grants[index].Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateBindings(input CompileInput) error {
+	task, contract := input.Task, input.Contract
+	run, transaction := input.Run, input.Transaction
+	binding := transaction.Admission
+	if task.AgentProfile.RuntimeClass != "oci" {
+		return deny(model.ErrorCapabilityDenied, task.ID, "only OCI execution is authoritative", nil)
+	}
+	if run.State != model.RunAdmitted || run.Runtime != nil ||
+		run.ParentRunID != "" ||
+		run.CheckpointID != "" || len(run.OutstandingApprovalIDs) != 0 {
+		return deny(model.ErrorTransitionInvalid, run.ID, "run is not launchable from admitted state", nil)
+	}
+	if transaction.State != model.TransactionRunning ||
+		len(transaction.StageBindings) != 1 ||
+		len(input.Executions) != 0 {
+		return deny(model.ErrorTransitionInvalid, transaction.ID, "transaction must be running with one stage and no prior execution", nil)
+	}
+	if binding == nil || transaction.Task == nil ||
+		task.Namespace != run.Namespace || task.Namespace != transaction.Namespace ||
+		task.TransactionID != transaction.ID || task.RunID != run.ID ||
+		run.ContractDigest != contract.Digest ||
+		binding.TaskDigest != task.Digest || binding.RunID != run.ID ||
+		binding.ContractDigest != contract.Digest ||
+		!reflect.DeepEqual(*transaction.Task, task) ||
+		transaction.IntentDigest != task.IntentDigest ||
+		len(transaction.AgentRunIDs) != 1 ||
+		transaction.AgentRunIDs[0] != run.ID {
+		return deny(model.ErrorEventChain, transaction.ID, "task, contract, run, and transaction do not cross-bind", nil)
+	}
+	if !reflect.DeepEqual(contract.Owner, transaction.Sponsor) ||
+		len(run.DelegationChain) != 1 ||
+		!reflect.DeepEqual(run.DelegationChain[0], transaction.Sponsor) {
+		return deny(model.ErrorIdentityInvalid, run.ID, "delegation lineage does not match sponsor", nil)
+	}
+	if run.ImageDigest != task.AgentProfile.ImageDigest ||
+		!sameTime(run.Deadline, contract.Deadline) ||
+		!reflect.DeepEqual(run.BudgetLimits, contract.Budgets) {
+		return deny(model.ErrorEventChain, run.ID, "run executable, deadline, or budget binding changed", nil)
+	}
+	if contract.MaxChildDepth != nil || contract.MaxChildren != nil ||
+		len(contract.Checkpoints) != 0 || len(contract.Obligations) != 0 ||
+		contract.Escalation != nil || contract.ReleaseContractRef != "" ||
+		contract.Budgets.MaxToolCalls != nil ||
+		contract.Budgets.MaxCostMicros != nil {
+		return deny(model.ErrorCapabilityDenied, contract.ID, "contract contains unsupported execution controls", nil)
+	}
+	return nil
+}
+
+func validateCeilings(ceilings DaemonCeilings) error {
+	if ceilings.MaxWallTimeSeconds < 1 || len(ceilings.AllowedImageDigests) == 0 {
+		return deny(model.ErrorSchemaInvalid, "daemon", "daemon ceilings are incomplete", nil)
+	}
+	seen := map[string]struct{}{}
+	for _, digest := range ceilings.AllowedImageDigests {
+		if !model.IsSHA256Digest(digest) {
+			return deny(model.ErrorSchemaInvalid, "daemon", "daemon image digest is invalid", nil)
+		}
+		if _, duplicate := seen[digest]; duplicate {
+			return deny(model.ErrorSchemaInvalid, "daemon", "daemon image digests are duplicated", nil)
+		}
+		seen[digest] = struct{}{}
+	}
+	if broker := ceilings.ModelBroker; broker != nil {
+		if !model.IsIdentifier(broker.Provider) ||
+			!model.IsSHA256Digest(broker.ImageDigest) ||
+			!model.IsSHA256Digest(broker.PolicyDigest) ||
+			len(broker.AllowedModels) == 0 ||
+			broker.MaxModelCalls < 1 || broker.MaxInputTokens < 1 ||
+			broker.MaxOutputTokens < 1 || broker.MaxOutputTokensPerRequest < 1 ||
+			broker.MaxOutputTokensPerRequest > broker.MaxOutputTokens {
+			return deny(model.ErrorSchemaInvalid, "daemon-model-broker", "model broker ceiling is invalid", nil)
+		}
+		for _, allowed := range broker.AllowedModels {
+			if strings.TrimSpace(allowed) != allowed || allowed == "" || strings.ContainsRune(allowed, 0) {
+				return deny(model.ErrorSchemaInvalid, "daemon-model-broker", "allowed model is invalid", nil)
+			}
+		}
+	}
+	return nil
+}
+
+func validateGrants(input CompileInput, now time.Time) (*ModelBrokerPlan, string, error) {
+	if len(input.Grants) != len(input.Contract.Resources) ||
+		len(input.Grants) != len(input.Run.CapabilityIDs) {
+		return nil, "", deny(model.ErrorEventChain, input.Run.ID, "grants do not exactly cover contract resources", nil)
+	}
+	workspaceSeen, modelSeen := false, false
+	decisionID := ""
+	for index, grant := range input.Grants {
+		resource := input.Contract.Resources[index]
+		if grant.ID != input.Run.CapabilityIDs[index] ||
+			grant.SubjectRunID != input.Run.ID ||
+			!reflect.DeepEqual(grant.Resource, resource.Selector) ||
+			!reflect.DeepEqual(grant.Operations, resource.Operations) ||
+			!reflect.DeepEqual(grant.Conditions, resource.Conditions) ||
+			grant.Issuer != daemonPrincipal() || grant.Delegable ||
+			grant.DelegationParentID != "" ||
+			!grant.IssuedAt.Equal(input.Run.CreatedAt) ||
+			grant.MaxUses != nil {
+			return nil, "", deny(model.ErrorEventChain, grant.ID, "grant does not match admission", nil)
+		}
+		if decisionID == "" {
+			decisionID = grant.PolicyDecisionID
+		} else if decisionID != grant.PolicyDecisionID {
+			return nil, "", deny(model.ErrorEventChain, grant.ID, "grants do not share one decision", nil)
+		}
+		if grant.RevokedAt != nil {
+			return nil, "", deny(model.ErrorCapabilityRevoked, grant.ID, "grant is revoked", nil)
+		}
+		if grant.IssuedAt.After(now) {
+			return nil, "", deny(model.ErrorCapabilityDenied, grant.ID, "grant is not active yet", nil)
+		}
+		if !grant.ExpiresAt.After(now) {
+			return nil, "", deny(model.ErrorCapabilityExpired, grant.ID, "grant is expired", nil)
+		}
+		if input.Run.Deadline != nil && grant.ExpiresAt.After(*input.Run.Deadline) {
+			return nil, "", deny(model.ErrorEventChain, grant.ID, "grant exceeds run deadline", nil)
+		}
+
+		switch resource.Selector.Kind {
+		case "filesystem":
+			if workspaceSeen || resource.Selector.Pattern != "workspace/**" ||
+				!exactOperations(resource.Operations, "filesystem.read", "filesystem.write") ||
+				resource.Conditions.WorkspaceRoot != "workspace" ||
+				unsupportedConditions(resource.Conditions, true) {
+				return nil, "", deny(model.ErrorCapabilityDenied, resource.ID, "only full workspace read/write is enforceable", nil)
+			}
+			workspaceSeen = true
+		case ModelResourceKind:
+			if modelSeen || input.Ceilings.ModelBroker == nil {
+				return nil, "", deny(model.ErrorCapabilityDenied, resource.ID, "model grant has no exact daemon broker", nil)
+			}
+			broker := input.Ceilings.ModelBroker
+			if resource.Selector.Pattern != broker.Provider+"/*" ||
+				!exactOperations(resource.Operations, ModelInvoke) ||
+				unsupportedConditions(resource.Conditions, false) {
+				return nil, "", deny(model.ErrorCapabilityDenied, resource.ID, "model grant is not the supported provider boundary", nil)
+			}
+			modelSeen = true
+		default:
+			return nil, "", deny(model.ErrorCapabilityDenied, resource.ID, "resource kind is not enforceable", nil)
+		}
+	}
+	if !workspaceSeen {
+		return nil, "", deny(model.ErrorCapabilityDenied, input.Contract.ID, "full workspace authority is required", nil)
+	}
+	hasModelBudgets := input.Contract.Budgets.MaxInputTokens != nil ||
+		input.Contract.Budgets.MaxOutputTokens != nil ||
+		input.Contract.Budgets.MaxModelCalls != nil
+	if !modelSeen {
+		if hasModelBudgets {
+			return nil, "", deny(model.ErrorCapabilityDenied, input.Contract.ID, "model budgets require a model grant", nil)
+		}
+		return nil, NetworkNone, nil
+	}
+	broker := input.Ceilings.ModelBroker
+	for _, limit := range []struct {
+		contract *int64
+		usage    int64
+		daemon   int64
+		name     string
+	}{
+		{input.Contract.Budgets.MaxModelCalls, input.Run.BudgetUsage.ModelCalls, broker.MaxModelCalls, "model calls"},
+		{input.Contract.Budgets.MaxInputTokens, input.Run.BudgetUsage.InputTokens, broker.MaxInputTokens, "input tokens"},
+		{input.Contract.Budgets.MaxOutputTokens, input.Run.BudgetUsage.OutputTokens, broker.MaxOutputTokens, "output tokens"},
+	} {
+		if limit.contract != nil {
+			remaining := *limit.contract - limit.usage
+			if remaining < 1 {
+				return nil, "", deny(model.ErrorBudgetExceeded, input.Run.ID, limit.name+" budget is exhausted", nil)
+			}
+			if limit.daemon > remaining {
+				return nil, "", deny(model.ErrorCapabilityDenied, input.Run.ID, "static broker exceeds "+limit.name+" budget", nil)
+			}
+		}
+	}
+	return &ModelBrokerPlan{
+		Provider: broker.Provider, AllowedModels: append([]string(nil), broker.AllowedModels...),
+		ImageDigest: broker.ImageDigest, PolicyDigest: broker.PolicyDigest,
+		MaxModelCalls: broker.MaxModelCalls, MaxInputTokens: broker.MaxInputTokens,
+		MaxOutputTokens:           broker.MaxOutputTokens,
+		MaxOutputTokensPerRequest: broker.MaxOutputTokensPerRequest,
+	}, NetworkModelBroker, nil
+}
+
+func timeoutBoundary(input CompileInput, now time.Time) (time.Time, int64, error) {
+	notAfter := now.Add(time.Duration(input.Ceilings.MaxWallTimeSeconds) * time.Second)
+	for _, deadline := range []*time.Time{input.Contract.Deadline, input.Run.Deadline} {
+		if deadline != nil && deadline.Before(notAfter) {
+			notAfter = deadline.UTC()
+		}
+	}
+	for index := range input.Grants {
+		if input.Grants[index].ExpiresAt.Before(notAfter) {
+			notAfter = input.Grants[index].ExpiresAt.UTC()
+		}
+	}
+	if wall := input.Contract.Budgets.MaxWallTimeSeconds; wall != nil {
+		remaining := *wall - input.Run.BudgetUsage.WallTimeSeconds
+		if remaining < 1 {
+			return time.Time{}, 0, deny(model.ErrorBudgetExceeded, input.Run.ID, "wall-time budget is exhausted", nil)
+		}
+		if boundary := now.Add(time.Duration(remaining) * time.Second); boundary.Before(notAfter) {
+			notAfter = boundary
+		}
+	}
+	maximum := int64(notAfter.Sub(now) / time.Second)
+	if maximum < 1 {
+		return time.Time{}, 0, deny(model.ErrorCapabilityExpired, input.Run.ID, "authority expires before launch", nil)
+	}
+	if input.CallerTimeoutSeconds == nil {
+		return notAfter, maximum, nil
+	}
+	if *input.CallerTimeoutSeconds < 1 {
+		return time.Time{}, 0, deny(model.ErrorSchemaInvalid, input.Run.ID, "caller timeout must be positive", nil)
+	}
+	if *input.CallerTimeoutSeconds > maximum {
+		return time.Time{}, 0, deny(model.ErrorCapabilityDenied, input.Run.ID, "caller timeout widens authority", nil)
+	}
+	return now.Add(time.Duration(*input.CallerTimeoutSeconds) * time.Second),
+		*input.CallerTimeoutSeconds, nil
+}
+
+func commandDigest(command []string) (string, error) {
+	if len(command) == 0 || strings.TrimSpace(command[0]) == "" {
+		return "", fmt.Errorf("command is required")
+	}
+	for _, argument := range command {
+		if strings.ContainsRune(argument, 0) {
+			return "", fmt.Errorf("command contains NUL")
+		}
+	}
+	return transactionreducer.ComputeCommandDigest(command)
+}
+
+func unsupportedConditions(conditions model.CapabilityConditions, workspace bool) bool {
+	return conditions.ApprovalRequired ||
+		(!workspace && conditions.WorkspaceRoot != "") ||
+		len(conditions.EnvironmentAllow) != 0 ||
+		len(conditions.DataClassifications) != 0 ||
+		conditions.MaxOutputBytes != nil
+}
+
+func exactOperations(actual []string, expected ...string) bool {
+	if len(actual) != len(expected) {
+		return false
+	}
+	for _, operation := range expected {
+		if !contains(actual, operation) {
+			return false
+		}
+	}
+	return true
+}
+
+func sameTime(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == nil && right == nil
+	}
+	return left.Equal(*right)
+}
+
+func daemonPrincipal() model.Principal {
+	return model.Principal{ID: "service:vouchd", Kind: model.PrincipalService, Issuer: "vouchd"}
+}
+
+func cloneModelPlan(plan *ModelBrokerPlan) *ModelBrokerPlan {
+	if plan == nil {
+		return nil
+	}
+	cloned := *plan
+	cloned.AllowedModels = append([]string(nil), plan.AllowedModels...)
+	return &cloned
+}
+
+func contains[T comparable](values []T, target T) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
+}
+
+func deny(code model.ErrorCode, resource, message string, cause error) *model.KernelError {
+	return &model.KernelError{
+		Code: code, Operation: "compile_execution_authority",
+		Resource: resource, Message: message, Cause: cause,
+	}
+}

--- a/internal/kernel/authority/authority_test.go
+++ b/internal/kernel/authority/authority_test.go
@@ -1,0 +1,469 @@
+package authority_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/authority"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+func TestCompileDerivesContentBoundOCIPlan(t *testing.T) {
+	input := validInput(t, workspaceResource(
+		"filesystem.read", "filesystem.write",
+	), model.BudgetLimits{})
+	timeout := int64(120)
+	input.CallerTimeoutSeconds = &timeout
+
+	plan, err := authority.Compile(input)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if plan.Namespace != input.Task.Namespace ||
+		plan.TransactionID != input.Transaction.ID ||
+		plan.StageBindingID != input.Transaction.StageBindings[0].ID ||
+		plan.TaskDigest != input.Task.Digest ||
+		plan.ContractDigest != input.Contract.Digest ||
+		plan.RunID != input.Run.ID {
+		t.Fatalf("plan identity is not derived from admission: %#v", plan)
+	}
+	if plan.ImageReference != input.ImageReference ||
+		plan.ImageDigest != input.Task.AgentProfile.ImageDigest ||
+		plan.CommandDigest != input.Task.AgentProfile.CommandDigest ||
+		plan.Entrypoint != "agent" ||
+		len(plan.Command) != 1 || plan.Command[0] != "--task" {
+		t.Fatalf("plan executable binding = %#v", plan)
+	}
+	if plan.WorkspaceAccess != authority.WorkspaceReadWrite ||
+		plan.NetworkAccess != authority.NetworkNone ||
+		plan.ModelBroker != nil {
+		t.Fatalf("plan isolation = %#v", plan)
+	}
+	if plan.TimeoutSeconds != timeout ||
+		!plan.NotAfter.Equal(input.Now.Add(time.Duration(timeout)*time.Second)) {
+		t.Fatalf("plan timeout = %d / %s", plan.TimeoutSeconds, plan.NotAfter)
+	}
+	input.Command[1] = "--mutated"
+	input.Run.CapabilityIDs[0] = "cap:mutated"
+	if plan.Command[0] != "--task" ||
+		plan.CapabilityIDs[0] == "cap:mutated" {
+		t.Fatal("plan aliases caller-owned slices")
+	}
+}
+
+func TestCompileEnablesOnlyExplicitNarrowModelEgress(t *testing.T) {
+	maxCalls, maxInput, maxOutput := int64(10), int64(2_000), int64(1_000)
+	input := validInput(
+		t,
+		[]model.ContractResource{
+			workspaceResource("filesystem.read", "filesystem.write")[0],
+			{
+				ID:         "model-openai",
+				Selector:   model.ResourceSelector{Kind: authority.ModelResourceKind, Pattern: "openai/*"},
+				Operations: []string{authority.ModelInvoke},
+			},
+		},
+		model.BudgetLimits{
+			MaxModelCalls:   &maxCalls,
+			MaxInputTokens:  &maxInput,
+			MaxOutputTokens: &maxOutput,
+		},
+	)
+	input.Ceilings.ModelBroker = &authority.ModelBrokerCeiling{
+		Provider: "openai", AllowedModels: []string{"gpt-4.1"},
+		ImageDigest: testDigest("d"), PolicyDigest: testDigest("e"),
+		MaxModelCalls: 5, MaxInputTokens: 1_000, MaxOutputTokens: 500,
+		MaxOutputTokensPerRequest: 100,
+	}
+
+	plan, err := authority.Compile(input)
+	if err != nil {
+		t.Fatalf("Compile() error = %v", err)
+	}
+	if plan.NetworkAccess != authority.NetworkModelBroker ||
+		plan.ModelBroker == nil ||
+		plan.ModelBroker.Provider != "openai" ||
+		len(plan.ModelBroker.AllowedModels) != 1 ||
+		plan.ModelBroker.AllowedModels[0] != "gpt-4.1" ||
+		plan.ModelBroker.MaxModelCalls != 5 {
+		t.Fatalf("model plan = %#v", plan.ModelBroker)
+	}
+
+	withoutGrant := validInput(
+		t, workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{},
+	)
+	withoutGrant.Ceilings.ModelBroker = input.Ceilings.ModelBroker
+	noEgress, err := authority.Compile(withoutGrant)
+	if err != nil {
+		t.Fatalf("Compile(no model grant) error = %v", err)
+	}
+	if noEgress.NetworkAccess != authority.NetworkNone || noEgress.ModelBroker != nil {
+		t.Fatalf("model broker enabled without a grant: %#v", noEgress)
+	}
+}
+
+func TestCompileRejectsModelAuthorityTheStaticBrokerCannotEnforce(t *testing.T) {
+	modelResource := model.ContractResource{
+		ID:         "model-openai",
+		Selector:   model.ResourceSelector{Kind: authority.ModelResourceKind, Pattern: "openai/*"},
+		Operations: []string{authority.ModelInvoke},
+	}
+	tests := []struct {
+		name   string
+		mutate func(*authority.CompileInput)
+		code   model.ErrorCode
+	}{
+		{
+			name: "broker unavailable",
+			mutate: func(input *authority.CompileInput) {
+				input.Ceilings.ModelBroker = nil
+			},
+			code: model.ErrorCapabilityDenied,
+		},
+		{
+			name: "static call budget broader than contract",
+			mutate: func(input *authority.CompileInput) {
+				input.Ceilings.ModelBroker.MaxModelCalls = 6
+			},
+			code: model.ErrorCapabilityDenied,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			maxCalls := int64(5)
+			input := validInput(
+				t, []model.ContractResource{
+					workspaceResource("filesystem.read", "filesystem.write")[0],
+					modelResource,
+				},
+				model.BudgetLimits{MaxModelCalls: &maxCalls},
+			)
+			input.Ceilings.ModelBroker = &authority.ModelBrokerCeiling{
+				Provider: "openai", AllowedModels: []string{"gpt-4.1"},
+				ImageDigest: testDigest("d"), PolicyDigest: testDigest("e"),
+				MaxModelCalls: 5, MaxInputTokens: 1_000,
+				MaxOutputTokens: 500, MaxOutputTokensPerRequest: 100,
+			}
+			test.mutate(&input)
+			_, err := authority.Compile(input)
+			requireKernelCode(t, err, test.code)
+		})
+	}
+
+	narrowed := validInput(
+		t,
+		[]model.ContractResource{
+			workspaceResource("filesystem.read", "filesystem.write")[0],
+			{
+				ID: "model-openai",
+				Selector: model.ResourceSelector{
+					Kind: authority.ModelResourceKind, Pattern: "openai/gpt-4.1",
+				},
+				Operations: []string{authority.ModelInvoke},
+			},
+		},
+		model.BudgetLimits{},
+	)
+	narrowed.Ceilings.ModelBroker = &authority.ModelBrokerCeiling{
+		Provider: "openai", AllowedModels: []string{"gpt-4.1"},
+		ImageDigest: testDigest("d"), PolicyDigest: testDigest("e"),
+		MaxModelCalls: 5, MaxInputTokens: 1_000,
+		MaxOutputTokens: 500, MaxOutputTokensPerRequest: 100,
+	}
+	_, err := authority.Compile(narrowed)
+	requireKernelCode(t, err, model.ErrorCapabilityDenied)
+}
+
+func TestCompileRejectsUntrustedExecutableWidening(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*authority.CompileInput)
+	}{
+		{"different image digest", func(input *authority.CompileInput) {
+			input.ImageReference = "registry.example/agent@" + testDigest("f")
+		}},
+		{"mutable image", func(input *authority.CompileInput) {
+			input.ImageReference = "registry.example/agent:latest"
+		}},
+		{"different command", func(input *authority.CompileInput) {
+			input.Command = []string{"agent", "--other"}
+		}},
+		{"different entrypoint", func(input *authority.CompileInput) {
+			input.Command = []string{"other", "--task"}
+		}},
+		{"image outside daemon ceiling", func(input *authority.CompileInput) {
+			input.Ceilings.AllowedImageDigests = []string{testDigest("f")}
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validInput(t, workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{})
+			test.mutate(&input)
+			if _, err := authority.Compile(input); err == nil {
+				t.Fatal("Compile() accepted widened executable material")
+			}
+		})
+	}
+}
+
+func TestCompileRejectsBrokenLiveBindingsAndLifecycle(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*authority.CompileInput)
+		code   model.ErrorCode
+	}{
+		{"contract content digest", func(input *authority.CompileInput) {
+			input.Contract.Goal = "changed"
+		}, model.ErrorEventChain},
+		{"delegation lineage", func(input *authority.CompileInput) {
+			input.Run.DelegationChain[0] = model.Principal{
+				ID: "human:other", Kind: model.PrincipalHuman,
+			}
+		}, model.ErrorIdentityInvalid},
+		{"run not admitted", func(input *authority.CompileInput) {
+			input.Run.State = model.RunRunning
+		}, model.ErrorTransitionInvalid},
+		{"run already leased", func(input *authority.CompileInput) {
+			input.Run.Runtime = &model.RuntimeBinding{
+				Adapter: "oci", AdapterVersion: "1",
+			}
+		}, model.ErrorTransitionInvalid},
+		{"unsupported parent run", func(input *authority.CompileInput) {
+			input.Run.ParentRunID = "run:parent"
+		}, model.ErrorTransitionInvalid},
+		{"transaction not running", func(input *authority.CompileInput) {
+			input.Transaction.State = model.TransactionCreated
+		}, model.ErrorTransitionInvalid},
+		{"transaction missing stage", func(input *authority.CompileInput) {
+			input.Transaction.StageBindings = nil
+		}, model.ErrorTransitionInvalid},
+		{"prior execution", func(input *authority.CompileInput) {
+			input.Executions = []model.AgentExecution{{ID: "execution:prior"}}
+		}, model.ErrorTransitionInvalid},
+		{"run deadline changed", func(input *authority.CompileInput) {
+			changed := input.Run.Deadline.Add(-time.Second)
+			input.Run.Deadline = &changed
+		}, model.ErrorEventChain},
+		{"grant resource changed", func(input *authority.CompileInput) {
+			input.Grants[0].Resource.Pattern = "workspace/private/**"
+		}, model.ErrorEventChain},
+		{"grant subject changed", func(input *authority.CompileInput) {
+			input.Grants[0].SubjectRunID = "run:other"
+		}, model.ErrorEventChain},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validInput(
+				t, workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{},
+			)
+			test.mutate(&input)
+			_, err := authority.Compile(input)
+			requireKernelCode(t, err, test.code)
+		})
+	}
+}
+
+func TestCompileRejectsInactiveGrantsAndTimeoutWidening(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*authority.CompileInput)
+		code   model.ErrorCode
+	}{
+		{"revoked", func(input *authority.CompileInput) {
+			revoked := input.Now
+			input.Grants[0].RevokedAt = &revoked
+		}, model.ErrorCapabilityRevoked},
+		{"expired", func(input *authority.CompileInput) {
+			input.Now = input.Grants[0].ExpiresAt
+		}, model.ErrorCapabilityExpired},
+		{"not active yet", func(input *authority.CompileInput) {
+			input.Now = input.Grants[0].IssuedAt.Add(-time.Second)
+		}, model.ErrorCapabilityDenied},
+		{"caller widens timeout", func(input *authority.CompileInput) {
+			timeout := int64(301)
+			input.CallerTimeoutSeconds = &timeout
+		}, model.ErrorCapabilityDenied},
+		{"zero caller timeout", func(input *authority.CompileInput) {
+			timeout := int64(0)
+			input.CallerTimeoutSeconds = &timeout
+		}, model.ErrorSchemaInvalid},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validInput(
+				t, workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{},
+			)
+			test.mutate(&input)
+			_, err := authority.Compile(input)
+			requireKernelCode(t, err, test.code)
+		})
+	}
+}
+
+func TestCompileRejectsUnsupportedContractSurface(t *testing.T) {
+	tests := []struct {
+		name      string
+		resources []model.ContractResource
+		budgets   model.BudgetLimits
+		mutate    func(*authority.CompileInput)
+	}{
+		{"write only", workspaceResource("filesystem.write"), model.BudgetLimits{}, nil},
+		{"narrow subpath", []model.ContractResource{{
+			ID: "workspace", Selector: model.ResourceSelector{
+				Kind: "filesystem", Pattern: "workspace/private/**",
+			}, Operations: []string{"filesystem.read"},
+			Conditions: model.CapabilityConditions{WorkspaceRoot: "workspace"},
+		}}, model.BudgetLimits{}, nil},
+		{"data classes", []model.ContractResource{{
+			ID: "workspace", Selector: model.ResourceSelector{
+				Kind: "filesystem", Pattern: "workspace/**",
+			}, Operations: []string{"filesystem.read"},
+			Conditions: model.CapabilityConditions{
+				WorkspaceRoot: "workspace", DataClassifications: []string{"secret"},
+			},
+		}}, model.BudgetLimits{}, nil},
+		{"unsupported resource", []model.ContractResource{{
+			ID: "email", Selector: model.ResourceSelector{
+				Kind: "email", Pattern: "mailbox/**",
+			}, Operations: []string{"email.send"},
+		}}, model.BudgetLimits{}, nil},
+		{"tool budget", workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{
+			MaxToolCalls: int64Pointer(5),
+		}, nil},
+		{"cost budget", workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{
+			MaxCostMicros: int64Pointer(5),
+		}, nil},
+		{"model budget without model grant", workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{
+			MaxModelCalls: int64Pointer(5),
+		}, nil},
+		{"child delegation", workspaceResource("filesystem.read", "filesystem.write"), model.BudgetLimits{}, func(input *authority.CompileInput) {
+			input.Contract.MaxChildren = int64Pointer(1)
+			input.Contract.Digest = mustContractDigest(t, input.Contract)
+			input.Run.ContractDigest = input.Contract.Digest
+			input.Transaction.Admission.ContractDigest = input.Contract.Digest
+		}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := validInput(t, test.resources, test.budgets)
+			if test.mutate != nil {
+				test.mutate(&input)
+			}
+			_, err := authority.Compile(input)
+			requireKernelCode(t, err, model.ErrorCapabilityDenied)
+		})
+	}
+}
+
+func validInput(
+	t *testing.T,
+	resources []model.ContractResource,
+	budgets model.BudgetLimits,
+) authority.CompileInput {
+	t.Helper()
+	now := time.Date(2026, 7, 28, 3, 0, 0, 0, time.UTC)
+	command := []string{"agent", "--task"}
+	commandDigest, err := transactionreducer.ComputeCommandDigest(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	maxWall := int64(600)
+	budgets.MaxWallTimeSeconds = &maxWall
+	prepared, err := admission.Prepare("team", admission.Request{
+		Version:        admission.RequestVersion,
+		IdempotencyKey: "admission:test",
+		TransactionID:  "tx:test",
+		RunID:          "run:test",
+		Intent:         "perform the admitted task",
+		AgentProfile: model.AgentTaskProfileBinding{
+			ID: "agent:test", Digest: testDigest("a"), RuntimeClass: "oci",
+			ImageDigest: testDigest("b"), Entrypoint: "agent",
+			CommandDigest: commandDigest,
+		},
+		Sponsor: model.Principal{
+			ID: "human:sponsor", Kind: model.PrincipalHuman,
+		},
+		Actor: model.Principal{
+			ID: "operator:supervisor", Kind: model.PrincipalOperator,
+		},
+		Contract: admission.ContractSpec{
+			Risk: "high", Resources: resources, Budgets: budgets,
+		},
+	}, now)
+	if err != nil {
+		t.Fatalf("Prepare() error = %v", err)
+	}
+	transaction := prepared.Result.Transaction.Transaction
+	transaction.State = model.TransactionRunning
+	transaction.StageBindings = []model.StageBinding{{
+		ID: "stage:test", Kind: "git_worktree",
+		Resource: model.ResourceSelector{
+			Kind: "git_repository", Pattern: "/repository",
+		},
+		Location: "/staging/tx-test", BaseRevision: "revision:base",
+		CreatedAt: now,
+	}}
+	transaction.EventSequence = 3
+	transaction.UpdatedAt = now.Add(time.Second)
+	if err := transaction.Validate(); err != nil {
+		t.Fatalf("transaction fixture invalid: %v", err)
+	}
+	return authority.CompileInput{
+		Task: prepared.Result.Task, Contract: prepared.Result.Contract,
+		Run: prepared.Result.Run.Run, Grants: prepared.Result.Grants,
+		Transaction:    transaction,
+		ImageReference: "registry.example/agent@" + testDigest("b"),
+		Command:        command,
+		Ceilings: authority.DaemonCeilings{
+			MaxWallTimeSeconds:  300,
+			AllowedImageDigests: []string{testDigest("b")},
+		},
+		Now: now.Add(10 * time.Second),
+	}
+}
+
+func workspaceResource(operations ...string) []model.ContractResource {
+	return []model.ContractResource{{
+		ID: "workspace",
+		Selector: model.ResourceSelector{
+			Kind: "filesystem", Pattern: "workspace/**",
+		},
+		Operations: operations,
+		Conditions: model.CapabilityConditions{WorkspaceRoot: "workspace"},
+	}}
+}
+
+func testDigest(character string) string {
+	return "sha256:" + strings.Repeat(character, 64)
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
+}
+
+func mustContractDigest(t *testing.T, contract model.ExecutionContract) string {
+	t.Helper()
+	digest, err := model.ComputeExecutionContractDigest(contract)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return digest
+}
+
+func requireKernelCode(t *testing.T, err error, code model.ErrorCode) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want %s", code)
+	}
+	var kernelErr *model.KernelError
+	if !errors.As(err, &kernelErr) {
+		t.Fatalf("error = %T %v, want *model.KernelError", err, err)
+	}
+	if kernelErr.Code != code {
+		t.Fatalf("error code = %s, want %s: %v", kernelErr.Code, code, err)
+	}
+}

--- a/internal/kernel/client/client.go
+++ b/internal/kernel/client/client.go
@@ -356,7 +356,7 @@ func (c *Client) RunTransactionAgent(
 	ctx context.Context,
 	namespace, transactionID string,
 	expectedSequence int64,
-	runID, image string,
+	image string,
 	command []string,
 	timeoutSeconds int64,
 	actor model.Principal,
@@ -364,21 +364,24 @@ func (c *Client) RunTransactionAgent(
 	request := struct {
 		ExpectedSequence int64           `json:"expected_sequence"`
 		Actor            model.Principal `json:"actor"`
-		RunID            string          `json:"run_id"`
 		Image            string          `json:"image"`
 		Command          []string        `json:"command"`
-		TimeoutSeconds   int64           `json:"timeout_seconds"`
+		TimeoutSeconds   int64           `json:"timeout_seconds,omitempty"`
 	}{
 		ExpectedSequence: expectedSequence,
 		Actor:            actor,
-		RunID:            runID,
 		Image:            image,
 		Command:          append([]string(nil), command...),
 		TimeoutSeconds:   timeoutSeconds,
 	}
 	var result TransactionAgentRunResult
 	longHTTP := *c.http
-	longHTTP.Timeout = time.Duration(timeoutSeconds)*time.Second + 30*time.Second
+	if timeoutSeconds > 0 {
+		longHTTP.Timeout =
+			time.Duration(timeoutSeconds)*time.Second + 30*time.Second
+	} else {
+		longHTTP.Timeout = 0
+	}
 	longClient := &Client{http: &longHTTP, bearerToken: c.bearerToken}
 	err := longClient.do(
 		ctx, http.MethodPost,

--- a/internal/kernel/store/execution_authority_store.go
+++ b/internal/kernel/store/execution_authority_store.go
@@ -1,0 +1,398 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"reflect"
+
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+const getExecutionAuthorityOperation = "get_execution_authority"
+
+// GetExecutionAuthority returns one consistent, fully verified view of the
+// authority admitted for a transaction and its current lifecycle projections.
+// Legacy transactions are intentionally not upgraded into execution authority.
+func (s *SQLiteStore) GetExecutionAuthority(
+	ctx context.Context,
+	namespace, transactionID string,
+) (ExecutionAuthoritySnapshot, error) {
+	if err := validateNamespace(namespace); err != nil {
+		return ExecutionAuthoritySnapshot{}, err
+	}
+	if !identifierPattern.MatchString(transactionID) {
+		return ExecutionAuthoritySnapshot{}, storeError(
+			model.ErrorSchemaInvalid,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"invalid transaction ID",
+			nil,
+		)
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{
+		Isolation: sql.LevelSerializable,
+		ReadOnly:  true,
+	})
+	if err != nil {
+		return ExecutionAuthoritySnapshot{}, storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"begin authority snapshot",
+			err,
+		)
+	}
+	defer tx.Rollback()
+
+	var idempotencyKey string
+	err = tx.QueryRowContext(
+		ctx,
+		`SELECT idempotency_key
+		 FROM task_admissions
+		 WHERE namespace = ? AND transaction_id = ?`,
+		namespace,
+		transactionID,
+	).Scan(&idempotencyKey)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		return ExecutionAuthoritySnapshot{}, storeError(
+			model.ErrorNotFound,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"transaction has no task admission in namespace",
+			err,
+		)
+	case err != nil:
+		return ExecutionAuthoritySnapshot{}, storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"query task admission",
+			err,
+		)
+	}
+
+	initial, _, err := loadTaskAdmission(ctx, tx, namespace, idempotencyKey)
+	if err != nil {
+		return ExecutionAuthoritySnapshot{}, authoritySnapshotError(
+			transactionID,
+			"load admitted authority",
+			err,
+		)
+	}
+	if initial.Transaction.Transaction.ID != transactionID {
+		return ExecutionAuthoritySnapshot{}, storeError(
+			model.ErrorEventChain,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"task admission transaction binding does not match its index",
+			nil,
+		)
+	}
+
+	currentRun, err := loadProjection(
+		ctx,
+		tx,
+		namespace,
+		initial.Run.Run.ID,
+	)
+	if err != nil {
+		return ExecutionAuthoritySnapshot{}, err
+	}
+	currentTransaction, err := loadTransactionProjection(
+		ctx,
+		tx,
+		namespace,
+		transactionID,
+	)
+	if err != nil {
+		return ExecutionAuthoritySnapshot{}, err
+	}
+	if err := validateCurrentAdmissionBindings(
+		initial,
+		currentRun.Run,
+		currentTransaction,
+	); err != nil {
+		return ExecutionAuthoritySnapshot{}, authoritySnapshotError(
+			transactionID,
+			"current authority no longer matches its admission",
+			err,
+		)
+	}
+	if err := verifyLiveRunProjection(
+		ctx,
+		tx,
+		namespace,
+		currentRun,
+	); err != nil {
+		return ExecutionAuthoritySnapshot{}, err
+	}
+	if err := verifyLiveTransactionProjection(
+		ctx,
+		tx,
+		namespace,
+		currentTransaction,
+	); err != nil {
+		return ExecutionAuthoritySnapshot{}, err
+	}
+
+	if err := tx.Commit(); err != nil {
+		return ExecutionAuthoritySnapshot{}, storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"commit authority snapshot",
+			err,
+		)
+	}
+	return ExecutionAuthoritySnapshot{
+		Task:        initial.Task,
+		Contract:    initial.Contract,
+		Grants:      append([]model.CapabilityGrant(nil), initial.Grants...),
+		Run:         currentRun,
+		Transaction: currentTransaction,
+	}, nil
+}
+
+type authorityRowsQuerier interface {
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+}
+
+func verifyLiveRunProjection(
+	ctx context.Context,
+	query authorityRowsQuerier,
+	namespace string,
+	current reducer.Projection,
+) error {
+	rows, err := query.QueryContext(
+		ctx,
+		`SELECT sequence, event_id, event_type, event_digest, event_json
+		 FROM events
+		 WHERE namespace = ? AND run_id = ?
+		 ORDER BY sequence`,
+		namespace,
+		current.Run.ID,
+	)
+	if err != nil {
+		return storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			current.Run.ID,
+			"query authoritative run events",
+			err,
+		)
+	}
+	defer rows.Close()
+
+	events := make([]model.RunEvent, 0, current.Run.EventSequence)
+	for rows.Next() {
+		var sequence int64
+		var eventID, eventType, eventDigest string
+		var data []byte
+		if err := rows.Scan(
+			&sequence,
+			&eventID,
+			&eventType,
+			&eventDigest,
+			&data,
+		); err != nil {
+			return storeError(
+				model.ErrorInternal,
+				getExecutionAuthorityOperation,
+				current.Run.ID,
+				"scan authoritative run event",
+				err,
+			)
+		}
+		event, err := model.DecodeStrict[model.RunEvent](data)
+		if err != nil {
+			return storeError(
+				model.ErrorEventChain,
+				getExecutionAuthorityOperation,
+				current.Run.ID,
+				"stored run event is invalid",
+				err,
+			)
+		}
+		if event.RunID != current.Run.ID ||
+			event.Sequence != sequence ||
+			event.ID != eventID ||
+			event.Type != eventType ||
+			event.Digest != eventDigest {
+			return storeError(
+				model.ErrorEventChain,
+				getExecutionAuthorityOperation,
+				current.Run.ID,
+				"stored run event columns do not match their envelope",
+				nil,
+			)
+		}
+		if err := verifyEventDigest(event); err != nil {
+			return authoritySnapshotError(
+				current.Run.ID,
+				"stored run event digest is invalid",
+				err,
+			)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			current.Run.ID,
+			"iterate authoritative run events",
+			err,
+		)
+	}
+	replayed, err := reducer.Replay(events)
+	if err != nil {
+		return storeError(
+			model.ErrorEventChain,
+			getExecutionAuthorityOperation,
+			current.Run.ID,
+			"authoritative run event replay failed",
+			err,
+		)
+	}
+	if !reflect.DeepEqual(replayed, current) {
+		return storeError(
+			model.ErrorEventChain,
+			getExecutionAuthorityOperation,
+			current.Run.ID,
+			"current run projection does not match authoritative replay",
+			nil,
+		)
+	}
+	return nil
+}
+
+func verifyLiveTransactionProjection(
+	ctx context.Context,
+	query authorityRowsQuerier,
+	namespace string,
+	current transactionreducer.Projection,
+) error {
+	transactionID := current.Transaction.ID
+	rows, err := query.QueryContext(
+		ctx,
+		`SELECT sequence, event_id, event_type, event_digest, event_json
+		 FROM transaction_events
+		 WHERE namespace = ? AND transaction_id = ?
+		 ORDER BY sequence`,
+		namespace,
+		transactionID,
+	)
+	if err != nil {
+		return storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"query authoritative transaction events",
+			err,
+		)
+	}
+	defer rows.Close()
+
+	events := make([]model.TransactionEvent, 0, current.Transaction.EventSequence)
+	for rows.Next() {
+		var sequence int64
+		var eventID, eventType, eventDigest string
+		var data []byte
+		if err := rows.Scan(
+			&sequence,
+			&eventID,
+			&eventType,
+			&eventDigest,
+			&data,
+		); err != nil {
+			return storeError(
+				model.ErrorInternal,
+				getExecutionAuthorityOperation,
+				transactionID,
+				"scan authoritative transaction event",
+				err,
+			)
+		}
+		event, err := model.DecodeStrict[model.TransactionEvent](data)
+		if err != nil {
+			return storeError(
+				model.ErrorEventChain,
+				getExecutionAuthorityOperation,
+				transactionID,
+				"stored transaction event is invalid",
+				err,
+			)
+		}
+		if event.TransactionID != transactionID ||
+			event.Sequence != sequence ||
+			event.ID != eventID ||
+			event.Type != eventType ||
+			event.Digest != eventDigest {
+			return storeError(
+				model.ErrorEventChain,
+				getExecutionAuthorityOperation,
+				transactionID,
+				"stored transaction event columns do not match their envelope",
+				nil,
+			)
+		}
+		if err := verifyTransactionEventDigest(event); err != nil {
+			return authoritySnapshotError(
+				transactionID,
+				"stored transaction event digest is invalid",
+				err,
+			)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return storeError(
+			model.ErrorInternal,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"iterate authoritative transaction events",
+			err,
+		)
+	}
+	replayed, err := transactionreducer.Replay(events)
+	if err != nil {
+		return storeError(
+			model.ErrorEventChain,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"authoritative transaction event replay failed",
+			err,
+		)
+	}
+	if !reflect.DeepEqual(replayed, current) {
+		return storeError(
+			model.ErrorEventChain,
+			getExecutionAuthorityOperation,
+			transactionID,
+			"current transaction projection does not match authoritative replay",
+			nil,
+		)
+	}
+	return nil
+}
+
+func authoritySnapshotError(resource, message string, cause error) error {
+	var kernelError *model.KernelError
+	code := model.ErrorEventChain
+	if errors.As(cause, &kernelError) &&
+		kernelError.Code == model.ErrorInternal {
+		code = kernelError.Code
+	}
+	return storeError(
+		code,
+		getExecutionAuthorityOperation,
+		resource,
+		message,
+		cause,
+	)
+}

--- a/internal/kernel/store/execution_authority_store_test.go
+++ b/internal/kernel/store/execution_authority_store_test.go
@@ -1,0 +1,358 @@
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/eventlog"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+func TestGetExecutionAuthorityTracksLifecycleAndSurvivesRestart(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "kernel.db")
+	kernelStore, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	prepared := prepareStoreAdmission(t, "execution-authority")
+	initial, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil || !created {
+		t.Fatalf("admit task: created=%v err=%v", created, err)
+	}
+
+	fresh, err := kernelStore.GetExecutionAuthority(
+		ctx,
+		prepared.Namespace,
+		initial.Transaction.Transaction.ID,
+	)
+	if err != nil {
+		t.Fatalf("get fresh execution authority: %v", err)
+	}
+	assertAuthorityImmutableAdmission(t, fresh, initial)
+	if !reflect.DeepEqual(fresh.Run, initial.Run) ||
+		!reflect.DeepEqual(fresh.Transaction, initial.Transaction) {
+		t.Fatal("fresh authority did not return admitted lifecycle projections")
+	}
+
+	currentRun, currentTransaction := advanceAuthorityLifecycle(
+		t,
+		ctx,
+		kernelStore,
+		prepared.Namespace,
+		initial,
+	)
+	advanced, err := kernelStore.GetExecutionAuthority(
+		ctx,
+		prepared.Namespace,
+		initial.Transaction.Transaction.ID,
+	)
+	if err != nil {
+		t.Fatalf("get advanced execution authority: %v", err)
+	}
+	assertAuthorityImmutableAdmission(t, advanced, initial)
+	if !reflect.DeepEqual(advanced.Run, currentRun) ||
+		!reflect.DeepEqual(advanced.Transaction, currentTransaction) {
+		t.Fatal("advanced authority did not return current lifecycle projections")
+	}
+
+	if err := kernelStore.Close(); err != nil {
+		t.Fatal(err)
+	}
+	reopened, err := OpenSQLite(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = reopened.Close() })
+	afterRestart, err := reopened.GetExecutionAuthority(
+		ctx,
+		prepared.Namespace,
+		initial.Transaction.Transaction.ID,
+	)
+	if err != nil {
+		t.Fatalf("get execution authority after restart: %v", err)
+	}
+	if !reflect.DeepEqual(afterRestart, advanced) {
+		t.Fatal("execution authority changed across store restart")
+	}
+}
+
+func TestGetExecutionAuthorityRejectsTransactionWithoutAdmission(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	now := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	legacy := model.AgentTransaction{
+		Version:                model.AgentTransactionVersion,
+		ID:                     "tx:legacy-authority",
+		Namespace:              "store-test",
+		IntentDigest:           "sha256:" + strings.Repeat("a", 64),
+		Sponsor:                model.Principal{ID: "human:legacy", Kind: model.PrincipalHuman},
+		AgentRunIDs:            []string{"run:legacy-authority"},
+		StageBindings:          []model.StageBinding{},
+		State:                  model.TransactionCreated,
+		EffectIDs:              []string{},
+		VerificationResultIDs:  []string{},
+		OutstandingApprovalIDs: []string{},
+		EventSequence:          1,
+		CreatedAt:              now,
+		UpdatedAt:              now,
+	}
+	event, err := transactionreducer.CreationEvent(legacy, legacy.Sponsor)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kernelStore.CreateTransaction(ctx, event); err != nil {
+		t.Fatalf("create legacy transaction: %v", err)
+	}
+
+	_, err = kernelStore.GetExecutionAuthority(
+		ctx,
+		legacy.Namespace,
+		legacy.ID,
+	)
+	assertKernelCode(t, err, model.ErrorNotFound)
+
+	_, err = kernelStore.GetExecutionAuthority(
+		ctx,
+		legacy.Namespace,
+		"tx:missing-authority",
+	)
+	assertKernelCode(t, err, model.ErrorNotFound)
+}
+
+func TestGetExecutionAuthorityRejectsTamperedAuthority(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name   string
+		tamper func(*testing.T, context.Context, *SQLiteStore, string)
+	}{
+		{
+			name: "immutable task",
+			tamper: func(
+				t *testing.T,
+				ctx context.Context,
+				kernelStore *SQLiteStore,
+				transactionID string,
+			) {
+				t.Helper()
+				if _, err := kernelStore.db.ExecContext(
+					ctx,
+					`UPDATE agent_tasks SET task_json = ?
+					 WHERE namespace = ? AND transaction_id = ?`,
+					[]byte("{}"),
+					"store-test",
+					transactionID,
+				); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "current run binding",
+			tamper: func(
+				t *testing.T,
+				ctx context.Context,
+				kernelStore *SQLiteStore,
+				transactionID string,
+			) {
+				t.Helper()
+				var runID string
+				if err := kernelStore.db.QueryRowContext(
+					ctx,
+					`SELECT run_id FROM task_admissions
+					 WHERE namespace = ? AND transaction_id = ?`,
+					"store-test",
+					transactionID,
+				).Scan(&runID); err != nil {
+					t.Fatal(err)
+				}
+				current, err := kernelStore.GetRun(ctx, "store-test", runID)
+				if err != nil {
+					t.Fatal(err)
+				}
+				current.Run.ContractDigest = "sha256:" + strings.Repeat("f", 64)
+				data, err := json.Marshal(current.Run)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := kernelStore.db.ExecContext(
+					ctx,
+					`UPDATE runs SET state_json = ?
+					 WHERE namespace = ? AND run_id = ?`,
+					data,
+					"store-test",
+					runID,
+				); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+		{
+			name: "advanced run event",
+			tamper: func(
+				t *testing.T,
+				ctx context.Context,
+				kernelStore *SQLiteStore,
+				transactionID string,
+			) {
+				t.Helper()
+				var runID string
+				if err := kernelStore.db.QueryRowContext(
+					ctx,
+					`SELECT run_id FROM task_admissions
+					 WHERE namespace = ? AND transaction_id = ?`,
+					"store-test",
+					transactionID,
+				).Scan(&runID); err != nil {
+					t.Fatal(err)
+				}
+				var data []byte
+				if err := kernelStore.db.QueryRowContext(
+					ctx,
+					`SELECT event_json FROM events
+					 WHERE namespace = ? AND run_id = ? AND sequence = 4`,
+					"store-test",
+					runID,
+				).Scan(&data); err != nil {
+					t.Fatal(err)
+				}
+				event, err := model.DecodeStrict[model.RunEvent](data)
+				if err != nil {
+					t.Fatal(err)
+				}
+				event.Actor.ID = "service:tampered"
+				data, err = json.Marshal(event)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if _, err := kernelStore.db.ExecContext(
+					ctx,
+					`UPDATE events SET event_json = ?
+					 WHERE namespace = ? AND run_id = ? AND sequence = 4`,
+					data,
+					"store-test",
+					runID,
+				); err != nil {
+					t.Fatal(err)
+				}
+			},
+		},
+	} {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			kernelStore := openTestStore(t)
+			suffix := "tamper-" + strings.ReplaceAll(test.name, " ", "-")
+			prepared := prepareStoreAdmission(t, suffix)
+			initial, created, err := kernelStore.AdmitTask(ctx, prepared)
+			if err != nil || !created {
+				t.Fatalf("admit task: created=%v err=%v", created, err)
+			}
+			if test.name == "advanced run event" {
+				advanceAuthorityLifecycle(
+					t,
+					ctx,
+					kernelStore,
+					prepared.Namespace,
+					initial,
+				)
+			}
+			test.tamper(
+				t,
+				ctx,
+				kernelStore,
+				initial.Transaction.Transaction.ID,
+			)
+
+			_, err = kernelStore.GetExecutionAuthority(
+				ctx,
+				prepared.Namespace,
+				initial.Transaction.Transaction.ID,
+			)
+			assertKernelCode(t, err, model.ErrorEventChain)
+		})
+	}
+}
+
+func advanceAuthorityLifecycle(
+	t *testing.T,
+	ctx context.Context,
+	kernelStore *SQLiteStore,
+	namespace string,
+	initial admission.Result,
+) (reducer.Projection, transactionreducer.Projection) {
+	t.Helper()
+	actor := model.Principal{
+		ID: "service:vouchd", Kind: model.PrincipalService, Issuer: "vouchd",
+	}
+	advancedAt := initial.Task.CreatedAt.Add(time.Second)
+	runEvent, err := eventlog.Next(
+		initial.Run,
+		reducer.EventRunStateChanged,
+		actor,
+		advancedAt,
+		model.RunStateChangedPayload{
+			From: model.RunAdmitted,
+			To:   model.RunRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentRun, err := kernelStore.AppendEvent(
+		ctx,
+		namespace,
+		initial.Run.Run.EventSequence,
+		runEvent,
+	)
+	if err != nil {
+		t.Fatalf("advance admitted run: %v", err)
+	}
+	transactionEvent, err := transactionreducer.NextEvent(
+		initial.Transaction,
+		transactionreducer.EventTransactionStateChanged,
+		actor,
+		advancedAt,
+		transactionreducer.TransactionStateChangedPayload{
+			From: model.TransactionCreated,
+			To:   model.TransactionRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	currentTransaction, err := kernelStore.AppendTransactionEvents(
+		ctx,
+		namespace,
+		initial.Transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{transactionEvent},
+	)
+	if err != nil {
+		t.Fatalf("advance admitted transaction: %v", err)
+	}
+	return currentRun, currentTransaction
+}
+
+func assertAuthorityImmutableAdmission(
+	t *testing.T,
+	got ExecutionAuthoritySnapshot,
+	want admission.Result,
+) {
+	t.Helper()
+	if !reflect.DeepEqual(got.Task, want.Task) ||
+		!reflect.DeepEqual(got.Contract, want.Contract) ||
+		!reflect.DeepEqual(got.Grants, want.Grants) {
+		t.Fatal("execution authority changed immutable admission resources")
+	}
+}

--- a/internal/kernel/store/launch_claim_store_test.go
+++ b/internal/kernel/store/launch_claim_store_test.go
@@ -1,0 +1,257 @@
+package store
+
+import (
+	"context"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/admission"
+	"github.com/duriantaco/vouch/internal/kernel/eventlog"
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/vouch/internal/kernel/transaction"
+)
+
+func TestAppendTransactionEventsIfRunCurrentClaimsLaunch(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	fixture := prepareLaunchClaim(t, ctx, kernelStore, "claim-success")
+
+	claimed, err := kernelStore.AppendTransactionEventsIfRunCurrent(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.transaction.Transaction.EventSequence,
+		fixture.admission.Run.Run.EventSequence,
+		fixture.admission.Run.LastEventDigest,
+		[]model.TransactionEvent{fixture.startEvent},
+	)
+	if err != nil {
+		t.Fatalf("claim launch: %v", err)
+	}
+	if claimed.Transaction.EventSequence !=
+		fixture.transaction.Transaction.EventSequence+1 ||
+		len(claimed.Executions) != 1 ||
+		claimed.Executions[0].Status != model.AgentExecutionRunning ||
+		claimed.Executions[0].RunID != fixture.admission.Run.Run.ID {
+		t.Fatalf("unexpected claimed projection: %#v", claimed)
+	}
+	currentRun, err := kernelStore.GetRun(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Run.Run.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(currentRun, fixture.admission.Run) {
+		t.Fatal("launch claim mutated the admitted run")
+	}
+	events, err := kernelStore.TransactionEvents(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Transaction.Transaction.ID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != int(claimed.Transaction.EventSequence) ||
+		events[len(events)-1].Type !=
+			transactionreducer.EventAgentExecutionStarted {
+		t.Fatalf("launch event was not durably appended: %#v", events)
+	}
+}
+
+func TestAppendTransactionEventsIfRunCurrentConflictsWithoutAppend(
+	t *testing.T,
+) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	fixture := prepareLaunchClaim(t, ctx, kernelStore, "claim-run-conflict")
+	beforeEvents, err := kernelStore.TransactionEvents(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Transaction.Transaction.ID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	actor := model.Principal{
+		ID: "service:vouchd", Kind: model.PrincipalService, Issuer: "vouchd",
+	}
+	runEvent, err := eventlog.Next(
+		fixture.admission.Run,
+		reducer.EventRunStateChanged,
+		actor,
+		fixture.admission.Task.CreatedAt.Add(3*time.Second),
+		model.RunStateChangedPayload{
+			From: model.RunAdmitted,
+			To:   model.RunRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kernelStore.AppendEvent(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Run.Run.EventSequence,
+		runEvent,
+	); err != nil {
+		t.Fatalf("advance run before launch claim: %v", err)
+	}
+
+	_, err = kernelStore.AppendTransactionEventsIfRunCurrent(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.transaction.Transaction.EventSequence,
+		fixture.admission.Run.Run.EventSequence,
+		fixture.admission.Run.LastEventDigest,
+		[]model.TransactionEvent{fixture.startEvent},
+	)
+	assertKernelCode(t, err, model.ErrorConflict)
+
+	after, err := kernelStore.GetTransaction(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Transaction.Transaction.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(after, fixture.transaction) {
+		t.Fatal("run-head conflict changed the transaction projection")
+	}
+	afterEvents, err := kernelStore.TransactionEvents(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Transaction.Transaction.ID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(afterEvents, beforeEvents) {
+		t.Fatal("run-head conflict appended a transaction event")
+	}
+}
+
+type launchClaimFixture struct {
+	admission   admission.Result
+	transaction transactionreducer.Projection
+	startEvent  model.TransactionEvent
+}
+
+func prepareLaunchClaim(
+	t *testing.T,
+	ctx context.Context,
+	kernelStore *SQLiteStore,
+	suffix string,
+) launchClaimFixture {
+	t.Helper()
+	prepared := prepareStoreAdmission(t, suffix)
+	admitted, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil || !created {
+		t.Fatalf("admit task: created=%v err=%v", created, err)
+	}
+	actor := model.Principal{
+		ID: "service:vouchd", Kind: model.PrincipalService, Issuer: "vouchd",
+	}
+	startedAt := admitted.Task.CreatedAt.Add(time.Second)
+	started, err := transactionreducer.NextEvent(
+		admitted.Transaction,
+		transactionreducer.EventTransactionStateChanged,
+		actor,
+		startedAt,
+		transactionreducer.TransactionStateChangedPayload{
+			From: model.TransactionCreated,
+			To:   model.TransactionRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err := kernelStore.AppendTransactionEvents(
+		ctx,
+		prepared.Namespace,
+		admitted.Transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{started},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	boundAt := startedAt.Add(time.Second)
+	binding := model.StageBinding{
+		ID:   "stage:" + suffix,
+		Kind: "git_worktree",
+		Resource: model.ResourceSelector{
+			Kind: "git_repository", Pattern: "repo:" + suffix,
+		},
+		Location:     "/staging/" + suffix,
+		BaseRevision: strings.Repeat("a", 40),
+		CreatedAt:    boundAt,
+	}
+	bound, err := transactionreducer.NextEvent(
+		transaction,
+		transactionreducer.EventStageBindingCreated,
+		actor,
+		boundAt,
+		transactionreducer.StageBindingCreatedPayload{Binding: binding},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err = kernelStore.AppendTransactionEvents(
+		ctx,
+		prepared.Namespace,
+		transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{bound},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	executionAt := boundAt.Add(time.Second)
+	execution := model.AgentExecution{
+		Version: model.AgentExecutionVersion,
+		ID: transactionreducer.ExecutionID(
+			transaction.Transaction.ID,
+			transaction.Transaction.EventSequence+1,
+		),
+		TransactionID:       transaction.Transaction.ID,
+		RunID:               admitted.Run.Run.ID,
+		StageBindingID:      binding.ID,
+		Program:             "agent",
+		CommandDigest:       admitted.Task.AgentProfile.CommandDigest,
+		RuntimeClass:        "oci",
+		RuntimeConfigDigest: "sha256:" + strings.Repeat("d", 64),
+		ImageDigest:         admitted.Task.AgentProfile.ImageDigest,
+		TaskDigest:          admitted.Task.Digest,
+		Status:              model.AgentExecutionRunning,
+		StartedAt:           executionAt,
+	}
+	startEvent, err := transactionreducer.NextEvent(
+		transaction,
+		transactionreducer.EventAgentExecutionStarted,
+		actor,
+		executionAt,
+		transactionreducer.AgentExecutionStartedPayload{
+			Execution: execution,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return launchClaimFixture{
+		admission:   admitted,
+		transaction: transaction,
+		startEvent:  startEvent,
+	}
+}

--- a/internal/kernel/store/sqlite.go
+++ b/internal/kernel/store/sqlite.go
@@ -580,12 +580,14 @@ type rowQuerier interface {
 
 func loadProjection(ctx context.Context, query rowQuerier, namespace, runID string) (reducer.Projection, error) {
 	var data []byte
+	var sequence int64
 	var lastDigest string
 	err := query.QueryRowContext(ctx,
-		`SELECT state_json, last_event_digest FROM runs WHERE namespace = ? AND run_id = ?`,
+		`SELECT state_json, event_sequence, last_event_digest
+		 FROM runs WHERE namespace = ? AND run_id = ?`,
 		namespace,
 		runID,
-	).Scan(&data, &lastDigest)
+	).Scan(&data, &sequence, &lastDigest)
 	if errors.Is(err, sql.ErrNoRows) {
 		return reducer.Projection{}, storeError(model.ErrorNotFound, "get_run", runID, "run not found in namespace", err)
 	}
@@ -599,8 +601,10 @@ func loadProjection(ctx context.Context, query rowQuerier, namespace, runID stri
 	if err := run.Validate(); err != nil {
 		return reducer.Projection{}, storeError(model.ErrorEventChain, "get_run", runID, "stored run failed validation", err)
 	}
-	if run.Namespace != namespace || run.ID != runID {
-		return reducer.Projection{}, storeError(model.ErrorEventChain, "get_run", runID, "stored run identity does not match its key", nil)
+	if run.Namespace != namespace ||
+		run.ID != runID ||
+		run.EventSequence != sequence {
+		return reducer.Projection{}, storeError(model.ErrorEventChain, "get_run", runID, "stored run identity or sequence does not match its key", nil)
 	}
 	if !digestPattern.MatchString(lastDigest) {
 		return reducer.Projection{}, storeError(model.ErrorEventChain, "get_run", runID, "stored event digest is invalid", nil)

--- a/internal/kernel/store/store.go
+++ b/internal/kernel/store/store.go
@@ -39,6 +39,19 @@ type TransactionStore interface {
 type AdmissionStore interface {
 	AdmitTask(context.Context, admission.Prepared) (admission.Result, bool, error)
 	GetTaskAdmission(context.Context, string, string) (admission.Result, string, error)
+	GetExecutionAuthority(context.Context, string, string) (ExecutionAuthoritySnapshot, error)
+	AppendTransactionEventsIfRunCurrent(context.Context, string, int64, int64, string, []model.TransactionEvent) (transactionreducer.Projection, error)
+}
+
+// ExecutionAuthoritySnapshot is the consistently read authority envelope used
+// immediately before execution. The task, contract, and grants are immutable
+// admission outputs; the run and transaction are their current projections.
+type ExecutionAuthoritySnapshot struct {
+	Task        model.AgentTask
+	Contract    model.ExecutionContract
+	Grants      []model.CapabilityGrant
+	Run         reducer.Projection
+	Transaction transactionreducer.Projection
 }
 
 // Store combines the local kernel persistence boundaries with lifecycle

--- a/internal/kernel/store/transaction_store.go
+++ b/internal/kernel/store/transaction_store.go
@@ -77,11 +77,80 @@ func (s *SQLiteStore) AppendTransactionEvents(
 	expectedSequence int64,
 	events []model.TransactionEvent,
 ) (transactionreducer.Projection, error) {
+	return s.appendTransactionEvents(
+		ctx,
+		namespace,
+		expectedSequence,
+		events,
+		"append_transaction_events",
+		nil,
+	)
+}
+
+// AppendTransactionEventsIfRunCurrent atomically claims launch in the
+// transaction ledger only while the run admitted with that transaction still
+// has the exact event head verified by the caller's authority snapshot.
+func (s *SQLiteStore) AppendTransactionEventsIfRunCurrent(
+	ctx context.Context,
+	namespace string,
+	expectedTransactionSequence int64,
+	expectedRunSequence int64,
+	expectedRunDigest string,
+	events []model.TransactionEvent,
+) (transactionreducer.Projection, error) {
+	const operation = "append_transaction_events_if_run_current"
+	if expectedTransactionSequence < 1 ||
+		expectedRunSequence < 1 ||
+		!digestPattern.MatchString(expectedRunDigest) {
+		return transactionreducer.Projection{}, storeError(
+			model.ErrorSchemaInvalid,
+			operation,
+			"",
+			"expected transaction and run heads are invalid",
+			nil,
+		)
+	}
+	if len(events) != 1 ||
+		events[0].Type != transactionreducer.EventAgentExecutionStarted {
+		return transactionreducer.Projection{}, storeError(
+			model.ErrorSchemaInvalid,
+			operation,
+			"",
+			"guarded run-head append requires one agent execution start event",
+			nil,
+		)
+	}
+	return s.appendTransactionEvents(
+		ctx,
+		namespace,
+		expectedTransactionSequence,
+		events,
+		operation,
+		&expectedRunHead{
+			sequence: expectedRunSequence,
+			digest:   expectedRunDigest,
+		},
+	)
+}
+
+type expectedRunHead struct {
+	sequence int64
+	digest   string
+}
+
+func (s *SQLiteStore) appendTransactionEvents(
+	ctx context.Context,
+	namespace string,
+	expectedSequence int64,
+	events []model.TransactionEvent,
+	operation string,
+	runHead *expectedRunHead,
+) (transactionreducer.Projection, error) {
 	if err := validateNamespace(namespace); err != nil {
 		return transactionreducer.Projection{}, err
 	}
 	if len(events) == 0 {
-		return transactionreducer.Projection{}, storeError(model.ErrorSchemaInvalid, "append_transaction_events", "", "at least one event is required", nil)
+		return transactionreducer.Projection{}, storeError(model.ErrorSchemaInvalid, operation, "", "at least one event is required", nil)
 	}
 	for _, event := range events {
 		if err := verifyTransactionEventDigest(event); err != nil {
@@ -90,7 +159,7 @@ func (s *SQLiteStore) AppendTransactionEvents(
 	}
 	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
 	if err != nil {
-		return transactionreducer.Projection{}, storeError(model.ErrorInternal, "append_transaction_events", events[0].TransactionID, "begin transaction", err)
+		return transactionreducer.Projection{}, storeError(model.ErrorInternal, operation, events[0].TransactionID, "begin transaction", err)
 	}
 	defer tx.Rollback()
 	current, err := loadTransactionProjection(ctx, tx, namespace, events[0].TransactionID)
@@ -99,17 +168,29 @@ func (s *SQLiteStore) AppendTransactionEvents(
 	}
 	if current.Transaction.EventSequence != expectedSequence {
 		return transactionreducer.Projection{}, conflict(
-			"append_transaction_events",
+			operation,
 			events[0].TransactionID,
 			fmt.Sprintf("expected transaction sequence %d, current sequence is %d", expectedSequence, current.Transaction.EventSequence),
 			nil,
 		)
 	}
+	if runHead != nil {
+		if err := verifyAdmittedRunHead(
+			ctx,
+			tx,
+			namespace,
+			current,
+			*runHead,
+			operation,
+		); err != nil {
+			return transactionreducer.Projection{}, err
+		}
+	}
 	next := current
 	eventJSON := make([][]byte, len(events))
 	for i, event := range events {
 		if event.TransactionID != current.Transaction.ID {
-			return transactionreducer.Projection{}, storeError(model.ErrorEventSequence, "append_transaction_events", event.ID, "batch contains another transaction", nil)
+			return transactionreducer.Projection{}, storeError(model.ErrorEventSequence, operation, event.ID, "batch contains another transaction", nil)
 		}
 		next, err = transactionreducer.Apply(&next, event)
 		if err != nil {
@@ -117,7 +198,7 @@ func (s *SQLiteStore) AppendTransactionEvents(
 		}
 		eventJSON[i], err = json.Marshal(event)
 		if err != nil {
-			return transactionreducer.Projection{}, storeError(model.ErrorInternal, "append_transaction_events", event.ID, "encode event", err)
+			return transactionreducer.Projection{}, storeError(model.ErrorInternal, operation, event.ID, "encode event", err)
 		}
 	}
 	if err := next.Validate(); err != nil {
@@ -125,12 +206,13 @@ func (s *SQLiteStore) AppendTransactionEvents(
 	}
 	projectionJSON, err := json.Marshal(next)
 	if err != nil {
-		return transactionreducer.Projection{}, storeError(model.ErrorInternal, "append_transaction_events", current.Transaction.ID, "encode projection", err)
+		return transactionreducer.Projection{}, storeError(model.ErrorInternal, operation, current.Transaction.ID, "encode projection", err)
 	}
 	result, err := tx.ExecContext(ctx,
 		`UPDATE agent_transactions
 		 SET event_sequence = ?, last_event_digest = ?, projection_json = ?, updated_at = ?
-		 WHERE namespace = ? AND transaction_id = ? AND event_sequence = ?`,
+		 WHERE namespace = ? AND transaction_id = ?
+		   AND event_sequence = ? AND last_event_digest = ?`,
 		next.Transaction.EventSequence,
 		next.LastEventDigest,
 		projectionJSON,
@@ -138,16 +220,17 @@ func (s *SQLiteStore) AppendTransactionEvents(
 		namespace,
 		current.Transaction.ID,
 		expectedSequence,
+		current.LastEventDigest,
 	)
 	if err != nil {
-		return transactionreducer.Projection{}, classifyWriteError("append_transaction_events", current.Transaction.ID, err)
+		return transactionreducer.Projection{}, classifyWriteError(operation, current.Transaction.ID, err)
 	}
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return transactionreducer.Projection{}, storeError(model.ErrorInternal, "append_transaction_events", current.Transaction.ID, "read update result", err)
+		return transactionreducer.Projection{}, storeError(model.ErrorInternal, operation, current.Transaction.ID, "read update result", err)
 	}
 	if rows != 1 {
-		return transactionreducer.Projection{}, conflict("append_transaction_events", current.Transaction.ID, "transaction changed during append", nil)
+		return transactionreducer.Projection{}, conflict(operation, current.Transaction.ID, "transaction changed during append", nil)
 	}
 	for i, event := range events {
 		if err := insertTransactionEvent(ctx, tx, namespace, event, eventJSON[i]); err != nil {
@@ -155,9 +238,73 @@ func (s *SQLiteStore) AppendTransactionEvents(
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return transactionreducer.Projection{}, classifyWriteError("append_transaction_events", current.Transaction.ID, err)
+		return transactionreducer.Projection{}, classifyWriteError(operation, current.Transaction.ID, err)
 	}
 	return next, nil
+}
+
+func verifyAdmittedRunHead(
+	ctx context.Context,
+	tx *sql.Tx,
+	namespace string,
+	transaction transactionreducer.Projection,
+	expected expectedRunHead,
+	operation string,
+) error {
+	transactionID := transaction.Transaction.ID
+	var runID, lastDigest string
+	var sequence int64
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT a.run_id, r.event_sequence, r.last_event_digest
+		 FROM task_admissions AS a
+		 JOIN runs AS r
+		   ON r.namespace = a.namespace AND r.run_id = a.run_id
+		 WHERE a.namespace = ? AND a.transaction_id = ?`,
+		namespace,
+		transactionID,
+	).Scan(&runID, &sequence, &lastDigest)
+	if errors.Is(err, sql.ErrNoRows) {
+		return storeError(
+			model.ErrorNotFound,
+			operation,
+			transactionID,
+			"transaction has no admitted run in namespace",
+			err,
+		)
+	}
+	if err != nil {
+		return storeError(
+			model.ErrorInternal,
+			operation,
+			transactionID,
+			"query admitted run head",
+			err,
+		)
+	}
+	binding := transaction.Transaction.Admission
+	if binding == nil ||
+		binding.RunID != runID ||
+		!identifierPattern.MatchString(runID) ||
+		sequence < 1 ||
+		!digestPattern.MatchString(lastDigest) {
+		return storeError(
+			model.ErrorEventChain,
+			operation,
+			transactionID,
+			"admitted run binding or event head is invalid",
+			nil,
+		)
+	}
+	if sequence != expected.sequence || lastDigest != expected.digest {
+		return conflict(
+			operation,
+			runID,
+			"admitted run changed after execution authority was loaded",
+			nil,
+		)
+	}
+	return nil
 }
 
 func (s *SQLiteStore) GetTransaction(ctx context.Context, namespace, transactionID string) (transactionreducer.Projection, error) {
@@ -320,12 +467,14 @@ func loadTransactionProjection(
 	namespace, transactionID string,
 ) (transactionreducer.Projection, error) {
 	var data []byte
+	var sequence int64
 	var lastDigest string
 	err := query.QueryRowContext(ctx,
-		`SELECT projection_json, last_event_digest FROM agent_transactions WHERE namespace = ? AND transaction_id = ?`,
+		`SELECT projection_json, event_sequence, last_event_digest
+		 FROM agent_transactions WHERE namespace = ? AND transaction_id = ?`,
 		namespace,
 		transactionID,
-	).Scan(&data, &lastDigest)
+	).Scan(&data, &sequence, &lastDigest)
 	if errors.Is(err, sql.ErrNoRows) {
 		return transactionreducer.Projection{}, storeError(model.ErrorNotFound, "get_transaction", transactionID, "transaction not found in namespace", err)
 	}
@@ -339,8 +488,11 @@ func loadTransactionProjection(
 	if err := projection.Validate(); err != nil {
 		return transactionreducer.Projection{}, storeError(model.ErrorEventChain, "get_transaction", transactionID, "stored projection failed validation", err)
 	}
-	if projection.Transaction.Namespace != namespace || projection.Transaction.ID != transactionID || projection.LastEventDigest != lastDigest {
-		return transactionreducer.Projection{}, storeError(model.ErrorEventChain, "get_transaction", transactionID, "stored projection identity or digest is invalid", nil)
+	if projection.Transaction.Namespace != namespace ||
+		projection.Transaction.ID != transactionID ||
+		projection.Transaction.EventSequence != sequence ||
+		projection.LastEventDigest != lastDigest {
+		return transactionreducer.Projection{}, storeError(model.ErrorEventChain, "get_transaction", transactionID, "stored projection identity or event head is invalid", nil)
 	}
 	return projection, nil
 }

--- a/internal/vouch/cli.go
+++ b/internal/vouch/cli.go
@@ -39,6 +39,10 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 	switch rest[0] {
 	case "daemon":
 		return daemonCommand(absRepo, rest[1:], stdout, stderr)
+	case "runtime":
+		return runtimeCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "doctor":
+		return runtimeDoctorCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "run":
 		return runtimeRunCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "status":
@@ -554,6 +558,9 @@ func parseCommonArgs(args []string) (commonArgs, []string, error) {
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
+		case arg == "--":
+			rest = append(rest, args[i:]...)
+			return common, rest, nil
 		case arg == "--json":
 			common.json = true
 		case arg == "--repo" || arg == "--manifest":
@@ -868,6 +875,8 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "commands:")
 	fmt.Fprintln(out, "  daemon [--db FILE] [--socket FILE]")
+	fmt.Fprintln(out, "  runtime init --agent NAME --image IMAGE@sha256:DIGEST --source-digest sha256:DIGEST -- COMMAND [ARG...]")
+	fmt.Fprintln(out, "  doctor [--agent NAME] [--runtime-engine ENGINE] [--agent-profiles FILE] [--socket FILE]")
 	fmt.Fprintln(out, "  run (--intent TEXT | --intent-file FILE) (--agent NAME [-- AGENT_ARG...] | --image IMAGE -- COMMAND [ARG...])")
 	fmt.Fprintln(out, "  status ID [--namespace NS]")
 	fmt.Fprintln(out, "  approve ID [--namespace NS] --key FILE --key-id ID --approver ID --class CLASS")

--- a/internal/vouch/runtime_onboarding_cli.go
+++ b/internal/vouch/runtime_onboarding_cli.go
@@ -1,0 +1,751 @@
+package vouch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/duriantaco/vouch/internal/kernel/model"
+	"github.com/duriantaco/vouch/internal/kernel/sandbox"
+)
+
+const (
+	runtimeDoctorVersion = "vouch.runtime_doctor.v0"
+	runtimeInitVersion   = "vouch.runtime_init.v0"
+	runtimeIgnoreFile    = ".vouch/.gitignore"
+)
+
+var runtimeStateIgnore = []byte(`# Local Vouch Runtime state. Keep agent-profiles.json under version control.
+kernel.db
+kernel.db-shm
+kernel.db-wal
+kernel.db.lock
+vouchd.sock
+`)
+
+type runtimeInitResult struct {
+	Version           string `json:"version"`
+	Repository        string `json:"repository"`
+	AgentProfilesPath string `json:"agent_profiles_path"`
+	Agent             string `json:"agent"`
+	Image             string `json:"image"`
+	SourceDigest      string `json:"source_digest"`
+	ProfileCreated    bool   `json:"profile_created"`
+	IgnorePath        string `json:"ignore_path"`
+	IgnoreCreated     bool   `json:"ignore_created"`
+	IgnoreUpdated     bool   `json:"ignore_updated"`
+}
+
+type runtimeDoctorCheck struct {
+	Name    string `json:"name"`
+	Status  string `json:"status"`
+	Message string `json:"message"`
+}
+
+type runtimeDoctorResult struct {
+	Version string               `json:"version"`
+	Ready   bool                 `json:"ready"`
+	Checks  []runtimeDoctorCheck `json:"checks"`
+}
+
+type runtimeDoctorProbes struct {
+	gitRoot     func(context.Context, string) (string, error)
+	ociEngine   func(context.Context, string) (string, error)
+	ociImage    func(context.Context, string, string) error
+	daemonReady func(context.Context, string) error
+}
+
+func runtimeCommand(
+	repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+) int {
+	if len(args) == 0 {
+		runtimeUsage(stderr)
+		return 2
+	}
+	switch args[0] {
+	case "init":
+		return runtimeInitCommand(repo, args[1:], jsonOut, stdout, stderr)
+	case "doctor":
+		return runtimeDoctorCommand(repo, args[1:], jsonOut, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "runtime: unknown command %q\n", args[0])
+		runtimeUsage(stderr)
+		return 2
+	}
+}
+
+func runtimeUsage(out io.Writer) {
+	fmt.Fprintln(out, "usage: vouch [--repo DIR] [--json] runtime <command>")
+	fmt.Fprintln(out, "  runtime init --agent NAME --image IMAGE@sha256:DIGEST --source-digest sha256:DIGEST -- COMMAND [ARG...]")
+	fmt.Fprintln(out, "  runtime doctor [--agent NAME] [--runtime-engine ENGINE] [--agent-profiles FILE] [--socket FILE]")
+}
+
+func runtimeInitCommand(
+	repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+) int {
+	flags := flag.NewFlagSet("runtime init", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	agent := flags.String("agent", "", "stable name used by vouch run --agent")
+	image := flags.String("image", "", "complete digest-pinned OCI image reference")
+	sourceDigest := flags.String(
+		"source-digest", "",
+		"sha256 digest of the agent source",
+	)
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	command := flags.Args()
+	if *agent == "" || *image == "" || *sourceDigest == "" || len(command) == 0 {
+		fmt.Fprintln(
+			stderr,
+			"runtime init requires --agent, --image, --source-digest, and a command after --",
+		)
+		return 2
+	}
+	if !model.IsIdentifier(*agent) {
+		fmt.Fprintln(stderr, "runtime init: --agent must be a valid identifier")
+		return 2
+	}
+	imageDigest, err := sandbox.ImageDigest(*image)
+	if err != nil || !strings.Contains(*image, "@") {
+		fmt.Fprintln(
+			stderr,
+			"runtime init: --image must be a complete IMAGE@sha256:DIGEST reference",
+		)
+		return 2
+	}
+	if !model.IsSHA256Digest(*sourceDigest) {
+		fmt.Fprintln(stderr, "runtime init: --source-digest must be a lowercase sha256 digest")
+		return 2
+	}
+
+	root, err := discoverGitRoot(context.Background(), repo)
+	if err != nil {
+		fmt.Fprintf(stderr, "runtime init: %v\n", err)
+		return 1
+	}
+	sameRoot, err := sameFilesystemPath(root, repo)
+	if err != nil {
+		fmt.Fprintf(stderr, "runtime init: compare Git repository root: %v\n", err)
+		return 1
+	}
+	if !sameRoot {
+		fmt.Fprintf(
+			stderr,
+			"runtime init: --repo must be the Git repository root (%s)\n",
+			root,
+		)
+		return 1
+	}
+
+	profile := agentProfileEntry{
+		Name:     *agent,
+		OCIImage: *image,
+		Descriptor: model.AgentImage{
+			Version: model.AgentImageVersion,
+			ID:      "image." + *agent + ".v1",
+			Digest:  imageDigest,
+			Runtime: model.AgentRuntime{
+				Adapter:        "oci",
+				AdapterVersion: "v1",
+				Entrypoint:     append([]string(nil), command...),
+			},
+			SourceDigest: *sourceDigest,
+			Publisher: model.Principal{
+				ID:   "service:local-runtime-init",
+				Kind: model.PrincipalService,
+			},
+		},
+	}
+	document := agentProfileDocument{
+		Version: agentProfilesVersion,
+		Profiles: []agentProfileEntry{
+			profile,
+		},
+	}
+	if err := validateAgentProfileDocument(document); err != nil {
+		fmt.Fprintf(stderr, "runtime init: invalid agent profile: %v\n", err)
+		return 2
+	}
+
+	result, err := writeRuntimeInitialization(
+		repo, document, *agent, *image, *sourceDigest,
+	)
+	if err != nil {
+		fmt.Fprintf(stderr, "runtime init: %v\n", err)
+		return 1
+	}
+	if jsonOut {
+		return renderCommandJSON(result, stdout, stderr)
+	}
+	if result.ProfileCreated {
+		fmt.Fprintf(stdout, "Initialized Vouch Runtime in %s\n", result.Repository)
+	} else {
+		fmt.Fprintf(stdout, "Vouch Runtime already initialized in %s; profile left unchanged.\n", result.Repository)
+	}
+	fmt.Fprintf(stdout, "Agent profile: %s (%s)\n", result.Agent, result.AgentProfilesPath)
+	if result.IgnoreCreated {
+		fmt.Fprintf(stdout, "Runtime state ignore: %s\n", result.IgnorePath)
+	} else if result.IgnoreUpdated {
+		fmt.Fprintf(stdout, "Added missing Runtime state rules to %s\n", result.IgnorePath)
+	} else {
+		fmt.Fprintf(stdout, "Runtime state ignore is complete: %s\n", result.IgnorePath)
+	}
+	fmt.Fprintf(stdout, "Next: vouch --repo %s doctor\n", result.Repository)
+	return 0
+}
+
+func writeRuntimeInitialization(
+	repo string,
+	document agentProfileDocument,
+	agent, image, sourceDigest string,
+) (runtimeInitResult, error) {
+	vouchDirectory := filepath.Join(repo, ".vouch")
+	info, err := os.Lstat(vouchDirectory)
+	switch {
+	case err == nil:
+		if !info.IsDir() || info.Mode()&os.ModeSymlink != 0 {
+			return runtimeInitResult{}, errors.New(".vouch must be a real directory")
+		}
+	case os.IsNotExist(err):
+		if err := os.Mkdir(vouchDirectory, 0o700); err != nil {
+			return runtimeInitResult{}, fmt.Errorf("create .vouch directory: %w", err)
+		}
+	default:
+		return runtimeInitResult{}, fmt.Errorf("inspect .vouch directory: %w", err)
+	}
+
+	profilesPath := filepath.Join(repo, defaultAgentProfiles)
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return runtimeInitResult{}, fmt.Errorf("encode agent profiles: %w", err)
+	}
+	data = append(data, '\n')
+	profileCreated := false
+	if info, err := os.Lstat(profilesPath); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			return runtimeInitResult{}, fmt.Errorf(
+				"%s exists but is not a regular file",
+				defaultAgentProfiles,
+			)
+		}
+		existingData, err := readAgentProfilesFile(profilesPath)
+		if err != nil {
+			return runtimeInitResult{}, err
+		}
+		existing, err := decodeAgentProfileDocument(existingData)
+		if err != nil || !reflect.DeepEqual(existing, document) {
+			return runtimeInitResult{}, fmt.Errorf(
+				"%s already exists with different content; refusing to overwrite it",
+				defaultAgentProfiles,
+			)
+		}
+	} else if os.IsNotExist(err) {
+		if err := writeExclusiveRegularFile(profilesPath, data, 0o600); err != nil {
+			return runtimeInitResult{}, fmt.Errorf("create %s: %w", defaultAgentProfiles, err)
+		}
+		profileCreated = true
+	} else {
+		return runtimeInitResult{}, fmt.Errorf("inspect %s: %w", defaultAgentProfiles, err)
+	}
+
+	ignorePath := filepath.Join(repo, runtimeIgnoreFile)
+	ignoreCreated := false
+	ignoreUpdated := false
+	if info, err := os.Lstat(ignorePath); err == nil {
+		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
+			if profileCreated {
+				_ = os.Remove(profilesPath)
+			}
+			return runtimeInitResult{}, fmt.Errorf(
+				"%s exists but is not a regular file",
+				runtimeIgnoreFile,
+			)
+		}
+		existing, err := os.ReadFile(ignorePath)
+		if err != nil {
+			if profileCreated {
+				_ = os.Remove(profilesPath)
+			}
+			return runtimeInitResult{}, fmt.Errorf("read %s: %w", runtimeIgnoreFile, err)
+		}
+		missing := missingRuntimeIgnoreEntries(existing)
+		if len(missing) > 0 {
+			if err := appendRuntimeIgnoreEntries(ignorePath, existing, missing); err != nil {
+				if profileCreated {
+					_ = os.Remove(profilesPath)
+				}
+				return runtimeInitResult{}, fmt.Errorf("update %s: %w", runtimeIgnoreFile, err)
+			}
+			ignoreUpdated = true
+		}
+	} else if os.IsNotExist(err) {
+		if err := writeExclusiveRegularFile(ignorePath, runtimeStateIgnore, 0o600); err != nil {
+			if profileCreated {
+				_ = os.Remove(profilesPath)
+			}
+			return runtimeInitResult{}, fmt.Errorf("create %s: %w", runtimeIgnoreFile, err)
+		}
+		ignoreCreated = true
+	} else {
+		if profileCreated {
+			_ = os.Remove(profilesPath)
+		}
+		return runtimeInitResult{}, fmt.Errorf("inspect %s: %w", runtimeIgnoreFile, err)
+	}
+
+	return runtimeInitResult{
+		Version:           runtimeInitVersion,
+		Repository:        repo,
+		AgentProfilesPath: profilesPath,
+		Agent:             agent,
+		Image:             image,
+		SourceDigest:      sourceDigest,
+		ProfileCreated:    profileCreated,
+		IgnorePath:        ignorePath,
+		IgnoreCreated:     ignoreCreated,
+		IgnoreUpdated:     ignoreUpdated,
+	}, nil
+}
+
+func missingRuntimeIgnoreEntries(data []byte) []string {
+	lines := make(map[string]struct{})
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "#") {
+			lines[line] = struct{}{}
+		}
+	}
+	var missing []string
+	for _, entry := range []string{
+		"kernel.db", "kernel.db-shm", "kernel.db-wal", "kernel.db.lock", "vouchd.sock",
+	} {
+		if _, exists := lines[entry]; exists {
+			continue
+		}
+		if _, exists := lines["/"+entry]; exists {
+			continue
+		}
+		missing = append(missing, entry)
+	}
+	return missing
+}
+
+func appendRuntimeIgnoreEntries(path string, existing []byte, missing []string) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	var addition strings.Builder
+	if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+		addition.WriteByte('\n')
+	}
+	addition.WriteString("# Local Vouch Runtime state.\n")
+	for _, entry := range missing {
+		addition.WriteString(entry)
+		addition.WriteByte('\n')
+	}
+	if _, err := io.WriteString(file, addition.String()); err != nil {
+		return err
+	}
+	return file.Sync()
+}
+
+func writeExclusiveRegularFile(path string, data []byte, mode os.FileMode) error {
+	file, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_EXCL, mode)
+	if err != nil {
+		return err
+	}
+	remove := true
+	defer func() {
+		_ = file.Close()
+		if remove {
+			_ = os.Remove(path)
+		}
+	}()
+	if _, err := file.Write(data); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	remove = false
+	return nil
+}
+
+func runtimeDoctorCommand(
+	repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+) int {
+	return runtimeDoctorCommandWithProbes(
+		repo, args, jsonOut, stdout, stderr, runtimeDoctorProbes{},
+	)
+}
+
+func runtimeDoctorCommandWithProbes(
+	repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+	probes runtimeDoctorProbes,
+) int {
+	flags := flag.NewFlagSet("doctor", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	engine := flags.String("runtime-engine", "docker", "OCI engine executable")
+	agent := flags.String("agent", "", "agent profile that must be executable")
+	profilesPath := flags.String(
+		"agent-profiles", defaultAgentProfiles,
+		"agent profile document",
+	)
+	socketPath := flags.String("socket", defaultKernelSocket(repo), "vouchd Unix socket")
+	timeout := flags.Duration("timeout", 5*time.Second, "timeout for each external readiness check")
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintf(stderr, "doctor: unexpected argument %q\n", flags.Arg(0))
+		return 2
+	}
+	if strings.TrimSpace(*engine) == "" {
+		fmt.Fprintln(stderr, "doctor: --runtime-engine cannot be empty")
+		return 2
+	}
+	if *agent != "" && !model.IsIdentifier(*agent) {
+		fmt.Fprintln(stderr, "doctor: --agent must be a valid identifier")
+		return 2
+	}
+	if *timeout <= 0 || *timeout > time.Minute {
+		fmt.Fprintln(stderr, "doctor: --timeout must be greater than zero and at most 1m")
+		return 2
+	}
+	if !filepath.IsAbs(*profilesPath) {
+		*profilesPath = filepath.Join(repo, *profilesPath)
+	}
+	if !filepath.IsAbs(*socketPath) {
+		*socketPath = filepath.Join(repo, *socketPath)
+	}
+	probes = withDefaultRuntimeDoctorProbes(probes)
+	result := runRuntimeDoctor(
+		repo, *engine, *agent, *profilesPath, *socketPath, *timeout, probes,
+	)
+	if jsonOut {
+		if code := renderCommandJSON(result, stdout, stderr); code != 0 {
+			return code
+		}
+	} else {
+		fmt.Fprintln(stdout, "Vouch Runtime doctor")
+		for _, check := range result.Checks {
+			fmt.Fprintf(
+				stdout, "[%s] %s: %s\n",
+				strings.ToUpper(check.Status), check.Name, check.Message,
+			)
+		}
+		if result.Ready {
+			fmt.Fprintln(stdout, "Ready: required local Runtime checks passed.")
+		} else {
+			fmt.Fprintln(stdout, "Not ready: fix the failed checks above.")
+		}
+	}
+	if !result.Ready {
+		return 1
+	}
+	return 0
+}
+
+func withDefaultRuntimeDoctorProbes(probes runtimeDoctorProbes) runtimeDoctorProbes {
+	if probes.gitRoot == nil {
+		probes.gitRoot = discoverGitRoot
+	}
+	if probes.ociEngine == nil {
+		probes.ociEngine = probeOCIEngine
+	}
+	if probes.ociImage == nil {
+		probes.ociImage = probeOCIImage
+	}
+	if probes.daemonReady == nil {
+		probes.daemonReady = probeDaemonReadiness
+	}
+	return probes
+}
+
+func runRuntimeDoctor(
+	repo, engine, selectedAgent, profilesPath, socketPath string,
+	timeout time.Duration,
+	probes runtimeDoctorProbes,
+) runtimeDoctorResult {
+	result := runtimeDoctorResult{Version: runtimeDoctorVersion, Ready: true}
+	add := func(name, status, message string) {
+		result.Checks = append(result.Checks, runtimeDoctorCheck{
+			Name: name, Status: status, Message: message,
+		})
+		if status == "fail" {
+			result.Ready = false
+		}
+	}
+	probeContext := func() (context.Context, context.CancelFunc) {
+		return context.WithTimeout(context.Background(), timeout)
+	}
+
+	ctx, cancel := probeContext()
+	root, err := probes.gitRoot(ctx, repo)
+	cancel()
+	if err != nil {
+		add("git_repository", "fail", err.Error())
+	} else {
+		sameRoot, compareErr := sameFilesystemPath(root, repo)
+		switch {
+		case compareErr != nil:
+			add("git_repository", "fail", "compare Git repository root: "+compareErr.Error())
+		case !sameRoot:
+			add("git_repository", "fail", "--repo must be the Git repository root: "+root)
+		default:
+			add("git_repository", "pass", "Git worktree detected at "+root)
+		}
+	}
+
+	ctx, cancel = probeContext()
+	enginePath, engineErr := probes.ociEngine(ctx, engine)
+	cancel()
+	if engineErr != nil {
+		add("oci_engine", "fail", engineErr.Error())
+	} else {
+		add("oci_engine", "pass", engine+" is available and reachable at "+enginePath)
+	}
+
+	var profiles agentProfileDocument
+	profilesValid := false
+	data, profileErr := readAgentProfilesFile(profilesPath)
+	if profileErr == nil {
+		profiles, profileErr = decodeAgentProfileDocument(data)
+	}
+	switch {
+	case profileErr == nil:
+		profilesValid = true
+		add(
+			"agent_profiles", "pass",
+			fmt.Sprintf("%d valid profile(s) in %s", len(profiles.Profiles), profilesPath),
+		)
+	case os.IsNotExist(profileRootCause(profileErr)):
+		add(
+			"agent_profiles", "warn",
+			"not configured; create it with `vouch runtime init`",
+		)
+	default:
+		add("agent_profiles", "fail", profileErr.Error())
+	}
+
+	switch {
+	case !profilesValid:
+		if selectedAgent == "" {
+			add("agent_images", "warn", "not checked because agent profiles are unavailable")
+		} else {
+			add(
+				"agent_images", "fail",
+				fmt.Sprintf("agent profile %q cannot be checked because profiles are unavailable", selectedAgent),
+			)
+		}
+	case engineErr != nil:
+		add("agent_images", "warn", "not checked because the OCI engine is unavailable")
+	default:
+		profileImages := profileImagesByName(profiles)
+		selectedImage, selectedExists := profileImages[selectedAgent]
+		switch {
+		case selectedAgent == "":
+			add(
+				"agent_images", "warn",
+				"not checked; pass --agent NAME to verify one pull=never image",
+			)
+		case !selectedExists:
+			add(
+				"agent_images", "fail",
+				fmt.Sprintf("agent profile %q was not found in %s", selectedAgent, profilesPath),
+			)
+		default:
+			ctx, cancel = probeContext()
+			err := probes.ociImage(ctx, enginePath, selectedImage)
+			cancel()
+			if err != nil {
+				add(
+					"agent_images", "fail",
+					fmt.Sprintf(
+						"selected agent %q image is not present locally: %s; Vouch executes with pull=never",
+						selectedAgent, selectedImage,
+					),
+				)
+			} else {
+				add(
+					"agent_images", "pass",
+					fmt.Sprintf("selected agent %q image is present locally", selectedAgent),
+				)
+			}
+		}
+	}
+
+	socketInfo, socketErr := os.Lstat(socketPath)
+	switch {
+	case os.IsNotExist(socketErr):
+		add(
+			"daemon", "warn",
+			"not running; start it with `vouch daemon` when you are ready to execute",
+		)
+	case socketErr != nil:
+		add("daemon", "fail", "inspect daemon socket: "+socketErr.Error())
+	case socketInfo.Mode()&os.ModeSymlink != 0 || socketInfo.Mode()&os.ModeSocket == 0:
+		add("daemon", "fail", "daemon path exists but is not a real Unix socket: "+socketPath)
+	case socketInfo.Mode().Perm()&0o077 != 0:
+		add("daemon", "fail", "daemon socket permissions must not grant group or other access: "+socketPath)
+	default:
+		ctx, cancel = probeContext()
+		err := probes.daemonReady(ctx, socketPath)
+		cancel()
+		if err != nil {
+			add("daemon", "fail", err.Error())
+		} else {
+			add("daemon", "pass", "vouchd is ready at "+socketPath)
+		}
+	}
+	return result
+}
+
+func profileRootCause(err error) error {
+	for {
+		next := errors.Unwrap(err)
+		if next == nil {
+			return err
+		}
+		err = next
+	}
+}
+
+func profileImagesByName(document agentProfileDocument) map[string]string {
+	images := make(map[string]string, len(document.Profiles))
+	for _, profile := range document.Profiles {
+		images[profile.Name] = profile.OCIImage
+	}
+	return images
+}
+
+func discoverGitRoot(ctx context.Context, repo string) (string, error) {
+	gitPath, err := exec.LookPath("git")
+	if err != nil {
+		return "", fmt.Errorf("find Git executable: %w", err)
+	}
+	command := exec.CommandContext(ctx, gitPath, "-C", repo, "rev-parse", "--show-toplevel")
+	output, err := command.Output()
+	if err != nil {
+		return "", fmt.Errorf("%s is not a Git worktree", repo)
+	}
+	root := strings.TrimSpace(string(output))
+	if root == "" {
+		return "", fmt.Errorf("%s is not a Git worktree", repo)
+	}
+	command = exec.CommandContext(ctx, gitPath, "-C", repo, "rev-parse", "--verify", "HEAD^{commit}")
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	if err := command.Run(); err != nil {
+		return "", fmt.Errorf("%s does not have a HEAD commit", repo)
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve Git root: %w", err)
+	}
+	return absolute, nil
+}
+
+func sameFilesystemPath(left, right string) (bool, error) {
+	leftResolved, err := filepath.EvalSymlinks(left)
+	if err != nil {
+		return false, err
+	}
+	rightResolved, err := filepath.EvalSymlinks(right)
+	if err != nil {
+		return false, err
+	}
+	return filepath.Clean(leftResolved) == filepath.Clean(rightResolved), nil
+}
+
+func probeOCIEngine(ctx context.Context, engine string) (string, error) {
+	path, err := exec.LookPath(engine)
+	if err != nil {
+		return "", fmt.Errorf("find OCI engine %q: %w", engine, err)
+	}
+	command := exec.CommandContext(ctx, path, "info", "--format", "{{.ServerVersion}}")
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	if err := command.Run(); err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return "", fmt.Errorf("OCI engine %q readiness timed out", engine)
+		}
+		return "", fmt.Errorf("OCI engine %q is installed but unreachable: %w", engine, err)
+	}
+	return path, nil
+}
+
+func probeOCIImage(ctx context.Context, enginePath, image string) error {
+	command := exec.CommandContext(
+		ctx, enginePath, "image", "inspect", "--format", "{{.Id}}", image,
+	)
+	command.Stdout = io.Discard
+	command.Stderr = io.Discard
+	return command.Run()
+}
+
+func probeDaemonReadiness(ctx context.Context, socketPath string) error {
+	dialer := &net.Dialer{}
+	transport := &http.Transport{
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			return dialer.DialContext(ctx, "unix", socketPath)
+		},
+	}
+	defer transport.CloseIdleConnections()
+	client := &http.Client{Transport: transport}
+	request, err := http.NewRequestWithContext(
+		ctx, http.MethodGet, "http://vouchd/readyz", nil,
+	)
+	if err != nil {
+		return fmt.Errorf("build vouchd readiness request: %w", err)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("vouchd socket exists but readiness failed: %w", err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("vouchd is not ready: %s", response.Status)
+	}
+	var body struct {
+		Status string `json:"status"`
+	}
+	decoder := json.NewDecoder(io.LimitReader(response.Body, 4097))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&body); err != nil {
+		return fmt.Errorf("decode vouchd readiness response: %w", err)
+	}
+	if body.Status != "ready" {
+		return fmt.Errorf("vouchd returned unexpected readiness status %q", body.Status)
+	}
+	return nil
+}

--- a/internal/vouch/runtime_onboarding_cli_test.go
+++ b/internal/vouch/runtime_onboarding_cli_test.go
@@ -1,0 +1,313 @@
+package vouch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRuntimeInitCreatesStrictProfileAndIsIdempotent(t *testing.T) {
+	repo := runtimeGitRepoForTest(t)
+	args := runtimeInitArgsForTest(
+		repo, "/opt/agent", "run", "--repo", "/agent/workspace", "--json",
+	)
+	var stdout, stderr bytes.Buffer
+	if code := Main(args, &stdout, &stderr); code != 0 {
+		t.Fatalf("runtime init code=%d stderr=%s", code, stderr.String())
+	}
+
+	profilesPath := filepath.Join(repo, defaultAgentProfiles)
+	data, err := readAgentProfilesFile(profilesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := decodeAgentProfileDocument(data)
+	if err != nil {
+		t.Fatalf("generated profile is not strict and valid: %v", err)
+	}
+	if len(document.Profiles) != 1 ||
+		document.Profiles[0].Name != "coding-agent" ||
+		strings.Join(document.Profiles[0].Descriptor.Runtime.Entrypoint, " ") !=
+			"/opt/agent run --repo /agent/workspace --json" {
+		t.Fatalf("unexpected generated profile: %#v", document)
+	}
+	original := append([]byte(nil), data...)
+	ignore, err := os.ReadFile(filepath.Join(repo, runtimeIgnoreFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, entry := range []string{"kernel.db\n", "kernel.db-shm\n", "kernel.db-wal\n", "kernel.db.lock\n", "vouchd.sock\n"} {
+		if !bytes.Contains(ignore, []byte(entry)) {
+			t.Fatalf("runtime ignore is missing %q: %s", entry, ignore)
+		}
+	}
+	if bytes.Contains(ignore, []byte("agent-profiles.json\n")) {
+		t.Fatal("runtime ignore hides the repo-owned agent profile")
+	}
+	originalIgnore := append([]byte(nil), ignore...)
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main(args, &stdout, &stderr); code != 0 ||
+		!strings.Contains(stdout.String(), "already initialized") {
+		t.Fatalf("identical init was not idempotent: code=%d stderr=%s", code, stderr.String())
+	}
+	after, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(original, after) {
+		t.Fatal("identical init rewrote the profile")
+	}
+	afterIgnore, err := os.ReadFile(filepath.Join(repo, runtimeIgnoreFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(originalIgnore, afterIgnore) {
+		t.Fatal("identical init rewrote the complete Runtime ignore")
+	}
+
+	different := runtimeInitArgsForTest(repo, "/opt/agent", "different")
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main(different, &stdout, &stderr); code != 1 ||
+		!strings.Contains(stderr.String(), "different content") {
+		t.Fatalf("different init was not refused: code=%d stderr=%s", code, stderr.String())
+	}
+
+	mergeRepo := runtimeGitRepoForTest(t)
+	if err := os.Mkdir(filepath.Join(mergeRepo, ".vouch"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	mergeIgnore := filepath.Join(mergeRepo, runtimeIgnoreFile)
+	if err := os.WriteFile(mergeIgnore, []byte("custom-entry\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main(runtimeInitArgsForTest(mergeRepo, "/opt/agent"), &stdout, &stderr); code != 0 {
+		t.Fatalf("init did not merge Runtime ignore rules: code=%d stderr=%s", code, stderr.String())
+	}
+	merged, err := os.ReadFile(mergeIgnore)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Contains(merged, []byte("custom-entry\n")) ||
+		len(missingRuntimeIgnoreEntries(merged)) != 0 {
+		t.Fatalf("existing Runtime ignore content was not safely completed: %s", merged)
+	}
+}
+
+func TestRuntimeInitPreservesContractsInitAndRefusesSymlink(t *testing.T) {
+	repo := runtimeGitRepoForTest(t)
+	var stdout, stderr bytes.Buffer
+	if code := Main(
+		[]string{"--repo", repo, "init", "--profile", "generic"},
+		&stdout, &stderr,
+	); code != 0 {
+		t.Fatalf("legacy Contracts init failed: code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(repo, ".vouch", "config.json")); err != nil {
+		t.Fatalf("legacy Contracts config is missing: %v", err)
+	}
+
+	target := filepath.Join(t.TempDir(), "profiles.json")
+	if err := os.WriteFile(target, []byte("unchanged"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, filepath.Join(repo, defaultAgentProfiles)); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main(runtimeInitArgsForTest(repo, "/opt/agent"), &stdout, &stderr); code != 1 ||
+		!strings.Contains(stderr.String(), "not a regular file") {
+		t.Fatalf("symlink profile was not refused: code=%d stderr=%s", code, stderr.String())
+	}
+	data, err := os.ReadFile(target)
+	if err != nil || string(data) != "unchanged" {
+		t.Fatalf("symlink target changed: data=%q err=%v", data, err)
+	}
+}
+
+func TestRuntimeDoctorDistinguishesWarningsFailuresAndSelectedImages(t *testing.T) {
+	repo := runtimeGitRepoForTest(t)
+	first := validAgentProfileForTest()
+	second := validAgentProfileForTest()
+	second.Name = "other-agent"
+	second.OCIImage = "registry.example.invalid/other@" +
+		"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	second.Descriptor.ID = "image.other-agent.v1"
+	second.Descriptor.Digest = "sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	second.Descriptor.SourceDigest = "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	profilesPath := writeAgentProfilesForTest(t, repo, first, second)
+
+	probes := runtimeDoctorProbes{
+		gitRoot: func(context.Context, string) (string, error) { return repo, nil },
+		ociEngine: func(context.Context, string) (string, error) {
+			return "/fake/docker", nil
+		},
+		ociImage: func(_ context.Context, _ string, image string) error {
+			if image == second.OCIImage {
+				return errors.New("not found")
+			}
+			return nil
+		},
+		daemonReady: func(context.Context, string) error {
+			t.Fatal("missing daemon socket should not be probed")
+			return nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runtimeDoctorCommandWithProbes(
+		repo,
+		[]string{"--agent", first.Name, "--agent-profiles", profilesPath},
+		true,
+		&stdout, &stderr, probes,
+	)
+	if code != 0 {
+		t.Fatalf("selected available image should pass: code=%d stderr=%s", code, stderr.String())
+	}
+	var result runtimeDoctorResult
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if !result.Ready ||
+		doctorCheckStatusForTest(result, "agent_images") != "pass" ||
+		doctorCheckStatusForTest(result, "daemon") != "warn" {
+		t.Fatalf("unexpected warning result: %#v", result)
+	}
+
+	mismatchedRoot := probes
+	mismatchedRoot.gitRoot = func(context.Context, string) (string, error) {
+		return filepath.Dir(repo), nil
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = runtimeDoctorCommandWithProbes(
+		repo,
+		[]string{"--agent", first.Name, "--agent-profiles", profilesPath},
+		true,
+		&stdout, &stderr, mismatchedRoot,
+	)
+	if code != 1 {
+		t.Fatalf("non-root --repo did not fail doctor: code=%d", code)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code = runtimeDoctorCommandWithProbes(
+		repo,
+		[]string{"--agent", second.Name, "--agent-profiles", profilesPath},
+		true,
+		&stdout, &stderr, probes,
+	)
+	if code != 1 {
+		t.Fatalf("selected missing image did not fail: code=%d", code)
+	}
+
+	if err := os.WriteFile(profilesPath, []byte(`{"version":"vouch.agent_profiles.v0","profiles":[]}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = runtimeDoctorCommandWithProbes(
+		repo, []string{"--agent-profiles", profilesPath}, true,
+		&stdout, &stderr, probes,
+	)
+	if code != 1 {
+		t.Fatalf("invalid existing profiles did not fail: code=%d", code)
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if doctorCheckStatusForTest(result, "agent_profiles") != "fail" {
+		t.Fatalf("invalid profile result: %#v", result)
+	}
+}
+
+func TestCommonArgumentsStopAtAgentCommandSeparator(t *testing.T) {
+	for _, args := range [][]string{
+		{
+			"--repo", "/real/repo", "runtime", "init",
+			"--agent", "coding-agent", "--",
+			"/opt/agent", "--repo", "/agent/workspace", "--json",
+		},
+		{
+			"--repo", "/real/repo", "run",
+			"--intent", "fix auth", "--image", "image@sha256:digest", "--",
+			"/opt/agent", "--manifest", "/agent/manifest", "--json=false",
+		},
+	} {
+		common, rest, err := parseCommonArgs(args)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if common.repo != "/real/repo" || common.json || common.manifest != "" {
+			t.Fatalf("agent arguments mutated common options: %#v", common)
+		}
+		separator := -1
+		for index, value := range rest {
+			if value == "--" {
+				separator = index
+				break
+			}
+		}
+		if separator < 0 || separator+1 >= len(rest) {
+			t.Fatalf("command separator or agent command was lost: %q", rest)
+		}
+		joined := strings.Join(rest[separator+1:], "\x00")
+		for _, expected := range []string{"/opt/agent", "--json"} {
+			if !strings.Contains(joined, expected) {
+				t.Fatalf("agent argument %q was lost from %q", expected, rest)
+			}
+		}
+	}
+}
+
+func runtimeGitRepoForTest(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	command := exec.Command("git", "-C", repo, "init", "--quiet")
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v: %s", err, output)
+	}
+	command = exec.Command(
+		"git", "-C", repo,
+		"-c", "user.name=Vouch Test",
+		"-c", "user.email=vouch-test@example.invalid",
+		"commit", "--allow-empty", "--quiet", "-m", "initial",
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v: %s", err, output)
+	}
+	return repo
+}
+
+func runtimeInitArgsForTest(repo string, command ...string) []string {
+	args := []string{
+		"--repo", repo,
+		"runtime", "init",
+		"--agent", "coding-agent",
+		"--image", "registry.example.invalid/coding-agent@" + testAgentImageDigest,
+		"--source-digest", testAgentSourceDigest,
+		"--",
+	}
+	return append(args, command...)
+}
+
+func doctorCheckStatusForTest(result runtimeDoctorResult, name string) string {
+	for _, check := range result.Checks {
+		if check.Name == name {
+			return check.Status
+		}
+	}
+	return ""
+}

--- a/internal/vouch/transaction_cli.go
+++ b/internal/vouch/transaction_cli.go
@@ -29,7 +29,7 @@ type transactionClient interface {
 	CreateTransactionWorktree(context.Context, string, string, int64, string, model.Principal) (kernelclient.TransactionWorktreeResult, error)
 	StartAgentExecution(context.Context, string, string, int64, string, string, string, string, string, string, model.Principal) (transactionreducer.Projection, error)
 	FinishAgentExecution(context.Context, string, string, int64, string, model.AgentExecutionStatus, *int, string, string, model.Principal) (transactionreducer.Projection, error)
-	RunTransactionAgent(context.Context, string, string, int64, string, string, []string, int64, model.Principal) (kernelclient.TransactionAgentRunResult, error)
+	RunTransactionAgent(context.Context, string, string, int64, string, []string, int64, model.Principal) (kernelclient.TransactionAgentRunResult, error)
 	StageTransaction(context.Context, string, string, int64, model.Principal) (kernelclient.TransactionStageResult, error)
 	ValidateTransaction(context.Context, string, string, int64, model.Principal) (kernelclient.TransactionValidationResult, error)
 	RecordTransactionVerification(context.Context, string, string, int64, string, model.VerificationStatus, string, string, string, []model.ArtifactRef, string, model.Principal) (kernelclient.TransactionVerificationRecordResult, error)

--- a/internal/vouch/transaction_profile_cli.go
+++ b/internal/vouch/transaction_profile_cli.go
@@ -61,40 +61,13 @@ func resolveNamedAgentProfile(
 	if err != nil {
 		return resolvedAgentProfile{}, err
 	}
-	document, err := model.DecodeStrict[agentProfileDocument](data)
+	document, err := decodeAgentProfileDocument(data)
 	if err != nil {
-		return resolvedAgentProfile{}, fmt.Errorf("decode agent profiles: %w", err)
+		return resolvedAgentProfile{}, err
 	}
-	if document.Version != agentProfilesVersion {
-		return resolvedAgentProfile{}, fmt.Errorf(
-			"agent profiles version must be %q", agentProfilesVersion,
-		)
-	}
-	if len(document.Profiles) == 0 || len(document.Profiles) > maxAgentProfiles {
-		return resolvedAgentProfile{}, fmt.Errorf(
-			"agent profiles must contain between 1 and %d profiles", maxAgentProfiles,
-		)
-	}
-	seen := make(map[string]struct{}, len(document.Profiles))
 	var selected *agentProfileEntry
 	for index := range document.Profiles {
 		profile := &document.Profiles[index]
-		if !model.IsIdentifier(profile.Name) {
-			return resolvedAgentProfile{}, fmt.Errorf(
-				"agent profile %d has an invalid name", index,
-			)
-		}
-		if _, exists := seen[profile.Name]; exists {
-			return resolvedAgentProfile{}, fmt.Errorf(
-				"agent profile name %q is duplicated", profile.Name,
-			)
-		}
-		seen[profile.Name] = struct{}{}
-		if err := validateAgentProfile(*profile); err != nil {
-			return resolvedAgentProfile{}, fmt.Errorf(
-				"agent profile %q: %w", profile.Name, err,
-			)
-		}
 		if profile.Name == name {
 			selected = profile
 		}
@@ -123,6 +96,42 @@ func resolveNamedAgentProfile(
 		Entrypoint:   selected.Descriptor.Runtime.Entrypoint[0],
 		Command:      command,
 	}, nil
+}
+
+func decodeAgentProfileDocument(data []byte) (agentProfileDocument, error) {
+	document, err := model.DecodeStrict[agentProfileDocument](data)
+	if err != nil {
+		return agentProfileDocument{}, fmt.Errorf("decode agent profiles: %w", err)
+	}
+	if err := validateAgentProfileDocument(document); err != nil {
+		return agentProfileDocument{}, err
+	}
+	return document, nil
+}
+
+func validateAgentProfileDocument(document agentProfileDocument) error {
+	if document.Version != agentProfilesVersion {
+		return fmt.Errorf("agent profiles version must be %q", agentProfilesVersion)
+	}
+	if len(document.Profiles) == 0 || len(document.Profiles) > maxAgentProfiles {
+		return fmt.Errorf(
+			"agent profiles must contain between 1 and %d profiles", maxAgentProfiles,
+		)
+	}
+	seen := make(map[string]struct{}, len(document.Profiles))
+	for index, profile := range document.Profiles {
+		if !model.IsIdentifier(profile.Name) {
+			return fmt.Errorf("agent profile %d has an invalid name", index)
+		}
+		if _, exists := seen[profile.Name]; exists {
+			return fmt.Errorf("agent profile name %q is duplicated", profile.Name)
+		}
+		seen[profile.Name] = struct{}{}
+		if err := validateAgentProfile(profile); err != nil {
+			return fmt.Errorf("agent profile %q: %w", profile.Name, err)
+		}
+	}
+	return nil
 }
 
 func validateAgentProfile(profile agentProfileEntry) error {

--- a/internal/vouch/transaction_run_cli.go
+++ b/internal/vouch/transaction_run_cli.go
@@ -122,6 +122,11 @@ func transactionRunNamed(
 	runID := flags.String("run", "", "participating agent run ID; generated when omitted")
 	revision := flags.String("revision", "HEAD", "base Git revision")
 	timeout := flags.Duration("timeout", 30*time.Minute, "maximum agent execution duration")
+	modelProvider := flags.String(
+		"model-provider",
+		"",
+		"allow model egress only through the daemon broker for this provider",
+	)
 	runtimeClass := flags.String("runtime", "oci", "execution runtime: oci or host")
 	image := flags.String("image", "", "digest-pinned OCI image")
 	agent := flags.String("agent", "", "named agent profile from the strict repo profile document")
@@ -140,6 +145,14 @@ func transactionRunNamed(
 	}
 	if *runtimeClass != "oci" && *runtimeClass != "host" {
 		fmt.Fprintf(stderr, "%s --runtime must be oci or host\n", commandName)
+		return 2
+	}
+	if *modelProvider != "" && !model.IsIdentifier(*modelProvider) {
+		fmt.Fprintf(stderr, "%s --model-provider must be an identifier\n", commandName)
+		return 2
+	}
+	if *modelProvider != "" && *runtimeClass != "oci" {
+		fmt.Fprintf(stderr, "%s --model-provider requires --runtime oci\n", commandName)
 		return 2
 	}
 	if *agent == "" && len(command) == 0 {
@@ -218,6 +231,27 @@ func transactionRunNamed(
 		return 1
 	}
 	maxWallTimeSeconds := int64(*timeout / time.Second)
+	resources := []model.ContractResource{{
+		ID: "workspace",
+		Selector: model.ResourceSelector{
+			Kind:    "filesystem",
+			Pattern: "workspace/**",
+		},
+		Operations: []string{"filesystem.read", "filesystem.write"},
+		Conditions: model.CapabilityConditions{
+			WorkspaceRoot: "workspace",
+		},
+	}}
+	if *modelProvider != "" {
+		resources = append(resources, model.ContractResource{
+			ID: "model-egress",
+			Selector: model.ResourceSelector{
+				Kind:    "model",
+				Pattern: *modelProvider + "/*",
+			},
+			Operations: []string{"model.invoke"},
+		})
+	}
 	admissionRequest := admission.Request{
 		Version:        admission.RequestVersion,
 		IdempotencyKey: *id,
@@ -231,18 +265,8 @@ func transactionRunNamed(
 		},
 		Actor: actor,
 		Contract: admission.ContractSpec{
-			Risk: "high",
-			Resources: []model.ContractResource{{
-				ID: "workspace",
-				Selector: model.ResourceSelector{
-					Kind:    "filesystem",
-					Pattern: "workspace/**",
-				},
-				Operations: []string{"filesystem.read", "filesystem.write"},
-				Conditions: model.CapabilityConditions{
-					WorkspaceRoot: "workspace",
-				},
-			}},
+			Risk:      "high",
+			Resources: resources,
 			Budgets: model.BudgetLimits{
 				MaxWallTimeSeconds: &maxWallTimeSeconds,
 			},
@@ -288,7 +312,7 @@ func transactionRunNamed(
 			processContext,
 			*namespace, *id,
 			worktree.Projection.Transaction.EventSequence,
-			*runID, *image, command, int64(*timeout/time.Second), actor,
+			*image, command, 0, actor,
 		)
 		if executeErr != nil {
 			fmt.Fprintln(stderr, executeErr)

--- a/scripts/vouchproductionbench.sh
+++ b/scripts/vouchproductionbench.sh
@@ -221,6 +221,7 @@ VOUCH_IDENTITY_TOKEN="$operator_token" "$bin_dir/vouch" --repo "$repo" --json tx
   --run run:production-bench \
   --runtime oci \
   --image "$production_image" \
+  --model-provider openai \
   -- \
   /bin/sh -c '
     set -eu

--- a/skills.md
+++ b/skills.md
@@ -10,6 +10,15 @@ architecture: the Vouch Control Plane plus a fleet of customer-side Vouch
 Runtimes. **Vouch Runtime** is the first sellable product and the enforcement
 boundary for autonomous-agent actions.
 
+One `vouchd` kernel supports two experiences:
+
+- **Vouch Developer Runtime** is the local developer experience around one
+  Runtime: initialize a real agent profile, execute it in a bounded Git
+  transaction, inspect the exact outcome and explicitly accept or reject it.
+- **Vouch Agent OS** is the enterprise experience and complete target:
+  non-bypassable connectors, cross-run policy and fleet management around the
+  same Runtime kernel.
+
 Its job is to make an agent task a controlled transaction:
 
 ```text
@@ -37,6 +46,8 @@ Keep these names distinct:
   manages connector configuration but does not execute downstream actions.
 - **Vouch Runtime**: the current product and customer-side enforcement
   boundary.
+- **Vouch Developer Runtime**: the local product experience around one Runtime,
+  not a separate or weaker engine.
 - **`vouchd` kernel**: the trusted authority and transaction engine inside each
   Runtime.
 - **Vouch Contracts**: an optional module that compiles release intent into
@@ -83,6 +94,11 @@ It does not currently push, open or merge pull requests, deploy, coordinate
 database/Kubernetes effects, provide remote multi-tenant service, or provide
 HA. Stable release packaging is pending.
 
+Runtime profile initialization and diagnostics exist. A maintained agent
+adapter, asynchronous supervision, live cancellation, friendly diff/apply and
+stable packaging remain in progress or planned; do not call the current
+low-level integration a self-serve developer preview yet.
+
 ## Good work
 
 Prefer work that strengthens the runtime path:
@@ -126,6 +142,8 @@ Use:
 
 - “Vouch Runtime — transaction and outcome control for autonomous-agent
   actions”
+- “Vouch Developer Runtime” for the local developer experience around the same
+  kernel
 - “the controlled boundary between an agent proposal and a real effect”
 - “`vouchd` kernel” for the trusted authority and transaction engine
 - “isolated, verified and authorized agent execution”
@@ -169,15 +187,17 @@ it.
 
 ## Near-term order
 
-1. Stabilize the implemented task-oriented CLI, named `AgentImage` profiles and
-   read-only `vouch.agent_task.v0` envelope; publish the external SDK/API.
-2. Wire execution contracts, budgets, mandatory verifier sets and release
-   targets into task creation.
-3. Deliver one deep remote-Git/GitHub connector and approval experience.
-4. Prove paid design-partner demand for fleet policy, audit and approvals.
-5. Build the Vouch Control Plane around customer-side Vouch Runtimes.
-6. Add Kubernetes and PostgreSQL transaction packs only after Git release and
+1. Pair the admitted run and transaction lifecycle and durably charge budgets.
+2. Complete the Vouch Developer Runtime shell: maintained adapter, supervision,
+   watch/cancel, diff and explicit apply/reject.
+3. Stabilize the authenticated action protocol and connector coordinator.
+4. Deliver one deep remote-Git/GitHub connector and approval experience.
+5. Prove paid design-partner demand for fleet policy, audit and approvals.
+6. Build the Vouch Control Plane around customer-side Vouch Runtimes.
+7. Add Kubernetes and PostgreSQL transaction packs only after Git release and
    reconciliation are deep.
 
-The primary product metric is permission expansion: a customer safely lets an
-agent complete work it previously could only propose.
+Developer success means a new user repeatedly reaches a controlled local
+outcome without low-level transaction surgery. Enterprise success means
+permission expansion: a customer safely lets an agent complete work it
+previously could only propose.


### PR DESCRIPTION
## What

- Reload and replay admitted task, contract, grants, run, and transaction state immediately before OCI execution.
- Compile a fail-closed plan for image, command, workspace, model broker, and deadline.
- Atomically pin the live run and transaction heads while recording execution start before any workload.
- Add explicit `--model-provider` admission and developer usage examples.

## Why

Atomic task admission existed, but execution did not yet consume it as live launch authority. Caller-controlled executable material and stale run state needed a non-bypassable claim point.

## Developer impact

Existing OCI agents read `/vouch/task.json`, edit `/workspace`, and run through `vouch run`. Model access is absent unless the task explicitly requests the configured provider broker.

## Validation

- `go test -count=1 ./...`
- focused race tests for authority, store, and API
- `go vet ./...`
- strict MkDocs build
- VouchBench 114/114; kernel 8/8; transaction 10/10; runtime 10/10
- production Docker acceptance, including broker receipt and committed release
