### PR TITLE
feat: pair execution lifecycle and add exact review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,9 @@ jobs:
           GATEMOLE_PRODUCTION_IMAGE: ${{ steps.fixture.outputs.image }}
         run: scripts/gatemoleproductionbench.sh
 
+      - name: Run paired execution recovery demo
+        run: scripts/gatemolepairedexecutiondemo.sh
+
   skylos:
     name: Skylos advisory
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -113,6 +113,10 @@ jobs:
           GATEMOLE_PRODUCTION_IMAGE: ${{ steps.fixture.outputs.image }}
         run: scripts/gatemoleproductionbench.sh
 
+      - name: Run paired execution recovery demo
+        if: steps.plan.outputs.production == 'true'
+        run: scripts/gatemolepairedexecutiondemo.sh
+
       - name: Summarize validation plan
         if: always()
         env:

--- a/README.md
+++ b/README.md
@@ -29,6 +29,151 @@ One kernel serves two product experiences:
 These are not separate engines. Developer adoption exercises the same kernel
 semantics that future enterprise deployments require.
 
+## What would a team use Gatemole for?
+
+Use Gatemole when a software agent needs permission to change a repository,
+but should not also receive permission to approve or publish its own work.
+Gatemole is the control layer around an existing agent; it is not the agent
+that diagnoses or writes the fix.
+
+Consider a real payments incident, `PAY-1842`: valid customers are being logged
+out because the API rejects their refresh tokens. The on-call engineer wants a
+coding agent to inspect the service, fix the authentication code, add a
+regression test and use a model while it works.
+
+### The pain: the worker is also inside the control boundary
+
+A common direct-agent setup looks roughly like this (the command varies by
+agent):
+
+```sh
+cd /srv/repos/payments-api
+export MODEL_PROVIDER_API_KEY="$REAL_PROVIDER_KEY"
+export GIT_RELEASE_TOKEN="$PAYMENTS_GIT_TOKEN"
+payments-coder --task-file tickets/PAY-1842.md
+```
+
+The agent may produce a perfectly good fix. The operational problem is that
+the team has also placed the live checkout, inherited credentials, network and
+the account's Git authority inside the same process boundary as the worker.
+Its transcript is useful context, but it is not an independent authority log.
+If the process edits an unrelated file, runs the wrong test, crashes halfway or
+pushes a branch, the surrounding workflow has to discover and recover from
+that after the fact.
+
+Some agent products already provide their own sandbox, permission prompts or
+review UI. Gatemole does not claim those features are absent everywhere. Its
+specific offer is an agent-independent enforcement boundary owned by a
+separate local daemon:
+
+| Control | Direct agent invocation | Same agent through Gatemole |
+| --- | --- | --- |
+| Task | Prompt and runner state | Content-bound, durable admission tied to one run and transaction |
+| Workspace | Live checkout or the agent product's sandbox | Daemon-created private Git worktree; source checkout is not mounted |
+| Model access | Provider credential and network policy of the agent process | Short-lived broker token; provider credential remains in `gatemoled`; no model network unless admitted |
+| What changed | Agent transcript and a Git diff inspected afterward | Daemon-authored normalized effects plus hash-chained execution and transaction receipts |
+| Testing | Often requested and run by the same worker | Separately pinned verifier runs against the exact frozen tree |
+| Approval | External convention or product-specific review | Signed decision bound to the immutable approval package |
+| Release | Whatever Git authority the process or account has | Distinct release identity and compare-and-swap to an allowed local ref |
+| Crash/retry | Runner-specific; partial state may need manual interpretation | Same admission resumes the transaction; earlier execution receipts remain immutable |
+
+`payments-coder` in both columns is the team's real agent or adapter—not a
+Gatemole-provided fake agent. The point of the comparison is to keep the worker
+constant and move authority out of it.
+
+With Gatemole, the team instead uses this workflow:
+
+1. The operator admits the exact ticket to a named, digest-pinned agent.
+   `gatemoled` gives the agent a private Git worktree and, if authorized, a
+   transaction-scoped model-broker token. It does not give the agent the source
+   checkout, provider credential, daemon socket or release credential.
+2. Gatemole freezes and inventories the resulting Git effects. The operator
+   can see that the agent changed, for example, the refresh-token implementation
+   and its test—not merely read the agent's description of what it changed.
+3. A separately configured verifier runs the authentication tests against the
+   exact frozen tree.
+4. A security reviewer signs the immutable approval package. The coding agent
+   cannot approve itself, and a later change invalidates that approval.
+5. A different release identity publishes the approved commit to a pre-existing
+   allowed local Git ref with compare-and-swap protection.
+
+After the Runtime has been configured with the `payments-coder` agent, model
+broker, verifier, OIDC identities, approval trust and allowed release ref, the
+day-to-day operator flow is:
+
+```sh
+export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_OPERATOR_TOKEN"
+
+gatemole --repo /srv/repos/payments-api run \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --run run:pay-1842 \
+  --require-enforcement-profile production \
+  --intent-file tickets/PAY-1842.md \
+  --agent payments-coder \
+  --model-provider openai
+
+gatemole --repo /srv/repos/payments-api review tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments
+```
+
+The operator then asks an independently pinned verifier to test the frozen
+candidate and prepares the exact local ref update:
+
+```sh
+VERIFIER_IMAGE="$(cat /etc/gatemole/images/go-verifier.ref)"
+
+gatemole --repo /srv/repos/payments-api tx verify \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --name auth-tests \
+  --image "$VERIFIER_IMAGE" \
+  -- /usr/local/bin/run-auth-tests
+
+gatemole --repo /srv/repos/payments-api tx prepare \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --git-ref refs/heads/agent-release/pay-1842
+```
+
+The reviewer and releaser use their own short-lived identities:
+
+```sh
+export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_REVIEWER_TOKEN"
+
+gatemole --repo /srv/repos/payments-api approve tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --key /secure/payments-reviewer.key \
+  --key-id key:payments-reviewer \
+  --approver human:alice \
+  --issuer https://login.acme.example/ \
+  --class security-reviewer
+
+export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_RELEASER_TOKEN"
+
+gatemole --repo /srv/repos/payments-api apply tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --actor operator:payments-release \
+  --actor-kind operator
+```
+
+If the agent or daemon fails, repeating the identical `gatemole run` resumes
+the same admitted transaction and retains the earlier execution receipts. It
+does not silently turn a failed attempt into releasable work.
+
+This is the useful boundary implemented today: governed agent work in a local
+Git repository. Release updates only the configured local ref; Gatemole does
+not yet push or merge a pull request, deploy the service, mutate a database or
+control Kubernetes. Those remote effects require the planned connector and
+Control Plane layers. The complete setup assumptions and operator walkthrough
+are in [Runtime examples](docs/EXAMPLES.md#real-life-use-case-govern-an-ai-hotfix).
+
 ## Architecture: where the OS, Runtime and kernel sit
 
 **Gatemole Agent OS** names the complete target system; it is not another process
@@ -72,11 +217,11 @@ The operating-system analogy is precise:
 
 | Name | Meaning | Status |
 | --- | --- | --- |
-| **Gatemole Developer Runtime** | The local product experience around one Runtime: package an agent, execute it in an isolated Git transaction, inspect exact effects and control release. | Low-level integration, Runtime profile initialization and diagnostics implemented; packaged adapters, `watch`, live cancellation and review UX planned |
+| **Gatemole Developer Runtime** | The local product experience around one Runtime: package an agent, execute it in an isolated Git transaction, inspect exact effects and control release. | Low-level integration, Runtime profile initialization, diagnostics and exact review/apply/reject shell implemented; packaged adapters, `watch` and live cancellation planned |
 | **Gatemole Agent OS** | The enterprise product experience and complete target architecture: Control Plane, Runtime fleet, transaction protocol and connector model. It is an umbrella, not a process. | Product direction |
 | **Gatemole Control Plane** | Organization-wide fleet, policy, approval, audit and incident management. It manages Runtimes but does not execute agent actions. | Planned |
 | **Gatemole Runtime** | The deployable enforcement boundary installed in a customer environment. It contains `gatemoled`, agent sandboxes, local durable state and connector drivers. | Runtime identity, a narrow single-node local-Git profile and exact profile-bound admission are implemented |
-| **`gatemoled` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Runtime preflight, atomic task admission, live OCI authority revalidation and head-pinned launch claim implemented; paired lifecycle and action enforcement are still converging |
+| **`gatemoled` kernel** | The trusted daemon that owns admission, authoritative lifecycle state, budgets, policy decisions, the transaction journal, approvals and commit coordination. | Runtime preflight, atomic task admission, live OCI authority revalidation, paired execution settlement/recovery and supported budget charging implemented; supervision and action enforcement are still converging |
 | **Agent sandbox** | The isolated, untrusted environment in which an agent loop executes. It receives no downstream production credentials. | OCI implementation available |
 | **Agent adapter** | Connects an existing agent framework or command to the kernel. It may request work and actions but cannot authorize itself or create receipts. | Command/profile and lower-level integration exist; supported broker API planned |
 | **Connector driver** | Performs typed operations against one downstream system after kernel authorization and reconciles external state. `gatemoled` records authoritative receipts and coordinates recovery. | Generic interface and remote drivers planned. Local Git currently uses a dedicated transaction path, not that future interface |
@@ -91,10 +236,16 @@ exact Runtime ID and daemon enforcement profile with the content-bound
 contract, real run, initial grants and transaction. Before OCI launch,
 `gatemoled` reloads that live authority and fail-closed derives the permitted
 image, command, full-workspace access, model-broker access and deadline. It
-then atomically verifies the admitted run and transaction heads while
-recording execution start, before starting any broker or agent workload.
-Execution still advances only the transaction ledger; paired run lifecycle and
-durable budget charging are the next Runtime milestone.
+then atomically verifies the admitted run and transaction heads while recording
+execution start in both ledgers, before starting any broker or agent workload.
+Settlement atomically closes the same execution in both ledgers, clears the
+run's active-execution binding and durably charges elapsed wall time plus
+verified model-call and token usage against the remaining hard limits. The raw
+transaction receipt retains the execution timestamps and counters if a charge
+saturates. Daemon restart performs the same paired settlement for an
+interrupted workload and marks unfinished model calls unknown before charging
+them. Live cancellation, tool/cost accounting and the mediated connector action
+path remain later Runtime milestones.
 
 The target remote-effect path is:
 
@@ -131,13 +282,17 @@ The current runtime requires Git, an OCI engine such as Docker, a running
 This is a low-level developer integration, not yet a self-serve desktop agent
 environment. `gatemole runtime init` creates a strict repository-owned profile
 and a local Runtime identity. `gatemole doctor` diagnoses Git, OCI, profile,
-local-image and daemon readiness. Packaged adapters, daemon supervision,
-`watch`, live cancellation and a friendly diff/apply flow remain roadmap work.
+local-image and daemon readiness. `gatemole review` shows the daemon-bound
+status, exact effects, evidence IDs and frozen patch; `diff`, `apply` and
+`reject` expose the corresponding task-oriented operations. Packaged adapters,
+daemon supervision, `watch` and live cancellation remain roadmap work.
 
 Build the CLI from source:
 
 ```sh
 go install ./cmd/gatemole
+gatemole version
+gatemole --help
 ```
 
 In a Git repository with a `HEAD` commit, register an agent image that is
@@ -270,21 +425,27 @@ expired grant, a changed image or command, a narrower unsupported workspace
 grant, or an ungranted model provider fails before any broker or agent
 container starts.
 
-For concrete scenarios rather than placeholders, see
-[Runtime examples](docs/EXAMPLES.md). It includes a runnable deterministic
-authentication-hotfix fixture, illustrative model-assisted and networkless
-deployment patterns, and an explicit description of which enterprise
-connector examples are not implemented.
+For the complete PAY-1842 operator workflow and the assumptions behind it, see
+[Runtime examples](docs/EXAMPLES.md#real-life-use-case-govern-an-ai-hotfix).
+That guide separately labels its runnable deterministic fixtures as acceptance
+proofs rather than presenting them as the normal user experience.
 
 `gatemole run` then creates the isolated worktree, runs the agent, freezes its Git
 effects, and performs deterministic sequence validation. Inspect the result
 with:
 
 ```sh
+gatemole --repo /path/to/service review <transaction-id> \
+  --namespace local
+
+# Print only the exact frozen patch (safe to pipe to another tool):
+gatemole --repo /path/to/service diff <transaction-id> \
+  --namespace local
+
+# Advanced lifecycle/debugging surface:
 gatemole --repo /path/to/service status <transaction-id> \
   --namespace local
 
-# Advanced compatibility surface:
 gatemole --repo /path/to/service tx effects \
   --namespace local --id <transaction-id>
 
@@ -292,11 +453,43 @@ gatemole --repo /path/to/service tx events \
   --namespace local --id <transaction-id>
 ```
 
+The daemon re-inspects the staged tree before returning a diff. The client
+checks its patch digest and transaction/attempt/event binding; a worktree
+change after staging fails closed instead of showing a mutable approximation.
+After verification, preparation and any required signed approval, `gatemole
+apply <transaction-id>` invokes the same release operation as `gatemole
+release`. `gatemole reject <transaction-id>` aborts and discards an unreleased
+worktree; it is not live workload cancellation.
+
+### Optional local proof: crash and resume the PAY-1842 agent
+
+This is an executable acceptance fixture, not the operator interface described
+above. Run it from a Gatemole source checkout to exercise the failure/recovery
+invariant without supplying a real agent, repository or production trust
+configuration. It requires Git, Go, Docker and `jq`; Docker may fetch
+`golang:1.26-alpine` the first time:
+
+```sh
+scripts/gatemolepairedexecutiondemo.sh
+```
+
+The fixture builds a disposable payments API and deterministic agent. Its first
+attempt saves the candidate fix in the private transaction worktree and exits
+with code 42; after a daemon restart, the second attempt resumes that patch and
+runs `go test ./internal/auth` successfully.
+
+The final JSON report includes both immutable execution receipts, all four
+paired `run.execution_started`/`run.execution_finished` events, cumulative wall
+time across both attempts, a `waiting_for_event` run with no active execution,
+and proof that the developer's source checkout was never modified. See
+[Runtime examples](docs/EXAMPLES.md#2-self-contained-recovery-proof-pay-1842-agent-crash)
+for the expected output and equivalent inspection commands.
+
 Production verification and preparation use the advanced `tx verify` and
-`tx prepare` operations. Reviewers and releasers use the top-level
-`gatemole approve` and `gatemole release` commands under the hardened daemon
-configuration. See [Production Runtime Operations](docs/PRODUCTION.md) for the
-complete deployment contract; do not infer production safety from the
+`tx prepare` operations. Reviewers and releasers use the top-level `gatemole
+review`, `gatemole approve` and `gatemole apply` commands under the hardened
+daemon configuration. See [Production Runtime Operations](docs/PRODUCTION.md)
+for the complete deployment contract; do not infer production safety from the
 development example above.
 
 Production callers should make the expected profile explicit:
@@ -390,12 +583,14 @@ code correct and are not a generic AI code reviewer.
 
 ## Documentation
 
+- [Real-life Runtime examples](docs/EXAMPLES.md)
 - [Agent transactions](docs/TRANSACTIONS.md)
 - [Production runtime operations](docs/PRODUCTION.md)
 - [Kernel internals](docs/KERNEL.md)
 - [Runtime and product roadmap](ROADMAP.md)
 - [Product validation and competitive assessment](docs/PRODUCT_VALIDATION.md)
 - [Transaction-control decision](docs/architecture/ADR-002-agent-transaction-control.md)
+- [Durable-supervisor decision](docs/architecture/ADR-003-durable-execution-supervisor.md)
 - [Threat model](docs/architecture/TRANSACTION_THREAT_MODEL.md)
 - [Gatemole Contracts](docs/COMPILER.md)
 - [Benchmarks and acceptance](docs/BENCHMARKS.md)

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -14,7 +14,7 @@ One kernel supports two product experiences:
 
 | Experience | User promise | Current truth |
 | --- | --- | --- |
-| **Gatemole Developer Runtime** | Run an existing agent locally with bounded authority, isolated effects, review and recovery. | A manually operated local-Git path plus profile initialization and diagnostics exists. Packaging, maintained adapters, live supervision and review UX need product work. |
+| **Gatemole Developer Runtime** | Run an existing agent locally with bounded authority, isolated effects, review and recovery. | A manually operated local-Git path plus profile initialization, diagnostics and an exact review/apply/reject shell exists. Packaging, maintained adapters and live supervision need product work. |
 | **Gatemole Agent OS** | Govern consequential agent actions across customer systems and a fleet of Runtimes. | Enterprise experience and full target architecture only. The action protocol, remote connectors, cross-run policy and Control Plane are planned. |
 
 The experiences are different packaging and operations around the same
@@ -85,15 +85,19 @@ read/write and explicitly granted provider-scoped model brokering are
 currently supported. Expired, terminal, narrowed or otherwise unsupported
 authority starts no workload.
 
-Before any broker or agent workload starts, `gatemoled` now atomically verifies
-that both snapshot heads are still current and records execution start in the
-transaction ledger. A concurrent run or transaction change therefore starts
-no workload. Execution is not yet one paired lifecycle: the OCI workload
-advances the transaction without advancing the admitted run, and usage is not
-yet durably charged to run budgets. OS-3 must next pair execution start,
-settlement and recovery across both ledgers before remote connectors are
-added. The older brokered `ActionRequest` endpoints remain disabled by the
-production profile.
+Before any broker or agent workload starts, `gatemoled` atomically verifies
+that both snapshot heads are still current and records the exact execution in
+the run and transaction ledgers. Settlement and restart recovery finish that
+same execution on both sides, clear the run's active binding, and cumulatively
+charge elapsed wall time plus verified model-call/token usage. A concurrent run
+or transaction change therefore starts no workload, and a partial paired
+mutation cannot commit.
+
+The remaining OS-3 work is narrower data authority, mediated tool/connector
+execution, and durable tool/cost accounting. Live lifecycle controls must also
+interrupt an active OCI workload rather than only changing metadata. The older
+brokered `ActionRequest` endpoints remain disabled by the production profile
+until that path is joined to current admission and execution authority.
 
 ## Execution principles
 
@@ -126,9 +130,9 @@ validation.
 | **OS-1: focused validation lanes** | Complete | At most three required PR lanes: Go checks, affected acceptance and documentation when changed. Run the full race, vulnerability and benchmark collections on `main`, nightly and release. Retain production OCI acceptance for security-critical Runtime changes. | Normal PR gate completes in a bounded target such as 12 minutes. Path rules cannot skip production acceptance when kernel, sandbox, identity, approval, release or connector code changes. |
 | **OS-2: atomic task admission** | Complete | One daemon-owned, idempotent endpoint persists the exact task, `ExecutionContract`, real `AgentRun`, initial capability grants and `AgentTransaction` in one database transaction. The server authors authoritative events and digests. | Fault injection after every persistence step creates no orphan resources. Identical idempotency retry returns the same admission; a changed retry conflicts. Every transaction references a digest-matching run and contract. |
 | **OS-3: bind execution authority and data boundaries** | In progress | OCI execution transitions the admitted `AgentRun`. Identity, sponsor and parent lineage, contract, capabilities, deadline, allowed resources, data classes, model egress and budgets become authoritative. Task limits may narrow daemon ceilings but never widen them. | Run and transaction state cannot diverge after success, failure or injected crash. Expired authority prevents start. Time, model, tool and cost limits fail closed and are durably charged across restart. Denied mounts, connector reads, resource classes and model-egress destinations are inaccessible rather than merely recorded. |
-| **OS-4: durable supervisor and circuit breaker** | Planned | Asynchronous workload start, durable desired state and execution lease; functional `watch`, `cancel`, kill and revocation. “Pause” means stop at a declared safe boundary, not arbitrary process snapshotting. | Repeated start creates one workload. Cancel terminates the agent and broker within a bounded interval and prevents release. No new effect executes after revocation. Restart produces one reconciled outcome. |
+| **OS-4: durable supervisor and circuit breaker** | Planned; design accepted | Asynchronous workload start, durable desired state and execution lease; functional `watch`, `cancel`, kill and revocation, following [ADR-003](docs/architecture/ADR-003-durable-execution-supervisor.md). “Pause” means stop at a declared safe boundary, not arbitrary process snapshotting. | Repeated start creates one workload. Cancel terminates the agent and broker within a bounded interval and prevents release. No new effect executes after revocation. Restart produces one reconciled outcome. |
 | **DX-1: Developer Runtime onboarding** | In progress | Runtime-aware project setup and diagnostics, a versioned CLI release, one maintained coding-agent profile and local daemon setup. Keep generated configuration explicit and repository-owned. | On a clean supported machine, a developer can install Gatemole, initialize a repository, diagnose prerequisites and start one maintained agent without hand-authoring kernel configuration. |
-| **DX-2: Developer review shell** | Planned | Readable status and diff plus explicit apply/reject, preserving the exact underlying transaction and evidence IDs. Reuse OS-4 for `watch` and real cancellation. | A developer can inspect the exact diff and evidence, then apply or reject it without low-level `tx` commands or database access. |
+| **DX-2: Developer review shell** | Complete | Readable status and daemon-rendered, digest-checked exact diff plus explicit apply/reject, preserving the underlying transaction, effect, evidence and approval IDs. `apply` and `reject` are thin aliases over release and abort; they do not bypass authority. Reuse OS-4 for `watch` and real cancellation. | Integration tests inspect the exact frozen patch and evidence, reject a changed worktree, apply only through prepared release authority, and reject by aborting and removing the isolated worktree. |
 | **OS-5: connector interface and transaction coordinator** | Planned | Introduce `Plan → Stage/Hold → Inspect → Verify → Commit → Reconcile → Compensate`; add a connector registry plus a durable dependency-ordered coordinator. Each connector persists preparation state, commit state and receipts. Unknown results stop dependent work; restart performs reconciliation before retry or compensation. Move local Git behind the interface only after the generic harness passes. | Two fake connectors prove dependency-ordered prepare/commit, stop-on-unknown, restart recovery, reverse compensation and manual-recovery escalation. Faults are injected before dispatch, during dispatch and after an external effect but before its receipt. Connectors cannot mint authority. Existing local-Git production acceptance remains behaviorally unchanged. |
 | **OS-6: versioned Runtime action protocol and broker** | Planned | Replace or converge the legacy broker behind a supported `ActionRequest → decision/approval → receipt` protocol. A transaction-scoped workload credential binds sandbox transport, task, run, transaction, delegated identity, capability, deadline and idempotency key. Publish stable status/event cursors, error semantics and one maintained Go client. Direct private-worktree mutation remains an explicitly contained, stageable boundary. | Local transport rejects forged, cross-run, expired and replayed credentials. Approval resumes only the exact immutable request after restart. A fake connector proves allow, deny, approval, expiry and revocation without exposing its credential. N/N-1 protocol and adapter-conformance fixtures pass; every attempted external effect is attributable. |
 | **OS-7: lineage-aware temporal policy** | Planned | Persist immutable identity, delegation, action and effect facts across runs and transactions. Evaluate bounded temporal and separation-of-duties rules across sessions, systems, child agents and a shared sponsor lineage. Ordinary stateless decisions may use an ACS/Cedar/OPA adapter, but Gatemole remains authoritative for history and commit. | An AP-style fixture spanning separate sessions and delegated identities is denied for the composed sequence while individually valid actions remain allowed. Restart yields the same decision. Retention and query bounds are explicit, and the policy adapter cannot authorize or commit an effect outside the Runtime transaction. |

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -5,7 +5,199 @@ trusted node. These examples therefore use software-delivery work rather than
 pretending that the current repository can already control SAP, Salesforce or
 bank transfers.
 
-## 1. Run the repository production-acceptance scenario
+## Real-life use case: govern an AI hotfix
+
+### The pain point
+
+It is 02:00 and incident `PAY-1842` is logging valid customers out of a payments
+API. A refresh-token regression is already captured in
+`tickets/PAY-1842.md`. The team has a real coding agent, called
+`payments-coder`, that can inspect the repository, call a model, edit the Go
+service and run tests.
+
+A common direct invocation is:
+
+```sh
+# Use a disposable clone when collecting a baseline. Do not experiment in the
+# production Runtime repository.
+cd /tmp/payments-api-baseline
+payments-coder --task-file tickets/PAY-1842.md
+go test ./internal/auth
+git diff
+```
+
+The agent may diagnose and fix the bug correctly. That is not the control
+problem Gatemole addresses. In this setup, the agent runs inside the same
+boundary as the checkout and whatever credentials and network its launcher
+inherited. The team normally relies on the agent transcript, the resulting
+working tree and surrounding conventions to answer:
+
+- Did the process touch only the two files it reported?
+- Did the successful test run against the exact tree being reviewed?
+- Can this process or one of its tools publish the branch itself?
+- What partial state remains if the agent or launcher crashes?
+- Is a human approval still valid if any byte changes afterward?
+
+An agent product may already implement some sandboxing or review controls.
+Gatemole's difference is that these decisions are owned by a separate local
+kernel and are bound together as one durable transaction, regardless of which
+agent performs the work.
+
+### Run the same real agent through Gatemole
+
+`payments-coder` below is the team's actual agent adapter, not the deterministic
+test fixture later in this guide. The adapter reads the retained task envelope
+from `$GATEMOLE_TASK_PATH`, invokes the normal agent loop and lets it edit
+`/workspace`. The platform team packages that command in a digest-pinned OCI
+image and registers it once:
+
+```sh
+gatemole --repo /srv/repos/payments-api runtime init \
+  --agent payments-coder \
+  --image registry.acme.example/agents/payments-coder@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
+  --source-digest sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
+  -- /usr/local/bin/payments-coder
+```
+
+The production daemon must also be configured with the `openai` model-broker
+policy, the `auth-tests` verifier profile, OIDC trust, approval trust and an
+allowlist containing the release ref. Those are one-time platform controls;
+the exact hardened setup is in [Production Runtime Operations](PRODUCTION.md).
+
+Assume the allowed release ref already exists at the current base revision and
+is not checked out:
+
+```sh
+git -C /srv/repos/payments-api \
+  branch agent-release/pay-1842 HEAD
+```
+
+The incident operator admits the exact ticket to one run and transaction:
+
+```sh
+export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_OPERATOR_TOKEN"
+
+gatemole --repo /srv/repos/payments-api run \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --run run:pay-1842 \
+  --require-enforcement-profile production \
+  --intent-file tickets/PAY-1842.md \
+  --agent payments-coder \
+  --model-provider openai
+```
+
+`gatemoled`, rather than the agent launcher, now creates the task authority and
+private worktree and starts the pinned container. The agent receives only the
+task-specific broker token; the provider key stays in `gatemoled`. The source
+checkout, daemon socket, Git release credential and production service
+credentials are absent from the container.
+
+When the agent exits, success means only that the worker completed. It does not
+mean that the change is approved or released. The operator inspects the
+daemon-owned transaction, evidence identifiers, exact normalized effects and
+digest-bound frozen patch:
+
+```sh
+gatemole --repo /srv/repos/payments-api review tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments
+
+gatemole --repo /srv/repos/payments-api diff tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments
+
+# Advanced event inspection remains available:
+gatemole --repo /srv/repos/payments-api tx events \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842
+
+# The agent did not edit the source checkout.
+git -C /srv/repos/payments-api diff --exit-code
+```
+
+The team then runs an independently configured verifier against the immutable
+staged tree—not against a path selected by the coding agent—and prepares the
+exact release operation:
+
+```sh
+VERIFIER_IMAGE="$(cat /etc/gatemole/images/go-verifier.ref)"
+
+gatemole --repo /srv/repos/payments-api tx verify \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --name auth-tests \
+  --image "$VERIFIER_IMAGE" \
+  -- /usr/local/bin/run-auth-tests
+
+gatemole --repo /srv/repos/payments-api tx prepare \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --git-ref refs/heads/agent-release/pay-1842
+```
+
+Authentication code and its test changing together require a focused security
+approval under the baseline sequence policy. A reviewer signs the exact frozen
+approval package with a separate short-lived identity:
+
+```sh
+export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_REVIEWER_TOKEN"
+
+gatemole --repo /srv/repos/payments-api approve tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --key /secure/payments-reviewer.key \
+  --key-id key:payments-reviewer \
+  --approver human:alice \
+  --issuer https://login.acme.example/ \
+  --class security-reviewer
+```
+
+A different identity performs the release:
+
+```sh
+export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_RELEASER_TOKEN"
+
+gatemole --repo /srv/repos/payments-api apply tx:pay-1842 \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --actor operator:payments-release \
+  --actor-kind operator
+```
+
+`apply` uses the existing release authority: it compares the prepared base
+revision and atomically updates only `refs/heads/agent-release/pay-1842`. A
+changed base, changed candidate, missing approval or wrong identity fails
+closed. The coding agent cannot turn its own successful process exit into a
+release.
+
+### What changed in the before/after comparison
+
+| Question | Direct invocation | Through Gatemole |
+| --- | --- | --- |
+| Which agent solved the bug? | `payments-coder` | The same `payments-coder` image and command |
+| Where could it write? | The checkout exposed by its launcher | A transaction-private worktree; the source checkout remains unchanged |
+| How could it call the model? | Whatever provider credential and network the launcher supplied | Only the admitted broker; the provider credential remains outside the agent |
+| Who says what happened? | Primarily the agent/runner transcript and resulting checkout | `gatemoled` writes paired execution receipts, normalized effects and hash-chained events |
+| Who checks the fix? | Commonly the agent itself plus later CI | A separately pinned verifier checks the exact frozen tree before approval |
+| Who can approve and release? | Depends on surrounding convention and available Git credentials | A trusted reviewer signs the exact package; a different releaser updates the allowed ref |
+| What happens on retry? | Depends on the runner and workspace | Identical admission resumes the durable transaction; failed/interrupted receipts remain |
+
+That is Gatemole's current practical value. It does not make
+`payments-coder` smarter, prove the fix semantically correct or replace CI. It
+makes the agent's authority narrower and makes the path from intent to an exact
+Git effect independently inspectable and enforceable.
+
+The current release target is deliberately limited: Gatemole updates an
+allowed **local Git ref**. It does not yet push or merge a pull request, deploy
+the payments service, mutate a database or operate Kubernetes. Remote effects
+need the planned connector and Control Plane layers.
+
+## 1. Optional: run the repository production-acceptance fixture
 
 The fastest end-to-end local-Git example is the same acceptance flow used
 before release. It requires Git, Go, Docker, `jq`, and `curl`:
@@ -39,13 +231,76 @@ receipt records an unknown call rather than pretending it succeeded. The
 scenario also proves that the provider credential never reaches the agent and
 that direct agent Internet egress is blocked.
 
-## 2. Runnable deterministic fixture: authentication hotfix
+## 2. Self-contained recovery proof: PAY-1842 agent crash
 
-This example creates a small payments-service repository and a digest-pinned
-agent image. The agent changes authentication code and its test inside a Gatemole
-transaction. The source checkout remains unchanged.
+This is a deterministic acceptance fixture for the recovery claims above, not
+the primary user workflow and not a substitute for evaluating a real agent.
+It starts with a payments API that rejects valid refresh tokens and has a
+failing regression test. Its fixture agent saves the fix but crashes before
+verification. After `gatemoled` is restarted, the same admitted task resumes
+the existing private worktree, runs the real Go test, and succeeds:
 
-Run the example as a non-root user with Git, Go, Docker, and `jq` installed.
+```sh
+scripts/gatemolepairedexecutiondemo.sh
+```
+
+Run it as a non-root user with Git, Go, Docker, and `jq` installed. Docker may
+fetch `golang:1.26-alpine` on the first run. The script builds Gatemole from the
+current checkout and creates all service, image, Runtime, ledger, and worktree
+state under a temporary directory; its cleanup does not touch the source
+checkout.
+
+The scenario checks each important boundary instead of merely printing a happy
+path:
+
+1. The first agent edits `internal/auth/refresh.go` only inside the detached
+   transaction worktree, then exits 42 before running tests.
+2. The transaction records a failed execution and the paired run settles to
+   `waiting_for_agent`, with its active-execution binding cleared.
+3. The daemon is stopped and started against the same SQLite ledger and
+   transaction root.
+4. Exact admission replay starts a second immutable execution receipt in the
+   same transaction. The agent finds the saved patch and runs
+   `go test ./internal/auth` inside the OCI boundary.
+5. Success settles the run to `waiting_for_event`; all four paired execution
+   events remain queryable and wall time from both attempts is cumulative.
+6. `git diff --exit-code` proves the developer's checkout remains unchanged.
+
+The execution IDs and timing vary, but the report has this shape:
+
+```json
+{
+  "incident": "PAY-1842 refresh-token rejection",
+  "first_attempt": "failed",
+  "state_after_failure": "waiting_for_agent",
+  "daemon_restarted": true,
+  "retry": "succeeded",
+  "regression_test": "go test ./internal/auth (passed on retry)",
+  "final_run_state": "waiting_for_event",
+  "active_execution_id": null,
+  "cumulative_budget_usage": {
+    "wall_time_seconds": 15
+  },
+  "paired_execution_events": [
+    {"type": "run.execution_started"},
+    {"type": "run.execution_finished", "status": "failed"},
+    {"type": "run.execution_started"},
+    {"type": "run.execution_finished", "status": "succeeded"}
+  ],
+  "source_checkout_unchanged": true
+}
+```
+
+The exact setup is executable source in
+[`scripts/gatemolepairedexecutiondemo.sh`](../scripts/gatemolepairedexecutiondemo.sh).
+The following single-attempt walkthrough unpacks the same integration contract
+for readers adapting their own agent image.
+
+### Manual single-attempt walkthrough
+
+This version creates a small payments-service repository and a digest-pinned
+agent image. The agent changes authentication code and its test inside a
+Gatemole transaction. The source checkout remains unchanged.
 
 ### Create the service repository
 
@@ -207,19 +462,33 @@ The response contains the detached workspace, daemon-authored execution
 receipt, normalized effects, and sequence decision. Inspect the durable state:
 
 ```sh
-gatemole --repo "$REPO" status tx:pay-1842 \
+gatemole --repo "$REPO" review tx:pay-1842 \
   --socket "$SOCKET" \
   --namespace payments
 
-gatemole --repo "$REPO" tx effects \
+gatemole --repo "$REPO" diff tx:pay-1842 \
   --socket "$SOCKET" \
-  --namespace payments \
-  --id tx:pay-1842
+  --namespace payments
 
 gatemole --repo "$REPO" tx events \
   --socket "$SOCKET" \
   --namespace payments \
   --id tx:pay-1842
+
+gatemole --repo "$REPO" --json kernel run get \
+  --socket "$SOCKET" \
+  --namespace payments \
+  --id run:pay-1842 \
+  | jq '.run | {state, active_execution_id, budget_usage}'
+
+gatemole --repo "$REPO" --json kernel run events \
+  --socket "$SOCKET" \
+  --namespace payments \
+  --id run:pay-1842 \
+  | jq '[.[]
+      | select(.type | startswith("run.execution_"))
+      | {type, execution_id: .payload.execution_id,
+         status: .payload.status, usage: .payload.usage}]'
 
 # The agent never edited the developer's source checkout.
 git -C "$REPO" diff --exit-code
@@ -227,117 +496,15 @@ git -C "$REPO" diff --exit-code
 
 Because authentication code and its test changed together, the baseline
 sequence policy routes this transaction to focused approval. It does not
-silently publish the change. Stop the example daemon with:
+silently publish the change. The paired run is `waiting_for_event`, has no
+active execution, and contains one start/finish pair whose finish usage was
+added to the run budget. Stop the example daemon with:
 
 ```sh
 kill "$DAEMON_PID"
 ```
 
-## 3. Illustrative deployment pattern: model-assisted coding agent
-
-Unlike the first two sections, this is not a self-contained shipped example.
-It assumes that the operator has supplied the named agent and verifier images,
-OIDC configuration and production trust material.
-
-Assume a payments team has:
-
-- repository `/srv/repos/payments-api`;
-- ticket file `tickets/PAY-1842.md`;
-- repository-owned agent profile `payments-coder`;
-- a daemon-configured `openai` broker policy;
-- independent verifier image and security approver.
-
-The operator uses its short-lived OIDC token for admission, execution,
-verification, and preparation:
-
-```sh
-export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_OPERATOR_TOKEN"
-```
-
-The allowed release ref must already exist at the transaction's exact base
-revision and must not be checked out:
-
-```sh
-git -C /srv/repos/payments-api \
-  branch agent-release/pay-1842 HEAD
-```
-
-The developer starts exactly one admitted task:
-
-```sh
-gatemole --repo /srv/repos/payments-api run \
-  --socket /run/gatemole/gatemoled.sock \
-  --namespace payments \
-  --id tx:pay-1842 \
-  --run run:pay-1842 \
-  --intent-file tickets/PAY-1842.md \
-  --agent payments-coder \
-  --model-provider openai
-```
-
-The coding agent receives the task and detached worktree. It can reach only
-the transaction-specific model broker. `OPENAI_API_KEY` inside the container is
-a short-lived broker token; the provider key remains in `gatemoled`. Direct
-Internet access, the source checkout, daemon socket, GitHub token and production
-database credentials are absent.
-
-After the agent exits, the team independently verifies the frozen tree:
-
-```sh
-VERIFIER_IMAGE="$(cat /etc/gatemole/images/go-verifier.ref)"
-
-gatemole --repo /srv/repos/payments-api tx verify \
-  --socket /run/gatemole/gatemoled.sock \
-  --namespace payments \
-  --id tx:pay-1842 \
-  --name auth-tests \
-  --image "$VERIFIER_IMAGE" \
-  -- /usr/local/bin/run-auth-tests
-
-gatemole --repo /srv/repos/payments-api tx prepare \
-  --socket /run/gatemole/gatemoled.sock \
-  --namespace payments \
-  --id tx:pay-1842 \
-  --git-ref refs/heads/agent-release/pay-1842
-```
-
-The verifier image and command must exactly match a daemon-owned verifier
-profile. A security reviewer then signs the exact frozen approval package:
-
-```sh
-export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_REVIEWER_TOKEN"
-
-gatemole --repo /srv/repos/payments-api tx approve \
-  --socket /run/gatemole/gatemoled.sock \
-  --namespace payments \
-  --id tx:pay-1842 \
-  --key /secure/payments-reviewer.key \
-  --key-id key:payments-reviewer \
-  --approver human:alice \
-  --issuer https://login.acme.example/ \
-  --class security-reviewer
-```
-
-The issuer must exactly match the trusted OIDC issuer. A different release
-identity performs release:
-
-```sh
-export GATEMOLE_IDENTITY_TOKEN="$PAYMENTS_RELEASER_TOKEN"
-
-gatemole --repo /srv/repos/payments-api tx release \
-  --socket /run/gatemole/gatemoled.sock \
-  --namespace payments \
-  --id tx:pay-1842 \
-  --actor operator:payments-release \
-  --actor-kind operator
-```
-
-Release updates only the pre-existing allowed local Git ref with
-compare-and-swap. Gatemole does not push or merge a remote pull request in the
-current profile. The trust setup is described in the
-[production operations guide](PRODUCTION.md).
-
-## 4. Illustrative deployment pattern: networkless migration generation
+## 3. Illustrative deployment pattern: networkless migration generation
 
 A schema team can run a deterministic migration generator without any model
 authority:
@@ -357,7 +524,7 @@ the detached worktree, but it receives no database credentials and cannot
 apply the migration to production. Review, verification and release operate on
 the exact generated Git effects.
 
-## 5. Planned multi-system examples
+## 4. Planned multi-system examples
 
 The accounts-payable scenario—create vendor, change bank details, approve an
 invoice and transfer money—is the intended multi-system Agent OS direction,

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -35,6 +35,10 @@ their existing CLI behavior.
   lower-level run record; they do not control a running production OCI
   workload. Raw run creation and grant installation remain embedded/unbound
   compatibility operations and configured `gatemoled` rejects them.
+- Paired execution start, settlement and startup recovery across the admitted
+  run and transaction ledgers. The run binds the exact active execution, then
+  cumulatively charges elapsed wall time and verified model usage when that
+  execution finishes or is recovered.
 - Execution-contract compilation into stable, expiring capability grants.
 - Typed filesystem read/write actions with output limits and workspace
   containment.

--- a/docs/PRODUCTION.md
+++ b/docs/PRODUCTION.md
@@ -598,10 +598,12 @@ acceptable:
   execution authority. The mediated filesystem API cannot access `.git` or
   `.gatemole` control state.
 - OCI launch revalidates live admission authority and atomically pins the
-  admitted run and transaction heads while recording execution start before
-  any workload. Run and transaction execution events are not yet advanced and
-  settled as one paired lifecycle, and run budget usage is not yet durably
-  charged. That is the remaining OS-3 boundary.
+  admitted run and transaction heads while recording the same execution start
+  in both ledgers before any workload. Settlement and restart recovery finish
+  both sides atomically, clear the run's active binding, and durably charge
+  elapsed wall time plus verified model-call/token usage. Tool/cost accounting,
+  narrower data authority, active workload interruption, and the mediated
+  connector path remain OS-3 boundaries.
 - No claim of universal rollback. The implemented commit primitive is an
   atomic, version-checked Git-ref update.
 

--- a/docs/PRODUCT_VALIDATION.md
+++ b/docs/PRODUCT_VALIDATION.md
@@ -190,15 +190,15 @@ The repository proves meaningful ingredients:
 - credential-isolated model access;
 - compare-and-swap local Git publication.
 
-It does not yet prove the intended Runtime enforcement boundary:
+It does not yet prove the complete intended Runtime enforcement boundary:
 
 - atomic admission binds the retained task, a content-digest
   `ExecutionContract`, a durable `AgentRun`, initial capability grants and the
-  transaction; production OCI launch now reloads that authority and atomically
-  pins the run and transaction heads, but it does not yet advance the run
-  lifecycle or durably charge budget usage;
-- lineage, durable budgets, narrower data boundaries and release scope are not
-  yet enforced as one synchronized execution lifecycle;
+  transaction; production OCI launch, settlement and restart recovery now pair
+  the run and transaction lifecycle and durably charge supported wall/model
+  usage;
+- lineage, tool/cost budgets, narrower data boundaries and release scope are
+  not yet enforced across the complete action lifecycle;
 - lifecycle controls do not yet interrupt a running production OCI workload;
 - there is no connector driver interface or external production connector;
 - sequence policy does not span transactions, sessions or identity lineage;

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -24,13 +24,18 @@ human intent + selected agent profile
   -> compare-and-swap update of an allowed local Git ref
 ```
 
-This is the transaction-ledger path, not yet one fully paired execution
-lifecycle. Admission creates the associated `AgentRun`, and launch revalidates
-its live authority and atomically pins both ledger heads. The OCI workload
-currently advances and settles only the transaction ledger; the run lifecycle
-and durable budget usage are not yet advanced with it. A metadata cancellation
-before launch can prevent launch, but Gatemole does not yet provide a supervisor
-that interrupts an already-running production workload.
+Admission creates the associated `AgentRun`, and launch revalidates its live
+authority before atomically starting the same execution in the run and
+transaction ledgers. Settlement atomically finishes both sides: success leaves
+the run `waiting_for_event`, while failed, interrupted and start-failed work
+leaves it `waiting_for_agent` for an explicit retry. Elapsed wall time and
+verified model-call/token usage are charged cumulatively to the run, including
+restart recovery, with each charge bounded by the remaining hard limit. The
+transaction receipt retains the raw timestamps and counters when a charge
+saturates. A metadata cancellation before launch can prevent launch, but
+Gatemole does not yet provide a supervisor that interrupts an
+already-running production workload. Tool/cost accounting and mediated remote
+actions also remain outside this local-Git profile.
 
 Gatemole can create and publish the prepared commit to an allowed local Git ref.
 It does not push to a remote, merge a pull request, deploy software, or execute
@@ -86,9 +91,17 @@ selected pull-never image. A failed preflight creates neither admission
 authority nor a worktree. After a successful preflight, `gatemole run` creates and
 starts the transaction, creates its isolated worktree, runs the agent, freezes
 the exact Git effects, and performs sequence validation. It prints the
-generated transaction ID. Inspect it with:
+generated transaction ID. Inspect its readable status, evidence identifiers and
+exact frozen patch with:
 
 ```sh
+gatemole --repo /path/to/service review <transaction-id> \
+  --namespace payments
+
+gatemole --repo /path/to/service diff <transaction-id> \
+  --namespace payments
+
+# Advanced lifecycle/debugging views:
 gatemole --repo /path/to/service status <transaction-id> \
   --namespace payments
 
@@ -98,6 +111,59 @@ gatemole --repo /path/to/service tx effects \
 gatemole --repo /path/to/service tx events \
   --namespace payments --id <transaction-id>
 ```
+
+The diff route re-inspects the private worktree, reconstructs the immutable Git
+tree and refuses output unless both the staged-state and normalized effect-set
+digests still match the authoritative transaction. The response binds the
+namespace, transaction, attempt, event sequence, base revision, tree revision
+and patch digest. The CLI validates that metadata and the raw patch body before
+printing it. `gatemole --json diff ...` exposes the body as `patch_base64` with
+the same metadata.
+
+The [PAY-1842 operator example](EXAMPLES.md#real-life-use-case-govern-an-ai-hotfix)
+shows why a team would put its real coding agent behind this lifecycle. The
+checked-in script below is the separate, deterministic acceptance proof for a
+failed attempt, daemon restart, resumed patch and passing Go regression test:
+
+```sh
+scripts/gatemolepairedexecutiondemo.sh
+```
+
+It uses stable IDs `tx:pay-1842` and `run:pay-1842`. On a long-lived Runtime,
+the equivalent run-side inspection is:
+
+```sh
+gatemole --repo /path/to/payments-api --json kernel run get \
+  --socket /path/to/gatemoled.sock \
+  --namespace payments --id run:pay-1842 \
+  | jq '.run | {
+      state,
+      active_execution_id: (.active_execution_id // null),
+      budget_usage
+    }'
+
+gatemole --repo /path/to/payments-api --json kernel run events \
+  --socket /path/to/gatemoled.sock \
+  --namespace payments --id run:pay-1842 \
+  | jq '[.[]
+      | select(.type | startswith("run.execution_"))
+      | {sequence, type, execution_id: .payload.execution_id,
+         status: .payload.status, usage: .payload.usage}]'
+
+gatemole --repo /path/to/payments-api --json tx get \
+  --socket /path/to/gatemoled.sock \
+  --namespace payments --id tx:pay-1842 \
+  | jq '[.executions[] | {id, status, started_at, completed_at}]'
+```
+
+The proof produces four run events: start/failed for the crashed attempt, then
+start/succeeded for the retry. The final projection is `waiting_for_event` with
+no `active_execution_id`; both transaction receipts remain immutable and
+`budget_usage.wall_time_seconds` is their cumulative charge. On daemon-crash
+recovery, a running attempt instead settles as `interrupted` and the run becomes
+`waiting_for_agent`. Model calls left in flight at restart are finalized as
+`unknown` before their conservative token charge is applied. The complete
+scenario and representative output are in [Runtime examples](EXAMPLES.md#2-self-contained-recovery-proof-pay-1842-agent-crash).
 
 `gatemole runtime init` writes `.gatemole/agent-profiles.json` using the
 [public profile schema](../schemas/gatemole.agent_profiles.v0.schema.json). The
@@ -252,9 +318,13 @@ gatemole --repo /path/to/service approve <transaction-id> \
   --approver human:alice \
   --class security-reviewer
 
-gatemole --repo /path/to/service release <transaction-id> \
+gatemole --repo /path/to/service apply <transaction-id> \
   --namespace payments
 ```
+
+`apply` invokes the same release operation as `release`; it still requires the
+prepared commit plan, exact signed approval package and distinct release
+authority.
 
 These commands require the hardened daemon identity, verifier, approval and
 release configuration described in
@@ -278,13 +348,14 @@ The raw `POST /v0/namespaces/{namespace}/transactions` creation route exists
 only for embedded, unbound compatibility servers and `gatemoled` rejects it.
 Existing-transaction operations such as `start|worktree|stage|validate` remain
 available for connector development, recovery and debugging. They do not
-replace the primary task-oriented path. Abort
-discards an unreleased isolated worktree after execution; it is not a live
+replace the primary task-oriented path. The task-oriented `reject` command is
+an alias over `tx abort`: it discards an unreleased isolated worktree after
+execution; it is not a live
 workload-cancellation command:
 
 ```sh
-gatemole --repo /path/to/service tx abort \
-  --namespace payments --id <transaction-id>
+gatemole --repo /path/to/service reject <transaction-id> \
+  --namespace payments
 ```
 
 ## Attempts and recovery

--- a/docs/architecture/ADR-003-durable-execution-supervisor.md
+++ b/docs/architecture/ADR-003-durable-execution-supervisor.md
@@ -1,0 +1,200 @@
+# ADR-003: Durable Execution Supervisor and Circuit Breaker
+
+- Status: accepted for the next implementation slice
+- Date: 2026-08-09
+- Depends on: ADR-002 and paired execution settlement
+- Owners: Gatemole maintainers
+
+## Context
+
+Gatemole now admits a task atomically and records one agent execution in both
+the run and transaction ledgers before starting its OCI workload. Normal exit
+and daemon-start recovery settle that same execution in both ledgers and charge
+the supported budgets.
+
+The workload is not yet supervised. `runAgentExecution` owns the process inside
+one synchronous HTTP handler, derives its cancellation context from that
+request, and holds the transaction mutex until the process and model broker
+finish. The public client waits for the full timeout. The lower-level run
+`cancel` command cannot move an active run out of `running`, and changing that
+metadata alone would not stop the named OCI container or broker.
+
+Startup recovery is intentionally safe but coarse. It removes the deterministic
+agent container and broker, verifies any retained model receipts, and settles a
+still-running execution as `interrupted`. There is no durable desired workload
+state, execution lease, or reconciler that can distinguish an accepted cancel
+from a lost client connection.
+
+Adding `watch` as a polling loop without changing these ownership semantics
+would improve display but would not satisfy OS-4. Adding a kill endpoint backed
+only by an in-memory `context.CancelFunc` would lose cancellation across daemon
+restart and could race normal settlement.
+
+## Decision
+
+The Runtime will introduce a daemon-owned, durable supervisor before connector
+work. The first implementation remains single-node and local-Git, but execution
+ownership moves out of the request handler.
+
+### Durable supervised-execution record
+
+Each admitted workload has one internal record bound to:
+
+- namespace, transaction ID, run ID, attempt and execution ID;
+- task, command, image, Runtime-configuration and stage-binding digests;
+- deterministic agent container, broker container and broker network names;
+- authority deadline and the run/transaction heads accepted at submission;
+- desired state: `running` or `cancelled`;
+- observed state: `pending`, `starting`, `running`, `stopping`, `settled` or
+  `unknown`;
+- lease owner, monotonically increasing lease epoch and lease expiry;
+- accepted, started, heartbeat, cancel-requested and settled timestamps; and
+- terminal process status plus receipt/evidence references when known.
+
+This is operational state, not a second authority ledger. The hash-chained run
+and transaction events remain authoritative for admission, execution and
+business outcome.
+
+### Submission and launch
+
+`POST .../executions` validates live authority and idempotency, then atomically:
+
+1. appends the paired execution-start events;
+2. creates the exact supervised-execution record in `pending`; and
+3. commits no workload effect before both writes succeed.
+
+It returns `202 Accepted` with the existing transaction, run and execution IDs.
+Repeating the same submission returns those IDs; changed immutable input
+conflicts. A supervisor loop claims the record with a compare-and-swap lease,
+revalidates live authority immediately before launch, and starts the
+deterministically named broker and agent containers. A lease epoch may launch
+that execution at most once.
+
+The current synchronous `gatemole run` becomes a client composition: submit,
+then watch to a terminal execution result. A `--detach` form returns immediately
+after durable acceptance. The old request-owned execution path is removed after
+the composition passes compatibility tests; it does not remain as a bypass.
+
+### Watch
+
+`gatemole watch TRANSACTION_ID` reads the authoritative transaction, run and
+execution projections and advances only by explicit event cursors. The first
+slice may use bounded polling with backoff; a server-side streaming transport is
+not required. Output reconnects after client interruption without creating or
+settling work.
+
+Human output reports state changes and the terminal process receipt. JSON
+output uses versioned records and exact IDs. A watcher timing out or
+disconnecting never changes desired execution state.
+
+### Cancel and revocation
+
+`gatemole cancel TRANSACTION_ID` is not a run-state shortcut. It submits an
+idempotent desired-state change bound to the active execution ID and current
+event cursor. The request can commit while the workload is running because the
+supervisor does not hold the transaction mutex across process execution.
+
+After accepting cancellation, the supervisor:
+
+1. prevents any not-yet-started workload from launching;
+2. cancels the local process context and force-removes the exact agent and
+   broker containers;
+3. confirms their absence and finalizes available model receipts;
+4. records one terminal interrupted/cancelled execution settlement in both
+   ledgers; and
+5. moves the run to `cancelled` and the transaction to a non-releasable aborted
+   outcome in the same durable settlement boundary.
+
+Cancel racing normal exit has one winner. If terminal settlement commits first,
+cancel returns the terminal representation and performs no kill. If cancel
+commits first, later successful process exit cannot restore release authority.
+Repeated cancel is idempotent.
+
+Authority expiry or explicit revocation uses the same desired-cancel path. No
+new effect may execute after the cancellation cursor commits. The supervisor
+must recheck desired state and live authority before each future mediated
+action; OCI termination alone is not the eventual connector circuit breaker.
+
+### Lease and restart reconciliation
+
+Only one daemon may own an unexpired lease. Lease acquisition and renewal are
+SQLite compare-and-swap operations tied to the ledger's existing single-writer
+boundary. Losing a lease cancels local workload control and forbids terminal
+settlement by the stale owner.
+
+On restart, the supervisor enumerates nonterminal records before accepting new
+work:
+
+- `pending` plus desired `running`: claim and launch once;
+- desired `cancelled`: remove named resources and settle cancellation;
+- observed `starting` or `running`: inspect the deterministic container names,
+  remove them, reconcile model receipts and settle `interrupted`; and
+- an ambiguous inspection or cleanup result: mark `unknown`, block release and
+  require reconciliation rather than relaunching.
+
+The first slice does not reattach to a surviving container after daemon crash.
+Deterministic interruption is safer and satisfies one reconciled outcome.
+
+## Required store boundary
+
+The store needs one transaction that can settle the paired execution, persist
+terminal supervised state, clear the active run binding and, for accepted
+cancel, append the run-cancel and transaction-abort transitions. Implementing
+those as separate public mutations would recreate the divergence window that
+paired execution settlement removed.
+
+Supervisor state must be included in ledger health, backup/restore and startup
+integrity checks. Foreign transaction/run/execution bindings, a regressing
+lease epoch, duplicate active records or a terminal record without matching
+ledger settlement fail startup.
+
+## Acceptance gates
+
+OS-4 is not complete until automated fault injection proves all of the
+following:
+
+1. Repeating submission before, during and after launch starts one workload.
+2. Cancel accepted before launch starts no agent or broker.
+3. Cancel during execution removes both containers within a bounded interval,
+   settles both ledgers once and makes release impossible.
+4. Cancel racing natural success produces one declared winner and no mixed
+   run/transaction outcome.
+5. Client disconnect and watcher timeout do not cancel the workload.
+6. Daemon exit after every durable boundary restarts to one reconciled terminal
+   outcome without relaunching a previously started workload.
+7. Lease expiry prevents a stale supervisor from settling or launching.
+8. Authority expiry and revocation use the same kill path.
+9. `watch` resumes from an event cursor without omission or duplication.
+10. Race-detector and production OCI acceptance cover submit, watch, cancel,
+    shutdown and restart.
+
+## Implementation order
+
+1. Add the strict supervised-execution model, SQLite schema, integrity checks
+   and atomic paired-start/terminal store operations.
+2. Extract the current OCI/broker execution body into a supervisor worker with
+   injected launch, inspect, kill and clock seams.
+3. Start the reconciler before the HTTP listener and add deterministic fault
+   tests for leases, launch and settlement.
+4. Add asynchronous submit/status/cancel endpoints and client methods.
+5. Compose `gatemole run`, `watch` and `cancel` over those endpoints; retain the
+   exact transaction/evidence IDs used by `review`.
+6. Route the new paths through Runtime and production acceptance before
+   beginning OS-5 or OS-6.
+
+## Non-goals
+
+- Arbitrary process checkpointing or resuming a container after daemon crash.
+- Pretending `pause` can freeze an agent at any instruction; pause remains
+  unavailable until a declared safe boundary exists.
+- Remote scheduling, high availability or multi-tenant leases.
+- Connector dispatch, compensation or the Runtime action protocol.
+- Control Plane enrollment or fleet cancellation.
+
+## Consequences
+
+The HTTP API becomes responsive while agents run, and cancellation becomes a
+durable authority decision rather than process-local control. The cost is a new
+operational state machine and a larger atomic store boundary. That cost is paid
+before connectors because a remote effect path without durable workload
+control would widen, rather than close, the current enforcement gap.

--- a/docs/architecture/KERNEL_SEMANTICS.md
+++ b/docs/architecture/KERNEL_SEMANTICS.md
@@ -135,9 +135,11 @@ conditions and unimplemented budgets fail before workload creation.
 
 After preflight and non-workload preparation, launch is claimed in one SQLite
 transaction: the admitted run head and transaction head must still match the
-snapshot while `agent_execution.started` is appended. The authority deadline
-also bounds model-broker startup. A stale or expired plan therefore starts no
-broker or agent container.
+snapshot while `agent_execution.started` and `run.execution_started` bind the
+same execution ID and attempt. The run becomes `running` with that active
+execution before any workload starts. The authority deadline also bounds
+model-broker startup. A stale or expired plan therefore starts no broker or
+agent container.
 
 A transaction may retain multiple immutable execution receipts. Another launch
 is allowed only while the transaction is running and no execution is active.
@@ -146,8 +148,13 @@ eligible to freeze only after the latest execution in the active transaction
 attempt succeeds. Revision starts a new numbered attempt and archives the old
 mutable work rather than rewriting it.
 
-The claim does not yet advance and settle both lifecycle ledgers. That paired
-run/transaction mutation and durable usage charging are the next OS-3 step.
+Settlement is also one SQLite transaction. It appends the immutable transaction
+receipt and matching `run.execution_finished`, clears the active binding, and
+adds that execution's wall time plus verified model usage to cumulative run
+usage. Success moves the run to `waiting_for_event`; failed, interrupted and
+start-failed execution moves it to `waiting_for_agent`. Startup recovery uses
+the same paired primitive and finalizes unfinished model calls as `unknown`
+before applying their conservative charge.
 
 ## Action lifecycle
 

--- a/docs/architecture/NORTH_STAR_DEMO.md
+++ b/docs/architecture/NORTH_STAR_DEMO.md
@@ -10,11 +10,13 @@ runs an OCI agent. It then stages immutable local Git effects, validates their
 sequence, runs daemon-owned verification, binds signed approvals and publishes
 to an allowed local ref.
 
-The OCI workload does not yet advance that admitted run or consume its
-capabilities through the lower-level brokered action path. The roadmap's OS-3
-through OS-7 work closes that execution, supervision, connector and temporal
-policy gap before this document becomes an executable end-to-end acceptance
-test.
+The OCI workload now advances and settles the admitted run together with its
+transaction and charges supported wall/model usage, including restart
+recovery. It does not yet consume capabilities through the lower-level
+brokered action path, and lifecycle metadata does not interrupt an active OCI
+workload. The roadmap's remaining OS-3 through OS-7 work closes those
+supervision, connector and temporal-policy gaps before this document becomes
+an executable end-to-end acceptance test.
 
 ## Target claim
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -18,6 +18,55 @@ Gatemole does not decide how an agent reasons or writes code. The trusted local
 kernel, `gatemoled`, orchestrates sandboxed execution and owns authoritative
 transaction state, verification, policy decisions and commit coordination.
 
+## Why a team would use it
+
+Suppose incident `PAY-1842` causes a payments API to reject valid refresh
+tokens. The team already has a real coding agent, `payments-coder`, that can
+diagnose the bug, edit the Go service and run its authentication tests.
+
+Invoked directly in a checkout, that agent works inside the same boundary as
+the files, inherited network and credentials:
+
+```sh
+cd /srv/repos/payments-api
+payments-coder --task-file tickets/PAY-1842.md
+```
+
+The fix may be correct. The unresolved production questions are who
+independently records its exact effects, who verifies the exact candidate, who
+can approve it, who can release it and what survives a crash.
+
+Gatemole runs that **same agent** behind a daemon-owned transaction boundary:
+
+```sh
+gatemole --repo /srv/repos/payments-api run \
+  --socket /run/gatemole/gatemoled.sock \
+  --namespace payments \
+  --id tx:pay-1842 \
+  --run run:pay-1842 \
+  --require-enforcement-profile production \
+  --intent-file tickets/PAY-1842.md \
+  --agent payments-coder \
+  --model-provider openai
+```
+
+| Direct agent invocation | Same agent through Gatemole |
+| --- | --- |
+| Checkout or agent-specific sandbox | Daemon-created private Git worktree |
+| Provider access supplied to the worker | Transaction broker token; provider credential remains in `gatemoled` |
+| Transcript and later diff | Normalized effects, paired execution receipts and hash-chained events |
+| Worker commonly runs its own tests | Separately pinned verifier checks the exact frozen tree |
+| Approval and Git release are surrounding conventions | Signed exact approval package and a different release identity |
+| Recovery depends on the runner | Identical admission resumes durable state and retains failed/interrupted receipts |
+
+Some agent products provide their own sandbox or review UI. Gatemole's specific
+offer is that authority and evidence are owned by a separate, agent-independent
+kernel. It does not make the agent smarter and does not replace CI.
+
+The implemented release operation updates a pre-existing allowed local Git
+ref; remote pull requests and deployments are not implemented. Read the
+[complete PAY-1842 before/after and operator workflow](https://github.com/duriantaco/gatemole/blob/main/docs/EXAMPLES.md#real-life-use-case-govern-an-ai-hotfix).
+
 ## Product hierarchy
 
 - **Gatemole Developer Runtime** is the local product experience: run an existing
@@ -63,6 +112,11 @@ gatemole --repo /path/to/service doctor --agent coding-agent
 gatemole --repo /path/to/service run \
   --intent "Fix authentication without changing public behavior" \
   --agent coding-agent
+
+gatemole --repo /path/to/service review <transaction-id>
+
+# Print only the daemon-bound frozen patch:
+gatemole --repo /path/to/service diff <transaction-id>
 ```
 
 This development command creates the isolated worktree, runs the agent, freezes
@@ -76,6 +130,13 @@ before creating authority or a worktree. Admission then durably binds the
 Runtime ID and actual profile with the transaction. Doctor reports warnings for
 optional or intentionally stopped components and fails on broken configured
 requirements; it does not prove that every future task will succeed.
+
+`review` reports the authoritative state, exact effect and evidence IDs, and a
+digest-checked patch rendered from the frozen Git tree. After explicit
+verification, preparation and any required signed approval, `apply` invokes
+the existing release authority; `reject` aborts and discards the unreleased
+worktree. Neither command is a shortcut around policy, and `reject` is not live
+workload cancellation.
 
 The product `run`, transaction, low-level `kernel` and `action` CLI surfaces
 also send that exact Runtime ID on every daemon read and lifecycle call,
@@ -112,9 +173,8 @@ Production callers should add
 `--require-enforcement-profile production` to both `doctor` and `run`; a
 development daemon then fails preflight before task authority is created.
 
-For a runnable deterministic payments-service fixture, including building the
-agent image, starting `gatemoled`, inspecting effects and understanding why an
-authentication change requires approval, read the
+For the realistic payments incident, the full operator flow and optional
+deterministic acceptance fixtures, read the
 [Runtime examples guide](https://github.com/duriantaco/gatemole/blob/main/docs/EXAMPLES.md).
 
 Read the
@@ -127,8 +187,10 @@ before treating the runtime as an enforcement boundary.
 
 The supported deployment profile is one node and one security tenant on a
 dedicated trusted host. It uses daemon-owned, digest-pinned OCI workloads,
-immutable Git-tree verification, OIDC, logically independent signed approvals, a separate
-releaser and atomic publication to an allowed local Git ref.
+paired run/transaction execution settlement and recovery, durable supported
+budget charging, immutable Git-tree verification, OIDC, logically independent
+signed approvals, a separate releaser and atomic publication to an allowed
+local Git ref.
 
 It does not push or merge remote changes, deploy software, coordinate database
 or Kubernetes effects, isolate multiple tenants, expose a remote control API or

--- a/examples/codex-agent/Dockerfile
+++ b/examples/codex-agent/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:20-bookworm-slim
+
+ARG CODEX_VERSION=0.144.4
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends ca-certificates git \
+    && npm install --global "@openai/codex@${CODEX_VERSION}" \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY gatemole-codex-entrypoint.sh /usr/local/bin/gatemole-codex
+
+ENTRYPOINT ["/usr/local/bin/gatemole-codex"]

--- a/examples/codex-agent/gatemole-codex-entrypoint.sh
+++ b/examples/codex-agent/gatemole-codex-entrypoint.sh
@@ -1,0 +1,57 @@
+#!/bin/sh
+set -eu
+
+if [ "${GATEMOLE_RUNTIME_ROLE:-}" != "agent" ]; then
+  echo "gatemole-codex: GATEMOLE_RUNTIME_ROLE must be agent" >&2
+  exit 64
+fi
+if [ "${GATEMOLE_TASK_PATH:-}" != "/gatemole/task.json" ] ||
+  [ ! -r "$GATEMOLE_TASK_PATH" ]; then
+  echo "gatemole-codex: admitted task envelope is unavailable" >&2
+  exit 64
+fi
+if [ -z "${OPENAI_BASE_URL:-}" ] || [ -z "${OPENAI_API_KEY:-}" ]; then
+  echo "gatemole-codex: task has no admitted model-broker authority" >&2
+  exit 64
+fi
+
+model="gpt-5.6"
+if [ "$#" -gt 0 ]; then
+  if [ "$#" -ne 2 ] || [ "$1" != "--model" ] || [ -z "$2" ]; then
+    echo "usage: gatemole-codex [--model MODEL]" >&2
+    exit 64
+  fi
+  model="$2"
+fi
+
+intent="$(
+  node -e '
+    const fs = require("node:fs");
+    const task = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+    if (typeof task.intent !== "string" || task.intent.trim() === "") {
+      throw new Error("task intent is missing");
+    }
+    process.stdout.write(task.intent);
+  ' "$GATEMOLE_TASK_PATH"
+)"
+
+# Codex supports a per-exec API key and an OpenAI base-URL override. The API
+# key here is Gatemole's transaction token, not the upstream provider key.
+export CODEX_API_KEY="$OPENAI_API_KEY"
+export CODEX_HOME=/tmp/codex
+mkdir -p "$CODEX_HOME"
+
+# The inner sandbox is deliberately bypassed because this process is already
+# inside Gatemole's read-only, capability-dropped OCI boundary. Its only
+# writable mount is the transaction worktree and its only network peer is the
+# transaction-specific model broker.
+exec codex exec \
+  --ephemeral \
+  --dangerously-bypass-approvals-and-sandbox \
+  --ignore-user-config \
+  --ignore-rules \
+  --skip-git-repo-check \
+  --cd /workspace \
+  --model "$model" \
+  --config "openai_base_url=\"${OPENAI_BASE_URL}\"" \
+  "$intent"

--- a/examples/payments-api/README.md
+++ b/examples/payments-api/README.md
@@ -1,0 +1,8 @@
+# PAY-1842 comparison repository
+
+This intentionally broken service is the input to Gatemole's real-agent
+before/after walkthrough. The existing tests pass, but they do not cover the
+valid-refresh-token path or the access-token negative case. The human-owned
+ticket in `tickets/PAY-1842.md` defines the required fix and test coverage.
+
+Do not copy the implementation into a real authentication service.

--- a/examples/payments-api/package.json
+++ b/examples/payments-api/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gatemole-payments-api-example",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/examples/payments-api/src/auth/refresh-token.js
+++ b/examples/payments-api/src/auth/refresh-token.js
@@ -1,0 +1,9 @@
+export function acceptsRefreshToken(token) {
+  if (!token || token.revoked === true) {
+    return false;
+  }
+
+  // PAY-1842: this regression checks the access-token kind instead of the
+  // refresh-token kind, logging valid customers out when sessions renew.
+  return token.kind === "access";
+}

--- a/examples/payments-api/test/auth/refresh-token.test.js
+++ b/examples/payments-api/test/auth/refresh-token.test.js
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { acceptsRefreshToken } from "../../src/auth/refresh-token.js";
+
+test("rejects a missing token", () => {
+  assert.equal(acceptsRefreshToken(null), false);
+});
+
+test("rejects a revoked refresh token", () => {
+  assert.equal(
+    acceptsRefreshToken({ kind: "refresh", revoked: true }),
+    false,
+  );
+});

--- a/examples/payments-api/tickets/PAY-1842.md
+++ b/examples/payments-api/tickets/PAY-1842.md
@@ -1,0 +1,12 @@
+# PAY-1842: valid refresh tokens are rejected
+
+Customers are being logged out when their sessions renew.
+
+Update `acceptsRefreshToken` so that it:
+
+- accepts an unrevoked token whose `kind` is `refresh`;
+- rejects access tokens, revoked refresh tokens and missing tokens;
+- preserves the exported function name and call shape.
+
+Add focused regression cases to `test/auth/refresh-token.test.js` and run
+`npm test`. Do not change files outside `src/auth` and `test/auth`.

--- a/internal/gatemole/cli.go
+++ b/internal/gatemole/cli.go
@@ -52,8 +52,16 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 		return runtimeRunCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "status":
 		return transactionStatusCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "review":
+		return transactionReviewCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "diff":
+		return transactionDiffCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "approve":
 		return transactionApproveCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "apply":
+		return transactionApplyCommand(absRepo, rest[1:], common.json, stdout, stderr)
+	case "reject":
+		return transactionRejectCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "release":
 		return transactionReleaseCommand(absRepo, rest[1:], common.json, stdout, stderr)
 	case "kernel":
@@ -884,10 +892,12 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "  doctor [--agent NAME] [--namespace NS] [--require-enforcement-profile development|production] [--runtime-engine ENGINE] [--agent-profiles FILE] [--socket FILE]")
 	fmt.Fprintln(out, "  run [--namespace NS] [--require-enforcement-profile development|production] (--intent TEXT | --intent-file FILE) (--agent NAME [-- AGENT_ARG...] | --image IMAGE -- COMMAND [ARG...])")
 	fmt.Fprintln(out, "  status ID [--namespace NS]")
+	fmt.Fprintln(out, "  review|diff ID [--namespace NS]")
 	fmt.Fprintln(out, "  approve ID [--namespace NS] --key FILE --key-id ID --approver ID --class CLASS")
+	fmt.Fprintln(out, "  apply|reject ID [--namespace NS]")
 	fmt.Fprintln(out, "  release ID [--namespace NS]")
 	fmt.Fprintln(out, "  tx create (development-only manual Runtime-bound admission)")
-	fmt.Fprintln(out, "  tx start|worktree|stage|validate|verify|prepare|get|list|effects|events|abort (advanced transaction lifecycle)")
+	fmt.Fprintln(out, "  tx start|worktree|stage|validate|verify|prepare|get|review|diff|list|effects|events|abort (advanced transaction lifecycle)")
 	fmt.Fprintln(out, "  kernel run get|list|events|transition|pause|resume|cancel (low-level run lifecycle)")
 	fmt.Fprintln(out, "  kernel run create|grant (embedded/unbound compatibility only; gatemoled rejects them)")
 	fmt.Fprintln(out, "  contracts <command> (optional release-contract verification module)")

--- a/internal/gatemole/cli.go
+++ b/internal/gatemole/cli.go
@@ -20,9 +20,16 @@ func Main(args []string, stdout io.Writer, stderr io.Writer) int {
 		fmt.Fprintln(stderr, err)
 		return 2
 	}
+	if handled, code := renderRequestedHelp(rest, stdout, stderr); handled {
+		return code
+	}
 	if len(rest) == 0 {
 		usage(stderr)
 		return 2
+	}
+	if rest[0] == "version" ||
+		(len(rest) == 1 && (rest[0] == "--version" || rest[0] == "-V")) {
+		return versionCommand(rest[1:], common.json, stdout, stderr)
 	}
 	absRepo, err := filepath.Abs(common.repo)
 	if err != nil {
@@ -887,6 +894,7 @@ func usage(out io.Writer) {
 	fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--manifest FILE] [--json] <command>")
 	fmt.Fprintln(out, "")
 	fmt.Fprintln(out, "commands:")
+	fmt.Fprintln(out, "  version")
 	fmt.Fprintln(out, "  daemon [--db FILE] [--socket FILE] [--transaction-root DIR] [--runtime-profile development|production]")
 	fmt.Fprintln(out, "  runtime init [--agent NAME --image IMAGE@sha256:DIGEST --source-digest sha256:DIGEST -- COMMAND [ARG...]]")
 	fmt.Fprintln(out, "  doctor [--agent NAME] [--namespace NS] [--require-enforcement-profile development|production] [--runtime-engine ENGINE] [--agent-profiles FILE] [--socket FILE]")

--- a/internal/gatemole/cli_discovery.go
+++ b/internal/gatemole/cli_discovery.go
@@ -1,0 +1,196 @@
+package gatemole
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"runtime"
+	"runtime/debug"
+	"strings"
+)
+
+const cliVersionSchema = "gatemole.cli_version.v1"
+
+// These values may be set by release builds with -ldflags -X. Development
+// builds fall back to the module and VCS metadata embedded by the Go tool.
+var (
+	buildVersion = "dev"
+	buildCommit  = ""
+)
+
+type cliVersionInfo struct {
+	Schema    string `json:"schema"`
+	Version   string `json:"version"`
+	Commit    string `json:"commit,omitempty"`
+	Dirty     bool   `json:"dirty"`
+	GoVersion string `json:"go_version"`
+}
+
+// renderRequestedHelp handles discovery before any repository or Runtime state
+// is inspected. It deliberately stops looking at the command separator so an
+// agent may still receive -h or --help as an argument.
+func renderRequestedHelp(args []string, stdout, stderr io.Writer) (bool, int) {
+	if len(args) == 0 {
+		return false, 0
+	}
+	if args[0] == "-h" || args[0] == "--help" {
+		usage(stdout)
+		return true, 0
+	}
+	if args[0] == "help" {
+		if len(args) == 1 {
+			usage(stdout)
+			return true, 0
+		}
+		if len(args) != 2 {
+			fmt.Fprintln(stderr, "help accepts at most one command")
+			return true, 2
+		}
+		if !renderCommandHelp(args[1], stdout) {
+			fmt.Fprintf(stderr, "unknown help topic %q\n", args[1])
+			return true, 2
+		}
+		return true, 0
+	}
+	if !helpFlagBeforeSeparator(args[1:]) {
+		return false, 0
+	}
+	if !renderCommandHelp(args[0], stdout) {
+		return false, 0
+	}
+	return true, 0
+}
+
+func helpFlagBeforeSeparator(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		if arg == "-h" || arg == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func renderCommandHelp(command string, out io.Writer) bool {
+	switch command {
+	case "daemon":
+		daemonUsage(out)
+	case "runtime":
+		runtimeUsage(out)
+	case "doctor":
+		runtimeDoctorUsage(out)
+	case "run":
+		runtimeRunUsage(out)
+	case "status", "review", "diff", "approve", "apply", "reject", "release":
+		transactionAliasUsage(command, out)
+	case "tx":
+		transactionUsage(out)
+	case "kernel":
+		kernelUsage(out)
+	case "contracts":
+		contractsUsage(out)
+	case "action":
+		actionUsage(out)
+	case "version":
+		versionUsage(out)
+	case "try", "init", "bootstrap", "compile", "intent", "ir", "plan",
+		"artifacts", "spec", "contract", "manifest", "junit", "policy",
+		"verify", "gate", "evidence", "approval", "identity":
+		// These compatibility and Contracts commands do not yet have isolated
+		// usage renderers. Root help still gives a state-independent entry point.
+		usage(out)
+	default:
+		return false
+	}
+	return true
+}
+
+func versionCommand(args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	if len(args) != 0 {
+		fmt.Fprintf(stderr, "version: unexpected argument %q\n", args[0])
+		versionUsage(stderr)
+		return 2
+	}
+	info := currentCLIVersion()
+	if jsonOut {
+		data, err := json.MarshalIndent(info, "", "  ")
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		fmt.Fprintln(stdout, string(data))
+		return 0
+	}
+	commit := info.Commit
+	if commit == "" {
+		commit = "unknown"
+	}
+	if info.Dirty {
+		commit += "+dirty"
+	}
+	fmt.Fprintf(stdout, "gatemole %s (commit %s, %s)\n", info.Version, commit, info.GoVersion)
+	return 0
+}
+
+func currentCLIVersion() cliVersionInfo {
+	info := cliVersionInfo{
+		Schema:    cliVersionSchema,
+		Version:   strings.TrimSpace(buildVersion),
+		Commit:    strings.TrimSpace(buildCommit),
+		GoVersion: runtime.Version(),
+	}
+	if info.Version == "" {
+		info.Version = "dev"
+	}
+	if build, ok := debug.ReadBuildInfo(); ok {
+		if info.Version == "dev" && build.Main.Version != "" && build.Main.Version != "(devel)" {
+			info.Version = build.Main.Version
+		}
+		for _, setting := range build.Settings {
+			switch setting.Key {
+			case "vcs.revision":
+				if info.Commit == "" {
+					info.Commit = setting.Value
+				}
+			case "vcs.modified":
+				info.Dirty = setting.Value == "true"
+			}
+		}
+	}
+	return info
+}
+
+func versionUsage(out io.Writer) {
+	fmt.Fprintln(out, "usage: gatemole [--json] version")
+}
+
+func daemonUsage(out io.Writer) {
+	fmt.Fprintln(out, "usage: gatemole [--repo DIR] daemon [options]")
+	flags, _ := newDaemonFlagSet("", out)
+	flags.PrintDefaults()
+}
+
+func runtimeDoctorUsage(out io.Writer) {
+	fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] doctor [--agent NAME] [--namespace NS] [--require-enforcement-profile development|production] [--runtime-engine ENGINE] [--agent-profiles FILE] [--socket FILE] [--timeout DURATION]")
+}
+
+func transactionAliasUsage(command string, out io.Writer) {
+	switch command {
+	case "status":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] status ID [--namespace NS] [--socket FILE]")
+	case "review":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] review ID [--namespace NS] [--socket FILE]")
+	case "diff":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] diff ID [--namespace NS] [--socket FILE]")
+	case "approve":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] approve ID [--namespace NS] --key FILE --key-id ID --approver ID --class CLASS [--decision approve|reject|revise]")
+	case "apply":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] apply ID [--namespace NS] [--socket FILE] [--actor ID] [--actor-kind KIND]")
+	case "reject":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] reject ID [--namespace NS] [--socket FILE] [--actor ID] [--actor-kind KIND]")
+	case "release":
+		fmt.Fprintln(out, "usage: gatemole [--repo DIR] [--json] release ID [--namespace NS] [--socket FILE] [--actor ID] [--actor-kind KIND]")
+	}
+}

--- a/internal/gatemole/cli_discovery_test.go
+++ b/internal/gatemole/cli_discovery_test.go
@@ -1,0 +1,111 @@
+package gatemole
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestHelpIsSuccessfulAndDoesNotRequireRepositoryState(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "does-not-exist")
+	for _, args := range [][]string{
+		{"--repo", repo, "--help"},
+		{"--repo", repo, "help"},
+		{"--repo", repo, "help", "run"},
+		{"--repo", repo, "daemon", "--help"},
+		{"--repo", repo, "run", "--help"},
+		{"--repo", repo, "runtime", "--help"},
+		{"--repo", repo, "doctor", "-h"},
+		{"--repo", repo, "review", "--help"},
+		{"--repo", repo, "diff", "--help"},
+		{"--repo", repo, "apply", "--help"},
+		{"--repo", repo, "reject", "--help"},
+		{"--repo", repo, "tx", "effects", "--help"},
+	} {
+		t.Run(strings.Join(args[2:], "_"), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := Main(args, &stdout, &stderr); code != 0 {
+				t.Fatalf("help returned %d; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+			}
+			if !strings.Contains(stdout.String(), "usage: gatemole") {
+				t.Fatalf("help did not write usage to stdout: %q", stdout.String())
+			}
+			if stderr.Len() != 0 {
+				t.Fatalf("help wrote stderr: %q", stderr.String())
+			}
+		})
+	}
+}
+
+func TestDaemonHelpIncludesProductionControls(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "does-not-exist")
+	var stdout, stderr bytes.Buffer
+	if code := Main([]string{"--repo", repo, "daemon", "--help"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("daemon help returned %d; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	for _, flagName := range []string{
+		"-allowed-images",
+		"-approval-trust",
+		"-identity-trust",
+		"-model-broker-policy",
+		"-verifier-profiles",
+	} {
+		if !strings.Contains(stdout.String(), flagName) {
+			t.Errorf("daemon help omitted %s: %q", flagName, stdout.String())
+		}
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("daemon help wrote stderr: %q", stderr.String())
+	}
+}
+
+func TestHelpAfterCommandSeparatorRemainsAnAgentArgument(t *testing.T) {
+	if helpFlagBeforeSeparator([]string{"--", "--help"}) {
+		t.Fatal("agent --help after the command separator was treated as CLI help")
+	}
+	if !helpFlagBeforeSeparator([]string{"--intent", "test", "--help", "--", "agent"}) {
+		t.Fatal("CLI --help before the command separator was not detected")
+	}
+}
+
+func TestVersionIsStateIndependentAndMachineReadable(t *testing.T) {
+	repo := filepath.Join(t.TempDir(), "does-not-exist")
+	var stdout, stderr bytes.Buffer
+	if code := Main([]string{"--repo", repo, "--json", "version"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("version returned %d; stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+	var info cliVersionInfo
+	if err := json.Unmarshal(stdout.Bytes(), &info); err != nil {
+		t.Fatalf("decode version JSON: %v; output=%q", err, stdout.String())
+	}
+	if info.Schema != cliVersionSchema || info.Version == "" || info.GoVersion == "" {
+		t.Fatalf("incomplete version information: %+v", info)
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("version wrote stderr: %q", stderr.String())
+	}
+}
+
+func TestConventionalVersionAliasesAreSupported(t *testing.T) {
+	for _, argument := range []string{"--version", "-V"} {
+		var stdout, stderr bytes.Buffer
+		if code := Main([]string{argument}, &stdout, &stderr); code != 0 {
+			t.Fatalf("%s returned %d; stdout=%q stderr=%q", argument, code, stdout.String(), stderr.String())
+		}
+		if !strings.HasPrefix(stdout.String(), "gatemole ") || stderr.Len() != 0 {
+			t.Fatalf("%s output: stdout=%q stderr=%q", argument, stdout.String(), stderr.String())
+		}
+	}
+}
+
+func TestVersionRejectsUnexpectedArguments(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := Main([]string{"version", "extra"}, &stdout, &stderr); code != 2 {
+		t.Fatalf("version returned %d, want 2", code)
+	}
+	if stdout.Len() != 0 || !strings.Contains(stderr.String(), "unexpected argument") {
+		t.Fatalf("unexpected output: stdout=%q stderr=%q", stdout.String(), stderr.String())
+	}
+}

--- a/internal/gatemole/daemon_cli.go
+++ b/internal/gatemole/daemon_cli.go
@@ -14,33 +14,55 @@ import (
 	"github.com/duriantaco/gatemole/internal/kernel/daemon"
 )
 
-func daemonCommand(repo string, args []string, stdout io.Writer, stderr io.Writer) int {
+type daemonFlagValues struct {
+	databasePath             string
+	socketPath               string
+	transactionRoot          string
+	runtimeProfile           string
+	allowedImages            string
+	approvalTrust            string
+	allowedGitRefs           string
+	runtimeEngine            string
+	verifierUID              int
+	verifierGID              int
+	modelBrokerImage         string
+	modelBrokerPolicy        string
+	modelTokenEnv            string
+	identityTrust            string
+	verifierProfiles         string
+	allowUnsafeHostExecution bool
+}
+
+func newDaemonFlagSet(repo string, output io.Writer) (*flag.FlagSet, *daemonFlagValues) {
 	flags := flag.NewFlagSet("daemon", flag.ContinueOnError)
-	flags.SetOutput(stderr)
-	databasePath := flags.String("db", filepath.Join(repo, ".gatemole", "kernel.db"), "SQLite kernel database path")
-	socketPath := flags.String("socket", defaultKernelSocket(repo), "Unix socket path")
-	transactionRoot := flags.String("transaction-root", "", "isolated transaction worktree root (defaults to a repository-scoped per-user directory)")
-	runtimeProfile := flags.String("runtime-profile", "development", "execution policy: development or production")
-	allowedImages := flags.String("allowed-images", "", "comma-separated digest-pinned OCI images allowed in production")
-	approvalTrust := flags.String("approval-trust", "", "JSON file containing trusted approval public keys")
-	allowedGitRefs := flags.String("allowed-git-refs", "", "comma-separated Git branch ref patterns allowed for release")
-	runtimeEngine := flags.String("runtime-engine", "docker", "daemon-owned OCI engine executable")
-	verifierUID := flags.Int("verifier-uid", os.Getuid(), "non-root UID for daemon-run agent, verifier, and broker workloads")
-	verifierGID := flags.Int("verifier-gid", os.Getgid(), "non-root GID for daemon-run agent, verifier, and broker workloads")
-	modelBrokerImage := flags.String("model-broker-image", "", "digest-pinned Gatemole model broker OCI image")
-	modelBrokerPolicy := flags.String("model-broker-policy", "", "model broker policy JSON")
-	modelTokenEnv := flags.String("model-provider-token-env", "OPENAI_API_KEY", "daemon environment containing the provider bearer credential")
-	identityTrust := flags.String("identity-trust", "", "OIDC issuer/JWKS trust document")
-	verifierProfiles := flags.String(
-		"verifier-profiles",
-		"",
-		"strict daemon-owned verifier profile JSON",
-	)
-	allowUnsafeHostExecution := flags.Bool(
+	flags.SetOutput(output)
+	values := &daemonFlagValues{}
+	flags.StringVar(&values.databasePath, "db", filepath.Join(repo, ".gatemole", "kernel.db"), "SQLite kernel database path")
+	flags.StringVar(&values.socketPath, "socket", defaultKernelSocket(repo), "Unix socket path")
+	flags.StringVar(&values.transactionRoot, "transaction-root", "", "isolated transaction worktree root (defaults to a repository-scoped per-user directory)")
+	flags.StringVar(&values.runtimeProfile, "runtime-profile", "development", "execution policy: development or production")
+	flags.StringVar(&values.allowedImages, "allowed-images", "", "comma-separated digest-pinned OCI images allowed in production")
+	flags.StringVar(&values.approvalTrust, "approval-trust", "", "JSON file containing trusted approval public keys")
+	flags.StringVar(&values.allowedGitRefs, "allowed-git-refs", "", "comma-separated Git branch ref patterns allowed for release")
+	flags.StringVar(&values.runtimeEngine, "runtime-engine", "docker", "daemon-owned OCI engine executable")
+	flags.IntVar(&values.verifierUID, "verifier-uid", os.Getuid(), "non-root UID for daemon-run agent, verifier, and broker workloads")
+	flags.IntVar(&values.verifierGID, "verifier-gid", os.Getgid(), "non-root GID for daemon-run agent, verifier, and broker workloads")
+	flags.StringVar(&values.modelBrokerImage, "model-broker-image", "", "digest-pinned Gatemole model broker OCI image")
+	flags.StringVar(&values.modelBrokerPolicy, "model-broker-policy", "", "model broker policy JSON")
+	flags.StringVar(&values.modelTokenEnv, "model-provider-token-env", "OPENAI_API_KEY", "daemon environment containing the provider bearer credential")
+	flags.StringVar(&values.identityTrust, "identity-trust", "", "OIDC issuer/JWKS trust document")
+	flags.StringVar(&values.verifierProfiles, "verifier-profiles", "", "strict daemon-owned verifier profile JSON")
+	flags.BoolVar(
+		&values.allowUnsafeHostExecution,
 		"allow-unsafe-host-execution",
 		false,
 		"development only: allow the CLI to supervise an unenforced host process",
 	)
+	return flags, values
+}
+
+func daemonCommand(repo string, args []string, stdout io.Writer, stderr io.Writer) int {
+	flags, values := newDaemonFlagSet(repo, stderr)
 	if err := flags.Parse(args); err != nil {
 		return 2
 	}
@@ -48,55 +70,55 @@ func daemonCommand(repo string, args []string, stdout io.Writer, stderr io.Write
 		fmt.Fprintf(stderr, "daemon: unexpected argument %q\n", flags.Arg(0))
 		return 2
 	}
-	if !filepath.IsAbs(*databasePath) {
-		*databasePath = filepath.Join(repo, *databasePath)
+	if !filepath.IsAbs(values.databasePath) {
+		values.databasePath = filepath.Join(repo, values.databasePath)
 	}
-	if !filepath.IsAbs(*socketPath) {
-		*socketPath = filepath.Join(repo, *socketPath)
+	if !filepath.IsAbs(values.socketPath) {
+		values.socketPath = filepath.Join(repo, values.socketPath)
 	}
 	var err error
-	*transactionRoot, err = daemonTransactionRoot(
+	values.transactionRoot, err = daemonTransactionRoot(
 		repo,
-		*transactionRoot,
+		values.transactionRoot,
 		daemonFlagWasSet(flags, "transaction-root"),
 	)
 	if err != nil {
 		fmt.Fprintln(stderr, err)
 		return 1
 	}
-	if *approvalTrust != "" && !filepath.IsAbs(*approvalTrust) {
-		*approvalTrust = filepath.Join(repo, *approvalTrust)
+	if values.approvalTrust != "" && !filepath.IsAbs(values.approvalTrust) {
+		values.approvalTrust = filepath.Join(repo, values.approvalTrust)
 	}
-	if *modelBrokerPolicy != "" && !filepath.IsAbs(*modelBrokerPolicy) {
-		*modelBrokerPolicy = filepath.Join(repo, *modelBrokerPolicy)
+	if values.modelBrokerPolicy != "" && !filepath.IsAbs(values.modelBrokerPolicy) {
+		values.modelBrokerPolicy = filepath.Join(repo, values.modelBrokerPolicy)
 	}
-	if *identityTrust != "" && !filepath.IsAbs(*identityTrust) {
-		*identityTrust = filepath.Join(repo, *identityTrust)
+	if values.identityTrust != "" && !filepath.IsAbs(values.identityTrust) {
+		values.identityTrust = filepath.Join(repo, values.identityTrust)
 	}
-	if *verifierProfiles != "" && !filepath.IsAbs(*verifierProfiles) {
-		*verifierProfiles = filepath.Join(repo, *verifierProfiles)
+	if values.verifierProfiles != "" && !filepath.IsAbs(values.verifierProfiles) {
+		values.verifierProfiles = filepath.Join(repo, values.verifierProfiles)
 	}
-	*runtimeEngine = repositoryExecutablePath(repo, *runtimeEngine)
+	values.runtimeEngine = repositoryExecutablePath(repo, values.runtimeEngine)
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
 	defer stop()
 	if err := daemon.Run(ctx, daemon.Config{
-		DatabasePath:             *databasePath,
-		SocketPath:               *socketPath,
+		DatabasePath:             values.databasePath,
+		SocketPath:               values.socketPath,
 		RepositoryRoot:           repo,
-		TransactionRoot:          *transactionRoot,
-		RuntimeProfile:           *runtimeProfile,
-		AllowedImages:            splitCommaValues(*allowedImages),
-		ApprovalTrustFile:        *approvalTrust,
-		AllowedGitRefs:           splitCommaValues(*allowedGitRefs),
-		RuntimeEngine:            *runtimeEngine,
-		VerifierUID:              *verifierUID,
-		VerifierGID:              *verifierGID,
-		ModelBrokerImage:         *modelBrokerImage,
-		ModelBrokerPolicy:        *modelBrokerPolicy,
-		ModelTokenEnv:            *modelTokenEnv,
-		IdentityTrustFile:        *identityTrust,
-		VerifierProfilesFile:     *verifierProfiles,
-		AllowUnsafeHostExecution: *allowUnsafeHostExecution,
+		TransactionRoot:          values.transactionRoot,
+		RuntimeProfile:           values.runtimeProfile,
+		AllowedImages:            splitCommaValues(values.allowedImages),
+		ApprovalTrustFile:        values.approvalTrust,
+		AllowedGitRefs:           splitCommaValues(values.allowedGitRefs),
+		RuntimeEngine:            values.runtimeEngine,
+		VerifierUID:              values.verifierUID,
+		VerifierGID:              values.verifierGID,
+		ModelBrokerImage:         values.modelBrokerImage,
+		ModelBrokerPolicy:        values.modelBrokerPolicy,
+		ModelTokenEnv:            values.modelTokenEnv,
+		IdentityTrustFile:        values.identityTrust,
+		VerifierProfilesFile:     values.verifierProfiles,
+		AllowUnsafeHostExecution: values.allowUnsafeHostExecution,
 		Stdout:                   stdout,
 	}); err != nil {
 		fmt.Fprintln(stderr, err)

--- a/internal/gatemole/transaction_cli.go
+++ b/internal/gatemole/transaction_cli.go
@@ -27,6 +27,7 @@ type transactionClient interface {
 	) (runtimepreflight.Result, error)
 	AdmitTask(context.Context, string, admission.Request) (admission.Result, error)
 	GetTransaction(context.Context, string, string) (transactionreducer.Projection, error)
+	GetTransactionDiff(context.Context, string, string) (kernelclient.TransactionDiffResult, error)
 	ListTransactions(context.Context, string) ([]model.AgentTransaction, error)
 	TransactionEvents(context.Context, string, string, int64) ([]model.TransactionEvent, error)
 	StartTransaction(context.Context, string, string, int64, model.Principal) (transactionreducer.Projection, error)
@@ -59,35 +60,46 @@ func transactionCommand(repo string, args []string, jsonOut bool, stdout, stderr
 }
 
 func transactionStatusCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
-	factory, err := runtimeBoundTransactionClientFactory(repo)
-	if err != nil {
-		fmt.Fprintf(stderr, "status: %v\n", err)
-		return 1
-	}
-	return transactionAliasCommandWithFactory(
-		"status", repo, args, jsonOut, stdout, stderr, factory,
-	)
+	return transactionTopLevelAliasCommand("status", repo, args, jsonOut, stdout, stderr)
+}
+
+func transactionReviewCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	return transactionTopLevelAliasCommand("review", repo, args, jsonOut, stdout, stderr)
+}
+
+func transactionDiffCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	return transactionTopLevelAliasCommand("diff", repo, args, jsonOut, stdout, stderr)
 }
 
 func transactionApproveCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
-	factory, err := runtimeBoundTransactionClientFactory(repo)
-	if err != nil {
-		fmt.Fprintf(stderr, "approve: %v\n", err)
-		return 1
-	}
-	return transactionAliasCommandWithFactory(
-		"approve", repo, args, jsonOut, stdout, stderr, factory,
-	)
+	return transactionTopLevelAliasCommand("approve", repo, args, jsonOut, stdout, stderr)
+}
+
+func transactionApplyCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	return transactionTopLevelAliasCommand("apply", repo, args, jsonOut, stdout, stderr)
+}
+
+func transactionRejectCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	return transactionTopLevelAliasCommand("reject", repo, args, jsonOut, stdout, stderr)
 }
 
 func transactionReleaseCommand(repo string, args []string, jsonOut bool, stdout, stderr io.Writer) int {
+	return transactionTopLevelAliasCommand("release", repo, args, jsonOut, stdout, stderr)
+}
+
+func transactionTopLevelAliasCommand(
+	alias, repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+) int {
 	factory, err := runtimeBoundTransactionClientFactory(repo)
 	if err != nil {
-		fmt.Fprintf(stderr, "release: %v\n", err)
+		fmt.Fprintf(stderr, "%s: %v\n", alias, err)
 		return 1
 	}
 	return transactionAliasCommandWithFactory(
-		"release", repo, args, jsonOut, stdout, stderr, factory,
+		alias, repo, args, jsonOut, stdout, stderr, factory,
 	)
 }
 
@@ -125,10 +137,16 @@ func transactionAliasCommandWithFactory(
 	switch alias {
 	case "status":
 		return transactionGet(repo, normalized, jsonOut, stdout, stderr, newClient)
+	case "review":
+		return transactionReview(repo, normalized, jsonOut, stdout, stderr, newClient)
+	case "diff":
+		return transactionDiff(repo, normalized, jsonOut, stdout, stderr, newClient)
 	case "approve":
 		return transactionApprove(repo, normalized, jsonOut, stdout, stderr, newClient)
-	case "release":
+	case "apply", "release":
 		return transactionRelease(repo, normalized, jsonOut, stdout, stderr, newClient)
+	case "reject":
+		return transactionAbort(repo, normalized, jsonOut, stdout, stderr, newClient)
 	default:
 		fmt.Fprintf(stderr, "unknown transaction alias %q\n", alias)
 		return 2
@@ -203,6 +221,10 @@ func transactionCommandWithFactory(
 		return transactionList(repo, args[1:], jsonOut, stdout, stderr, newClient)
 	case "effects":
 		return transactionEffects(repo, args[1:], jsonOut, stdout, stderr, newClient)
+	case "review":
+		return transactionReview(repo, args[1:], jsonOut, stdout, stderr, newClient)
+	case "diff":
+		return transactionDiff(repo, args[1:], jsonOut, stdout, stderr, newClient)
 	case "events":
 		return transactionEvents(repo, args[1:], jsonOut, stdout, stderr, newClient)
 	case "abort":
@@ -737,6 +759,6 @@ func transactionUsage(out io.Writer) {
 	fmt.Fprintln(out, "  tx renew --namespace NS --id ID")
 	fmt.Fprintln(out, "  tx approve --namespace NS --id ID --key FILE --key-id ID --approver ID --class CLASS [--decision approve|reject|revise]")
 	fmt.Fprintln(out, "  tx release --namespace NS --id ID")
-	fmt.Fprintln(out, "  tx get|effects|events|abort --namespace NS --id ID")
+	fmt.Fprintln(out, "  tx get|review|diff|effects|events|abort --namespace NS --id ID")
 	fmt.Fprintln(out, "  tx list --namespace NS")
 }

--- a/internal/gatemole/transaction_review_cli.go
+++ b/internal/gatemole/transaction_review_cli.go
@@ -1,0 +1,254 @@
+package gatemole
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	kernelclient "github.com/duriantaco/gatemole/internal/kernel/client"
+	"github.com/duriantaco/gatemole/internal/kernel/model"
+	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
+)
+
+const transactionReviewVersion = "gatemole.transaction_review.v1"
+
+type transactionReviewResult struct {
+	Version         string                              `json:"version"`
+	Projection      transactionreducer.Projection       `json:"projection"`
+	Diff            *kernelclient.TransactionDiffResult `json:"diff,omitempty"`
+	DiffUnavailable string                              `json:"diff_unavailable,omitempty"`
+}
+
+func transactionReview(
+	repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+	newClient transactionClientFactory,
+) int {
+	values, ok := parseTransactionTarget("tx review", repo, args, stderr)
+	if !ok {
+		return 2
+	}
+	client := newClient(values.socket)
+	projection, err := client.GetTransaction(
+		context.Background(), values.namespace, values.id,
+	)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	result := transactionReviewResult{
+		Version:    transactionReviewVersion,
+		Projection: projection,
+	}
+	if reason := transactionDiffUnavailable(projection); reason != "" {
+		result.DiffUnavailable = reason
+	} else {
+		diff, err := client.GetTransactionDiff(
+			context.Background(), values.namespace, values.id,
+		)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		current, err := client.GetTransaction(
+			context.Background(), values.namespace, values.id,
+		)
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if !diffMatchesProjection(diff, current) {
+			fmt.Fprintln(stderr, "transaction changed while its review was assembled; retry the command")
+			return 1
+		}
+		result.Projection = current
+		result.Diff = &diff
+	}
+	if jsonOut {
+		return renderCommandJSON(result, stdout, stderr)
+	}
+	return renderTransactionReview(result, stdout, stderr)
+}
+
+func transactionDiff(
+	repo string,
+	args []string,
+	jsonOut bool,
+	stdout, stderr io.Writer,
+	newClient transactionClientFactory,
+) int {
+	values, ok := parseTransactionTarget("tx diff", repo, args, stderr)
+	if !ok {
+		return 2
+	}
+	diff, err := newClient(values.socket).GetTransactionDiff(
+		context.Background(), values.namespace, values.id,
+	)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	if jsonOut {
+		return renderCommandJSON(diff, stdout, stderr)
+	}
+	if _, err := stdout.Write(diff.Patch); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 1
+	}
+	return 0
+}
+
+func transactionDiffUnavailable(projection transactionreducer.Projection) string {
+	switch {
+	case projection.Transaction.State == model.TransactionAborted:
+		return "the transaction was rejected and its isolated worktree was discarded"
+	case len(projection.Effects) == 0:
+		return "the transaction has no frozen Git effects"
+	case projection.Transaction.StagedStateDigest == "" ||
+		projection.Transaction.EffectSetDigest == "":
+		return "the transaction has not frozen a Git effect set"
+	default:
+		return ""
+	}
+}
+
+func diffMatchesProjection(
+	diff kernelclient.TransactionDiffResult,
+	projection transactionreducer.Projection,
+) bool {
+	metadata := diff.Metadata
+	transaction := projection.Transaction
+	return metadata.Namespace == transaction.Namespace &&
+		metadata.TransactionID == transaction.ID &&
+		metadata.Attempt == transaction.Attempt &&
+		metadata.EventSequence == transaction.EventSequence &&
+		metadata.StagedStateDigest == transaction.StagedStateDigest &&
+		metadata.EffectSetDigest == transaction.EffectSetDigest
+}
+
+func renderTransactionReview(
+	review transactionReviewResult,
+	stdout, stderr io.Writer,
+) int {
+	projection := review.Projection
+	transaction := projection.Transaction
+	fmt.Fprintf(
+		stdout,
+		"Transaction %s in %s\nState: %s (attempt %d, sequence %d)\n",
+		transaction.ID,
+		transaction.Namespace,
+		transaction.State,
+		transaction.Attempt,
+		transaction.EventSequence,
+	)
+	if transaction.Task != nil {
+		fmt.Fprintf(stdout, "Intent: %q\n", transaction.Task.Intent)
+	}
+	fmt.Fprintf(
+		stdout,
+		"Effects: %d\nStaged state: %s\nEffect set: %s\n",
+		len(projection.Effects),
+		valueOrNone(transaction.StagedStateDigest),
+		valueOrNone(transaction.EffectSetDigest),
+	)
+	for _, effect := range projection.Effects {
+		fmt.Fprintf(
+			stdout,
+			"  - #%d %s [%s] %s %q (%s; %s)\n",
+			effect.Sequence,
+			effect.ID,
+			effect.Status,
+			effect.Operation,
+			effect.Resource.Pattern,
+			effect.System,
+			effect.RecoveryClass,
+		)
+	}
+	fmt.Fprintf(stdout, "Verifications: %d\n", len(projection.Verifications))
+	for _, verification := range projection.Verifications {
+		fmt.Fprintf(
+			stdout,
+			"  - %s [%s] %s: %q\n",
+			verification.ID,
+			verification.Status,
+			verification.Name,
+			verification.Summary,
+		)
+		for _, evidence := range verification.Evidence {
+			fmt.Fprintf(
+				stdout,
+				"    evidence: %q (%s)\n",
+				evidence.URI,
+				evidence.Digest,
+			)
+		}
+	}
+	fmt.Fprintf(
+		stdout,
+		"Approval package: %s\nApproval decisions: %s\nOutstanding approvals: %s\n",
+		valueOrNone(transaction.ApprovalPackageDigest),
+		listOrNone(projection.ApprovalDigests),
+		listOrNone(transaction.OutstandingApprovalIDs),
+	)
+	if review.Diff == nil {
+		fmt.Fprintf(stdout, "Exact diff: unavailable (%s)\n", review.DiffUnavailable)
+	} else {
+		metadata := review.Diff.Metadata
+		fmt.Fprintf(
+			stdout,
+			"Exact diff: %s\nBase: %s\nTree: %s\n\n",
+			metadata.PatchDigest,
+			metadata.BaseRevision,
+			metadata.TreeRevision,
+		)
+		if _, err := stdout.Write(review.Diff.Patch); err != nil {
+			fmt.Fprintln(stderr, err)
+			return 1
+		}
+		if len(review.Diff.Patch) > 0 && review.Diff.Patch[len(review.Diff.Patch)-1] != '\n' {
+			fmt.Fprintln(stdout)
+		}
+	}
+	if next := transactionReviewNextStep(transaction); next != "" {
+		fmt.Fprintf(stdout, "\nNext: %s\n", next)
+	}
+	return 0
+}
+
+func transactionReviewNextStep(transaction model.AgentTransaction) string {
+	switch transaction.State {
+	case model.TransactionPendingApproval:
+		return "approve the exact approval package, then run `gatemole apply " + transaction.ID + "`"
+	case model.TransactionReadyToCommit:
+		return "run `gatemole apply " + transaction.ID + "` or `gatemole reject " + transaction.ID + "`"
+	case model.TransactionCommitted:
+		return "the approved Git ref update has already been applied"
+	case model.TransactionAborted:
+		return "the transaction has been rejected"
+	case model.TransactionCompletedNoEffect:
+		return "there are no effects to apply"
+	case model.TransactionValidating, model.TransactionValidationFailed:
+		return "complete the required verification and prepare an approval package"
+	case model.TransactionStaged:
+		return "validate the frozen effect sequence"
+	default:
+		return "wait for the transaction to reach a reviewable staged state"
+	}
+}
+
+func valueOrNone(value string) string {
+	if value == "" {
+		return "none"
+	}
+	return value
+}
+
+func listOrNone(values []string) string {
+	if len(values) == 0 {
+		return "none"
+	}
+	return strings.Join(values, ", ")
+}

--- a/internal/gatemole/transaction_run_cli_test.go
+++ b/internal/gatemole/transaction_run_cli_test.go
@@ -133,6 +133,56 @@ func TestTransactionRunSupervisesStagesAndValidatesAgent(t *testing.T) {
 	if result.Projection.Transaction.State != model.TransactionValidating {
 		t.Fatalf("state=%q, want validating", result.Projection.Transaction.State)
 	}
+	reviewStdout, reviewStderr, reviewCode := invokeTransactionRunCLI(
+		repo, newClient, false,
+		"review",
+		"--namespace", "payments",
+		"--id", "tx:runtime-success",
+	)
+	if reviewCode != 0 {
+		t.Fatalf("tx review code=%d stderr=%s", reviewCode, reviewStderr)
+	}
+	if !strings.Contains(reviewStdout, "Exact diff: sha256:") ||
+		!strings.Contains(reviewStdout, "func Allowed() bool { return true }") ||
+		!strings.Contains(reviewStdout, result.Projection.Effects[0].ID) {
+		t.Fatalf("review did not bind readable status, effects, and patch:\n%s", reviewStdout)
+	}
+	diffStdout, diffStderr, diffCode := invokeTransactionRunCLI(
+		repo, newClient, false,
+		"diff",
+		"--namespace", "payments",
+		"--id", "tx:runtime-success",
+	)
+	if diffCode != 0 || diffStderr != "" ||
+		!strings.Contains(diffStdout, "func Allowed() bool { return true }") {
+		t.Fatalf("tx diff code=%d stdout=%s stderr=%s", diffCode, diffStdout, diffStderr)
+	}
+	workspace := result.Projection.Transaction.StageBindings[0].Location
+	stagedMiddleware := filepath.Join(workspace, "internal", "auth", "middleware.go")
+	if err := os.WriteFile(
+		stagedMiddleware,
+		[]byte("package auth\n\nfunc Allowed() bool { return false }\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	_, staleDiffStderr, staleDiffCode := invokeTransactionRunCLI(
+		repo, newClient, false,
+		"diff",
+		"--namespace", "payments",
+		"--id", "tx:runtime-success",
+	)
+	if staleDiffCode != 1 ||
+		!strings.Contains(staleDiffStderr, string(model.ErrorTransactionConflict)) {
+		t.Fatalf("changed worktree diff code=%d stderr=%s", staleDiffCode, staleDiffStderr)
+	}
+	if err := os.WriteFile(
+		stagedMiddleware,
+		[]byte("package auth\n\nfunc Allowed() bool { return true }\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
 	pinnedVerifier := "registry.example.invalid/verifier@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 	verifyStdout, verifyStderr, verifyCode := invokeTransactionRunCLI(
 		repo, newClient, true,
@@ -264,11 +314,10 @@ func TestTransactionRunSupervisesStagesAndValidatesAgent(t *testing.T) {
 	if interrupted.Transaction.State != model.TransactionCommitting {
 		t.Fatalf("crash window did not remain recoverable: %s", interrupted.Transaction.State)
 	}
-	releaseStdout, releaseStderr, releaseCode = invokeTransactionRunCLI(
-		repo, newClient, true,
-		"release",
+	releaseStdout, releaseStderr, releaseCode = invokeTransactionAliasCLI(
+		repo, newClient, true, "apply",
+		"tx:runtime-success",
 		"--namespace", "payments",
-		"--id", "tx:runtime-success",
 	)
 	if releaseCode != 0 {
 		t.Fatalf("tx release recovery code=%d stderr=%s stdout=%s", releaseCode, releaseStderr, releaseStdout)
@@ -420,6 +469,22 @@ func TestTransactionRunPersistsFailedAgentWithoutStaging(t *testing.T) {
 		model.Principal{ID: "operator:local", Kind: model.PrincipalOperator},
 	); err == nil {
 		t.Fatal("failed execution was allowed to stage partial workspace state")
+	}
+	rejectStdout, rejectStderr, rejectCode := invokeTransactionAliasCLI(
+		repo, newClient, true, "reject",
+		"tx:runtime-failure",
+		"--namespace", "payments",
+	)
+	if rejectCode != 0 {
+		t.Fatalf("reject code=%d stdout=%s stderr=%s", rejectCode, rejectStdout, rejectStderr)
+	}
+	var rejected kernelclient.TransactionAbortResult
+	if err := json.Unmarshal([]byte(rejectStdout), &rejected); err != nil {
+		t.Fatalf("decode reject output: %v\n%s", err, rejectStdout)
+	}
+	if rejected.Projection.Transaction.State != model.TransactionAborted ||
+		!rejected.WorkspaceRemoved {
+		t.Fatalf("reject did not abort and discard the worktree: %#v", rejected)
 	}
 }
 
@@ -1342,6 +1407,21 @@ func invokeTransactionRunCLI(
 	var stderr bytes.Buffer
 	code := transactionCommandWithFactory(
 		repo, args, jsonOut, &stdout, &stderr, newClient,
+	)
+	return stdout.String(), stderr.String(), code
+}
+
+func invokeTransactionAliasCLI(
+	repo string,
+	newClient transactionClientFactory,
+	jsonOut bool,
+	alias string,
+	args ...string,
+) (string, string, int) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	code := transactionAliasCommandWithFactory(
+		alias, repo, args, jsonOut, &stdout, &stderr, newClient,
 	)
 	return stdout.String(), stderr.String(), code
 }

--- a/internal/gatemole/transaction_run_cli_test.go
+++ b/internal/gatemole/transaction_run_cli_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/duriantaco/gatemole/internal/kernel/approval"
 	kernelclient "github.com/duriantaco/gatemole/internal/kernel/client"
 	"github.com/duriantaco/gatemole/internal/kernel/model"
+	"github.com/duriantaco/gatemole/internal/kernel/reducer"
 	"github.com/duriantaco/gatemole/internal/kernel/runtimeidentity"
 	"github.com/duriantaco/gatemole/internal/kernel/store"
 	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
@@ -741,8 +742,21 @@ func TestTransactionRunDaemonOCIProvidesPersistedTaskEnvelope(t *testing.T) {
 	if err != nil {
 		t.Fatalf("load admitted run events: %v", err)
 	}
-	if len(runEvents) != 3 {
-		t.Fatalf("admitted run events=%d, want 3", len(runEvents))
+	currentRun, err := kernelStore.GetRun(
+		context.Background(), "payments", "run:task-envelope-oci",
+	)
+	if err != nil {
+		t.Fatalf("load current run projection: %v", err)
+	}
+	if currentRun.Run.State != model.RunWaitingForEvent ||
+		currentRun.Run.ActiveExecutionID != "" ||
+		currentRun.Run.EventSequence != 5 {
+		t.Fatalf("OCI execution did not settle the admitted run: %#v", currentRun.Run)
+	}
+	if len(runEvents) != 5 ||
+		runEvents[3].Type != reducer.EventRunExecutionStarted ||
+		runEvents[4].Type != reducer.EventRunExecutionFinished {
+		t.Fatalf("paired run events=%#v", runEvents)
 	}
 }
 

--- a/internal/kernel/api/execution_authority_test.go
+++ b/internal/kernel/api/execution_authority_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/duriantaco/gatemole/internal/kernel/admission"
 	"github.com/duriantaco/gatemole/internal/kernel/model"
+	kernelmodelbroker "github.com/duriantaco/gatemole/internal/kernel/modelbroker"
 	"github.com/duriantaco/gatemole/internal/kernel/store"
 	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
 	"github.com/duriantaco/gatemole/internal/kernel/transaction/gitstage"
@@ -84,6 +85,104 @@ func TestRunAgentExecutionRejectsLegacyTransactionBeforeWorkload(t *testing.T) {
 		fixture,
 		model.ErrorCapabilityDenied,
 	)
+}
+
+func TestRunAgentExecutionAdvancesAndSettlesPairedRun(t *testing.T) {
+	t.Parallel()
+	base := time.Now().UTC().Add(5 * time.Minute).Truncate(time.Second)
+	fixture := newExecutionAuthorityAPIFixture(
+		t,
+		"paired-lifecycle",
+		base,
+		model.ContractResource{
+			ID: "workspace",
+			Selector: model.ResourceSelector{
+				Kind: "filesystem", Pattern: "workspace/**",
+			},
+			Operations: []string{"filesystem.read", "filesystem.write"},
+			Conditions: model.CapabilityConditions{
+				WorkspaceRoot: "workspace",
+			},
+		},
+	)
+	response := requestJSONWithRuntimeHeader(
+		t,
+		fixture.handler,
+		http.MethodPost,
+		fmt.Sprintf(
+			"/v0/namespaces/%s/transactions/%s/executions/run",
+			fixture.namespace,
+			fixture.transactionID,
+		),
+		runAgentExecutionRequest{
+			ExpectedSequence: fixture.transactionHead,
+			Actor:            fixture.actor,
+			Image:            fixture.image,
+			Command:          append([]string(nil), fixture.command...),
+			TimeoutSeconds:   1,
+		},
+		fixture.runtimeID,
+	)
+	if response.Code != http.StatusOK {
+		t.Fatalf("run agent status=%d body=%s", response.Code, response.Body.String())
+	}
+	var result runAgentExecutionResponse
+	decodeResponse(t, response, &result)
+	if result.Execution.Status != model.AgentExecutionSucceeded ||
+		result.Projection.Transaction.EventSequence != fixture.transactionHead+2 {
+		t.Fatalf("unexpected paired execution response: %#v", result)
+	}
+	run, err := fixture.kernelStore.GetRun(
+		context.Background(),
+		fixture.namespace,
+		fixture.runID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Run.State != model.RunWaitingForEvent ||
+		run.Run.ActiveExecutionID != "" ||
+		run.Run.EventSequence != fixture.runHead+2 {
+		t.Fatalf("daemon execution did not settle paired run: %#v", run.Run)
+	}
+	events, err := fixture.kernelStore.Events(
+		context.Background(),
+		fixture.namespace,
+		fixture.runID,
+		fixture.runHead,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[0].Type != "run.execution_started" ||
+		events[1].Type != "run.execution_finished" {
+		t.Fatalf("paired run events=%#v", events)
+	}
+	if _, err := os.Stat(fixture.engineMarker); err != nil {
+		t.Fatalf("OCI engine was not invoked: %v", err)
+	}
+}
+
+func TestSettledModelBrokerExecutionBindsEmptyStartFailureLedger(t *testing.T) {
+	t.Parallel()
+	binding := model.ModelBrokerExecution{
+		Provider: "openai", ImageDigest: strings.Repeat("a", 64),
+		PolicyDigest: strings.Repeat("b", 64),
+	}
+	binding.ImageDigest = "sha256:" + binding.ImageDigest
+	binding.PolicyDigest = "sha256:" + binding.PolicyDigest
+	settled := settledModelBrokerExecution(
+		binding,
+		kernelmodelbroker.LedgerSummary{
+			Digest: "sha256:" + strings.Repeat("c", 64),
+		},
+	)
+	if settled.Provider != binding.Provider ||
+		settled.ImageDigest != binding.ImageDigest ||
+		settled.PolicyDigest != binding.PolicyDigest ||
+		settled.ReceiptLedgerDigest == "" || settled.Calls != 0 {
+		t.Fatalf("empty failed-start ledger was not bound: %#v", settled)
+	}
 }
 
 type executionAuthorityAPIFixture struct {
@@ -313,7 +412,7 @@ func newExecutionAuthorityServerFixtureWithOptions(
 	marker := filepath.Join(t.TempDir(), "oci-invoked")
 	engine := filepath.Join(t.TempDir(), "fake-oci-engine")
 	engineScript := fmt.Sprintf(
-		"#!/bin/sh\nprintf 'invoked\\n' >> %q\nexit 97\n",
+		"#!/bin/sh\nprintf 'invoked\\n' >> %q\nexit 0\n",
 		marker,
 	)
 	if err := os.WriteFile(engine, []byte(engineScript), 0o700); err != nil {

--- a/internal/kernel/api/server.go
+++ b/internal/kernel/api/server.go
@@ -265,6 +265,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions", s.listTransactions)
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions/{transactionID}", s.getTransaction)
 	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions/{transactionID}/events", s.listTransactionEvents)
+	mux.HandleFunc("GET /v0/namespaces/{namespace}/transactions/{transactionID}/diff", s.getTransactionDiff)
 	mux.HandleFunc("POST /v0/namespaces/{namespace}/transactions/{transactionID}/start", s.startTransaction)
 	mux.HandleFunc("POST /v0/namespaces/{namespace}/transactions/{transactionID}/git-worktree", s.createTransactionWorktree)
 	mux.HandleFunc("POST /v0/namespaces/{namespace}/transactions/{transactionID}/executions/start", s.startAgentExecution)

--- a/internal/kernel/api/transaction_handlers.go
+++ b/internal/kernel/api/transaction_handlers.go
@@ -189,6 +189,80 @@ func (s *Server) getTransaction(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, projection)
 }
 
+// getTransactionDiff returns the exact frozen Git patch as a bounded raw body.
+// Binding metadata travels in a base64url-encoded JSON header so the patch is
+// not corrupted by JSON string or base64 transformations.
+func (s *Server) getTransactionDiff(w http.ResponseWriter, r *http.Request) {
+	if s.gitStage == nil {
+		writeError(w, transactionRuntimeUnavailable())
+		return
+	}
+	namespace := r.PathValue("namespace")
+	transactionID := r.PathValue("transactionID")
+	lock := s.runLock(namespace, "transaction:"+transactionID)
+	lock.Lock()
+	defer lock.Unlock()
+	projection, err := s.store.GetTransaction(r.Context(), namespace, transactionID)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if len(projection.Effects) == 0 ||
+		projection.Transaction.StagedStateDigest == "" ||
+		projection.Transaction.EffectSetDigest == "" {
+		writeError(w, transactionTransitionError("transaction has no frozen Git effects to review"))
+		return
+	}
+	workspace, err := s.transactionWorkspace(r, projection)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	snapshot, err := s.gitStage.Inspect(r.Context(), workspace, s.now().UTC())
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	if !matchesFrozenStage(snapshot, projection) {
+		writeError(w, &model.KernelError{
+			Code:      model.ErrorTransactionConflict,
+			Operation: "review_transaction_diff",
+			Resource:  transactionID,
+			Message:   "transaction worktree changed after effects were frozen",
+		})
+		return
+	}
+	patch, err := s.gitStage.CapturePatch(r.Context(), snapshot)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	metadata := gitstage.DiffMetadata{
+		Version:           gitstage.DiffMetadataVersion,
+		Namespace:         namespace,
+		TransactionID:     transactionID,
+		Attempt:           projection.Transaction.Attempt,
+		EventSequence:     projection.Transaction.EventSequence,
+		StagedStateDigest: projection.Transaction.StagedStateDigest,
+		EffectSetDigest:   projection.Transaction.EffectSetDigest,
+		PatchDigest:       snapshot.PatchDigest,
+		BaseRevision:      snapshot.Workspace.BaseRevision,
+		TreeRevision:      snapshot.TreeRevision,
+	}
+	encoded, err := json.Marshal(metadata)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+	w.Header().Set(
+		gitstage.DiffMetadataHeader,
+		base64.RawURLEncoding.EncodeToString(encoded),
+	)
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(patch)
+}
+
 func (s *Server) listTransactionEvents(w http.ResponseWriter, r *http.Request) {
 	after := int64(0)
 	if raw := r.URL.Query().Get("after"); raw != "" {

--- a/internal/kernel/api/transaction_handlers.go
+++ b/internal/kernel/api/transaction_handlers.go
@@ -22,6 +22,7 @@ import (
 	kernelmodelbroker "github.com/duriantaco/gatemole/internal/kernel/modelbroker"
 	"github.com/duriantaco/gatemole/internal/kernel/runtimeidentity"
 	"github.com/duriantaco/gatemole/internal/kernel/sandbox"
+	"github.com/duriantaco/gatemole/internal/kernel/store"
 	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
 	"github.com/duriantaco/gatemole/internal/kernel/transaction/gitstage"
 	"github.com/duriantaco/gatemole/internal/kernel/verification"
@@ -401,8 +402,8 @@ func (s *Server) startAgentExecution(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	next, err := s.store.AppendTransactionEvents(
-		r.Context(), namespace, request.ExpectedSequence, []model.TransactionEvent{event},
+	next, err := s.appendExternalExecutionEvent(
+		r.Context(), namespace, projection, event,
 	)
 	if err != nil {
 		writeError(w, err)
@@ -451,8 +452,8 @@ func (s *Server) finishAgentExecution(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	next, err := s.store.AppendTransactionEvents(
-		r.Context(), namespace, request.ExpectedSequence, []model.TransactionEvent{event},
+	next, err := s.appendExternalExecutionEvent(
+		r.Context(), namespace, projection, event,
 	)
 	if err != nil {
 		writeError(w, err)
@@ -598,6 +599,10 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 	var brokerSession *sandbox.ModelBrokerSession
 	var brokerExecution *model.ModelBrokerExecution
 	var brokerConfig *sandbox.ModelBrokerConfig
+	executionID := transactionreducer.ExecutionID(
+		transactionID,
+		request.ExpectedSequence+1,
+	)
 	if executionPlan.ModelBroker != nil {
 		brokerPolicy := s.executionPolicy.ModelBroker
 		if brokerPolicy == nil {
@@ -618,14 +623,20 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		receiptDirectory := filepath.Join(
+		receiptDirectory := sandbox.ModelBrokerExecutionEvidenceDirectory(
 			s.transactionStaging,
-			".gatemole-model-evidence",
-			sandbox.ModelBrokerContainerName(
-				transactionID,
-				executionPlan.RunID,
-			),
+			transactionID,
+			executionPlan.RunID,
+			executionID,
 		)
+		if err := os.MkdirAll(receiptDirectory, 0o700); err != nil {
+			writeError(w, &model.KernelError{
+				Code: model.ErrorDriverUnavailable, Operation: "prepare_model_receipts",
+				Resource: executionID, Message: "create execution-scoped model receipt directory",
+				Cause: err,
+			})
+			return
+		}
 		brokerConfig = &sandbox.ModelBrokerConfig{
 			EnginePath:          s.executionPolicy.EnginePath,
 			Image:               brokerPolicy.Image,
@@ -687,7 +698,7 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 	now := s.now().UTC()
 	execution := model.AgentExecution{
 		Version:             model.AgentExecutionVersion,
-		ID:                  transactionreducer.ExecutionID(transactionID, request.ExpectedSequence+1),
+		ID:                  executionID,
 		TransactionID:       transactionID,
 		Attempt:             projection.Transaction.Attempt,
 		RunID:               executionPlan.RunID,
@@ -711,18 +722,23 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 		writeError(w, err)
 		return
 	}
-	projection, err = s.store.AppendTransactionEventsIfRunCurrent(
+	pairedExecution, err := s.store.AppendPairedExecutionEvent(
 		authorityContext,
 		namespace,
-		request.ExpectedSequence,
-		liveAuthority.RunSequence,
-		liveAuthority.RunLastEventDigest,
-		[]model.TransactionEvent{started},
+		store.ExecutionHeads{
+			TransactionSequence: request.ExpectedSequence,
+			TransactionDigest:   projection.LastEventDigest,
+			RunSequence:         liveAuthority.RunSequence,
+			RunDigest:           liveAuthority.RunLastEventDigest,
+		},
+		started,
 	)
 	if err != nil {
 		writeError(w, err)
 		return
 	}
+	projection = pairedExecution.Transaction
+	runProjection := pairedExecution.Run
 	var outcome verification.Outcome
 	var runErr error
 	runOperation := "run_agent_execution"
@@ -796,18 +812,33 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 			})
 			return
 		}
-		brokerExecution = &model.ModelBrokerExecution{
-			Provider:            s.executionPolicy.ModelBroker.Policy.Provider,
-			ImageDigest:         brokerSession.ImageDigest,
-			PolicyDigest:        brokerSession.PolicyDigest,
-			ReceiptLedgerDigest: summary.Digest,
-			Calls:               summary.Calls,
-			CompletedCalls:      summary.Completed,
-			FailedCalls:         summary.Failed,
-			UnknownCalls:        summary.Unknown,
-			InputTokens:         summary.InputTokens,
-			OutputTokens:        summary.OutputTokens,
+		brokerExecution = settledModelBrokerExecution(
+			model.ModelBrokerExecution{
+				Provider: brokerExecution.Provider, ImageDigest: brokerSession.ImageDigest,
+				PolicyDigest: brokerSession.PolicyDigest,
+			},
+			summary,
+		)
+	} else if brokerConfig != nil {
+		// A broker that could not start still needs a terminal, digest-bound
+		// empty ledger. Otherwise the start-failed process cannot settle and
+		// would remain active until a daemon restart.
+		summary, summaryErr := kernelmodelbroker.FinalizeLedger(
+			filepath.Join(brokerConfig.ReceiptDirectory, "model-calls.jsonl"),
+			transactionID,
+			executionPlan.RunID,
+			brokerExecution.Provider,
+		)
+		if summaryErr != nil {
+			writeError(w, &model.KernelError{
+				Code: model.ErrorEventChain, Operation: "finalize_model_receipts",
+				Resource: transactionID,
+				Message:  "failed broker start has no verifiable receipt ledger; execution remains active",
+				Cause:    summaryErr,
+			})
+			return
 		}
+		brokerExecution = settledModelBrokerExecution(*brokerExecution, summary)
 	}
 	if verification.IsCleanupError(runErr) {
 		writeError(w, &model.KernelError{
@@ -850,14 +881,22 @@ func (s *Server) runAgentExecution(w http.ResponseWriter, r *http.Request) {
 	}
 	finishContext, stopFinish := context.WithTimeout(context.Background(), 10*time.Second)
 	defer stopFinish()
-	projection, finishErr = s.store.AppendTransactionEvents(
-		finishContext, namespace, projection.Transaction.EventSequence,
-		[]model.TransactionEvent{finished},
+	pairedExecution, finishErr = s.store.AppendPairedExecutionEvent(
+		finishContext,
+		namespace,
+		store.ExecutionHeads{
+			TransactionSequence: projection.Transaction.EventSequence,
+			TransactionDigest:   projection.LastEventDigest,
+			RunSequence:         runProjection.Run.EventSequence,
+			RunDigest:           runProjection.LastEventDigest,
+		},
+		finished,
 	)
 	if finishErr != nil {
 		writeError(w, finishErr)
 		return
 	}
+	projection = pairedExecution.Transaction
 	execution = projection.Executions[len(projection.Executions)-1]
 	if runErr != nil {
 		var kernelErr *model.KernelError
@@ -897,6 +936,55 @@ func taskAuthorizesExecution(
 		Resource:  task.TransactionID,
 		Message:   "persisted task does not authorize the requested run or agent profile",
 	}
+}
+
+func settledModelBrokerExecution(
+	binding model.ModelBrokerExecution,
+	summary kernelmodelbroker.LedgerSummary,
+) *model.ModelBrokerExecution {
+	return &model.ModelBrokerExecution{
+		Provider: binding.Provider, ImageDigest: binding.ImageDigest,
+		PolicyDigest: binding.PolicyDigest, ReceiptLedgerDigest: summary.Digest,
+		Calls: summary.Calls, CompletedCalls: summary.Completed,
+		FailedCalls: summary.Failed, UnknownCalls: summary.Unknown,
+		InputTokens: summary.InputTokens, OutputTokens: summary.OutputTokens,
+	}
+}
+
+func (s *Server) appendExternalExecutionEvent(
+	ctx context.Context,
+	namespace string,
+	projection transactionreducer.Projection,
+	event model.TransactionEvent,
+) (transactionreducer.Projection, error) {
+	binding := projection.Transaction.Admission
+	if binding == nil {
+		return s.store.AppendTransactionEvents(
+			ctx,
+			namespace,
+			projection.Transaction.EventSequence,
+			[]model.TransactionEvent{event},
+		)
+	}
+	run, err := s.store.GetRun(ctx, namespace, binding.RunID)
+	if err != nil {
+		return transactionreducer.Projection{}, err
+	}
+	paired, err := s.store.AppendPairedExecutionEvent(
+		ctx,
+		namespace,
+		store.ExecutionHeads{
+			TransactionSequence: projection.Transaction.EventSequence,
+			TransactionDigest:   projection.LastEventDigest,
+			RunSequence:         run.Run.EventSequence,
+			RunDigest:           run.LastEventDigest,
+		},
+		event,
+	)
+	if err != nil {
+		return transactionreducer.Projection{}, err
+	}
+	return paired.Transaction, nil
 }
 
 func materializeAgentTask(

--- a/internal/kernel/authority/authority.go
+++ b/internal/kernel/authority/authority.go
@@ -200,10 +200,11 @@ func validateBindings(input CompileInput) error {
 	if task.AgentProfile.RuntimeClass != "oci" {
 		return deny(model.ErrorCapabilityDenied, task.ID, "only OCI execution is authoritative", nil)
 	}
-	if run.State != model.RunAdmitted || run.Runtime != nil ||
+	if !executionLaunchableRunState(run.State) ||
+		run.ActiveExecutionID != "" || run.Runtime != nil ||
 		run.ParentRunID != "" ||
 		run.CheckpointID != "" || len(run.OutstandingApprovalIDs) != 0 {
-		return deny(model.ErrorTransitionInvalid, run.ID, "run is not launchable from admitted state", nil)
+		return deny(model.ErrorTransitionInvalid, run.ID, "run is not launchable for a supervised execution", nil)
 	}
 	if transaction.State != model.TransactionRunning ||
 		len(transaction.StageBindings) != 1 ||
@@ -240,6 +241,15 @@ func validateBindings(input CompileInput) error {
 		return deny(model.ErrorCapabilityDenied, contract.ID, "contract contains unsupported execution controls", nil)
 	}
 	return nil
+}
+
+func executionLaunchableRunState(state model.RunState) bool {
+	switch state {
+	case model.RunAdmitted, model.RunWaitingForAgent, model.RunWaitingForEvent:
+		return true
+	default:
+		return false
+	}
 }
 
 func validateCeilings(ceilings DaemonCeilings) error {

--- a/internal/kernel/authority/authority_test.go
+++ b/internal/kernel/authority/authority_test.go
@@ -227,6 +227,10 @@ func TestCompileRejectsBrokenLiveBindingsAndLifecycle(t *testing.T) {
 		{"run not admitted", func(input *authority.CompileInput) {
 			input.Run.State = model.RunRunning
 		}, model.ErrorTransitionInvalid},
+		{"run has active execution", func(input *authority.CompileInput) {
+			input.Run.State = model.RunRunning
+			input.Run.ActiveExecutionID = "execution:active"
+		}, model.ErrorTransitionInvalid},
 		{"run already leased", func(input *authority.CompileInput) {
 			input.Run.Runtime = &model.RuntimeBinding{
 				Adapter: "oci", AdapterVersion: "1",
@@ -295,8 +299,15 @@ func TestCompileAllowsRetryAfterTerminalExecutionReceipt(t *testing.T) {
 		StartedAt:           input.Now.Add(-2 * time.Second),
 		CompletedAt:         &completedAt,
 	}}
-	if _, err := authority.Compile(input); err != nil {
-		t.Fatalf("terminal execution prevented retry: %v", err)
+	for _, state := range []model.RunState{
+		model.RunWaitingForAgent,
+		model.RunWaitingForEvent,
+	} {
+		candidate := input
+		candidate.Run.State = state
+		if _, err := authority.Compile(candidate); err != nil {
+			t.Fatalf("terminal execution prevented retry from %s: %v", state, err)
+		}
 	}
 }
 

--- a/internal/kernel/client/client.go
+++ b/internal/kernel/client/client.go
@@ -3,6 +3,9 @@ package client
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -26,6 +29,8 @@ import (
 )
 
 const maxResponseBytes = 4 << 20
+
+const maxTransactionDiffBytes = 128 << 20
 
 // Client talks to gatemoled over a local Unix socket. New verifies that each
 // connection's peer owns the stable, private socket path before HTTP can send
@@ -285,6 +290,70 @@ func (c *Client) TransactionEvents(ctx context.Context, namespace, transactionID
 	path := transactionPath(namespace, transactionID) + "/events?after=" + strconv.FormatInt(after, 10)
 	err := c.do(ctx, http.MethodGet, path, nil, &events)
 	return events, err
+}
+
+type TransactionDiffResult struct {
+	Metadata gitstage.DiffMetadata `json:"metadata"`
+	Patch    []byte                `json:"patch_base64"`
+}
+
+func (c *Client) GetTransactionDiff(
+	ctx context.Context,
+	namespace, transactionID string,
+) (TransactionDiffResult, error) {
+	request, err := c.newRequest(
+		ctx,
+		http.MethodGet,
+		transactionPath(namespace, transactionID)+"/diff",
+		nil,
+	)
+	if err != nil {
+		return TransactionDiffResult{}, err
+	}
+	response, err := c.http.Do(request)
+	if err != nil {
+		return TransactionDiffResult{}, fmt.Errorf("connect to gatemoled: %w", err)
+	}
+	defer response.Body.Close()
+	limited := io.LimitReader(response.Body, maxTransactionDiffBytes+1)
+	patch, err := io.ReadAll(limited)
+	if err != nil {
+		return TransactionDiffResult{}, fmt.Errorf("read kernel response: %w", err)
+	}
+	if len(patch) > maxTransactionDiffBytes {
+		return TransactionDiffResult{}, errors.New("transaction diff exceeds 128 MiB")
+	}
+	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
+		return TransactionDiffResult{}, kernelResponseError(response, patch)
+	}
+	rawMetadata, err := base64.RawURLEncoding.DecodeString(
+		response.Header.Get(gitstage.DiffMetadataHeader),
+	)
+	if err != nil {
+		return TransactionDiffResult{}, fmt.Errorf("decode transaction diff metadata: %w", err)
+	}
+	var metadata gitstage.DiffMetadata
+	decoder := json.NewDecoder(bytes.NewReader(rawMetadata))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&metadata); err != nil {
+		return TransactionDiffResult{}, fmt.Errorf("decode transaction diff metadata: %w", err)
+	}
+	if metadata.Version != gitstage.DiffMetadataVersion ||
+		metadata.Namespace != namespace ||
+		metadata.TransactionID != transactionID ||
+		metadata.Attempt < 1 || metadata.EventSequence < 1 ||
+		!model.IsSHA256Digest(metadata.StagedStateDigest) ||
+		!model.IsSHA256Digest(metadata.EffectSetDigest) ||
+		!model.IsSHA256Digest(metadata.PatchDigest) ||
+		!validGitObjectID(metadata.BaseRevision) ||
+		!validGitObjectID(metadata.TreeRevision) {
+		return TransactionDiffResult{}, errors.New("transaction diff metadata is invalid or does not match the request")
+	}
+	sum := sha256.Sum256(patch)
+	if metadata.PatchDigest != "sha256:"+hex.EncodeToString(sum[:]) {
+		return TransactionDiffResult{}, errors.New("transaction diff body does not match its patch digest")
+	}
+	return TransactionDiffResult{Metadata: metadata, Patch: patch}, nil
 }
 
 type TransactionWorktreeResult struct {
@@ -684,35 +753,9 @@ func (c *Client) transactionMutation(
 }
 
 func (c *Client) do(ctx context.Context, method, path string, input, output any) error {
-	if c.expectedRuntimeID != "" &&
-		!runtimeidentity.IsRuntimeID(c.expectedRuntimeID) {
-		return errors.New(
-			"build kernel request: expected Runtime identity is invalid",
-		)
-	}
-	var body io.Reader
-	if input != nil {
-		data, err := json.Marshal(input)
-		if err != nil {
-			return fmt.Errorf("encode kernel request: %w", err)
-		}
-		body = bytes.NewReader(data)
-	}
-	request, err := http.NewRequestWithContext(ctx, method, "http://gatemoled"+path, body)
+	request, err := c.newRequest(ctx, method, path, input)
 	if err != nil {
-		return fmt.Errorf("build kernel request: %w", err)
-	}
-	if input != nil {
-		request.Header.Set("Content-Type", "application/json")
-	}
-	if c.bearerToken != "" {
-		request.Header.Set("Authorization", "Bearer "+c.bearerToken)
-	}
-	if c.expectedRuntimeID != "" {
-		request.Header.Set(
-			runtimeidentity.HTTPHeader,
-			c.expectedRuntimeID,
-		)
+		return err
 	}
 	response, err := c.http.Do(request)
 	if err != nil {
@@ -728,11 +771,7 @@ func (c *Client) do(ctx context.Context, method, path string, input, output any)
 		return errors.New("kernel response exceeds 4 MiB")
 	}
 	if response.StatusCode < http.StatusOK || response.StatusCode >= http.StatusMultipleChoices {
-		var kernelErr model.KernelError
-		if err := json.Unmarshal(data, &kernelErr); err == nil && kernelErr.Code != "" {
-			return &kernelErr
-		}
-		return fmt.Errorf("gatemoled returned %s", response.Status)
+		return kernelResponseError(response, data)
 	}
 	if output == nil {
 		return nil
@@ -745,10 +784,64 @@ func (c *Client) do(ctx context.Context, method, path string, input, output any)
 	return nil
 }
 
+func (c *Client) newRequest(
+	ctx context.Context,
+	method, path string,
+	input any,
+) (*http.Request, error) {
+	if c.expectedRuntimeID != "" &&
+		!runtimeidentity.IsRuntimeID(c.expectedRuntimeID) {
+		return nil, errors.New(
+			"build kernel request: expected Runtime identity is invalid",
+		)
+	}
+	var body io.Reader
+	if input != nil {
+		data, err := json.Marshal(input)
+		if err != nil {
+			return nil, fmt.Errorf("encode kernel request: %w", err)
+		}
+		body = bytes.NewReader(data)
+	}
+	request, err := http.NewRequestWithContext(ctx, method, "http://gatemoled"+path, body)
+	if err != nil {
+		return nil, fmt.Errorf("build kernel request: %w", err)
+	}
+	if input != nil {
+		request.Header.Set("Content-Type", "application/json")
+	}
+	if c.bearerToken != "" {
+		request.Header.Set("Authorization", "Bearer "+c.bearerToken)
+	}
+	if c.expectedRuntimeID != "" {
+		request.Header.Set(
+			runtimeidentity.HTTPHeader,
+			c.expectedRuntimeID,
+		)
+	}
+	return request, nil
+}
+
+func kernelResponseError(response *http.Response, data []byte) error {
+	var kernelErr model.KernelError
+	if err := json.Unmarshal(data, &kernelErr); err == nil && kernelErr.Code != "" {
+		return &kernelErr
+	}
+	return fmt.Errorf("gatemoled returned %s", response.Status)
+}
+
 func runPath(namespace, runID string) string {
 	return "/v0/namespaces/" + url.PathEscape(namespace) + "/runs/" + url.PathEscape(runID)
 }
 
 func transactionPath(namespace, transactionID string) string {
 	return "/v0/namespaces/" + url.PathEscape(namespace) + "/transactions/" + url.PathEscape(transactionID)
+}
+
+func validGitObjectID(value string) bool {
+	if len(value) != 40 && len(value) != 64 {
+		return false
+	}
+	_, err := hex.DecodeString(value)
+	return err == nil
 }

--- a/internal/kernel/client/client_test.go
+++ b/internal/kernel/client/client_test.go
@@ -2,6 +2,9 @@ package client
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -14,6 +17,7 @@ import (
 	"github.com/duriantaco/gatemole/internal/kernel/model"
 	"github.com/duriantaco/gatemole/internal/kernel/runtimeidentity"
 	"github.com/duriantaco/gatemole/internal/kernel/runtimepreflight"
+	"github.com/duriantaco/gatemole/internal/kernel/transaction/gitstage"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -49,6 +53,95 @@ func TestClientSendsExplicitBearerToken(t *testing.T) {
 	}
 	if runtimeHeader != runtimeID {
 		t.Fatalf("Runtime header=%q, want %q", runtimeHeader, runtimeID)
+	}
+}
+
+func TestClientGetTransactionDiffValidatesExactBodyAndBinding(t *testing.T) {
+	t.Parallel()
+	patch := []byte("diff --git a/a.txt b/a.txt\n+reviewed\n")
+	sum := sha256.Sum256(patch)
+	metadata := gitstage.DiffMetadata{
+		Version:           gitstage.DiffMetadataVersion,
+		Namespace:         "team/platform",
+		TransactionID:     "tx:review",
+		Attempt:           2,
+		EventSequence:     14,
+		StagedStateDigest: "sha256:" + strings.Repeat("a", 64),
+		EffectSetDigest:   "sha256:" + strings.Repeat("b", 64),
+		PatchDigest:       "sha256:" + hex.EncodeToString(sum[:]),
+		BaseRevision:      strings.Repeat("c", 40),
+		TreeRevision:      strings.Repeat("d", 40),
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		if request.Method != http.MethodGet || request.URL.EscapedPath() !=
+			"/v0/namespaces/team%2Fplatform/transactions/tx:review/diff" {
+			t.Fatalf("unexpected request: %s %s", request.Method, request.URL.EscapedPath())
+		}
+		header := make(http.Header)
+		header.Set(
+			gitstage.DiffMetadataHeader,
+			base64.RawURLEncoding.EncodeToString(metadataJSON),
+		)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader(string(patch))),
+			Request:    request,
+		}, nil
+	})
+	result, err := NewWithTransport(transport).GetTransactionDiff(
+		context.Background(), "team/platform", "tx:review",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(result.Patch) != string(patch) || !reflect.DeepEqual(result.Metadata, metadata) {
+		t.Fatalf("diff result=%#v", result)
+	}
+}
+
+func TestClientGetTransactionDiffRejectsBodyOutsideDigest(t *testing.T) {
+	t.Parallel()
+	metadata := gitstage.DiffMetadata{
+		Version:           gitstage.DiffMetadataVersion,
+		Namespace:         "local",
+		TransactionID:     "tx:review",
+		Attempt:           1,
+		EventSequence:     2,
+		StagedStateDigest: "sha256:" + strings.Repeat("a", 64),
+		EffectSetDigest:   "sha256:" + strings.Repeat("b", 64),
+		PatchDigest:       "sha256:" + strings.Repeat("c", 64),
+		BaseRevision:      strings.Repeat("d", 40),
+		TreeRevision:      strings.Repeat("e", 40),
+	}
+	metadataJSON, err := json.Marshal(metadata)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transport := roundTripFunc(func(request *http.Request) (*http.Response, error) {
+		header := make(http.Header)
+		header.Set(
+			gitstage.DiffMetadataHeader,
+			base64.RawURLEncoding.EncodeToString(metadataJSON),
+		)
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Header:     header,
+			Body:       io.NopCloser(strings.NewReader("tampered")),
+			Request:    request,
+		}, nil
+	})
+	_, err = NewWithTransport(transport).GetTransactionDiff(
+		context.Background(), "local", "tx:review",
+	)
+	if err == nil || !strings.Contains(err.Error(), "patch digest") {
+		t.Fatalf("tampered diff body was accepted: %v", err)
 	}
 }
 

--- a/internal/kernel/daemon/daemon.go
+++ b/internal/kernel/daemon/daemon.go
@@ -261,6 +261,7 @@ func Run(ctx context.Context, config Config) error {
 		ctx,
 		kernelStore,
 		engineExecutionCleanup(executionPolicy.EnginePath),
+		recoverModelExecutionFrom(transactionRoot),
 		time.Now,
 	)
 	if err != nil {

--- a/internal/kernel/daemon/daemon_test.go
+++ b/internal/kernel/daemon/daemon_test.go
@@ -17,9 +17,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/duriantaco/gatemole/internal/kernel/admission"
 	"github.com/duriantaco/gatemole/internal/kernel/approval"
 	"github.com/duriantaco/gatemole/internal/kernel/identity"
 	"github.com/duriantaco/gatemole/internal/kernel/model"
+	kernelmodelbroker "github.com/duriantaco/gatemole/internal/kernel/modelbroker"
 	"github.com/duriantaco/gatemole/internal/kernel/runtimeidentity"
 	"github.com/duriantaco/gatemole/internal/kernel/sandbox"
 	"github.com/duriantaco/gatemole/internal/kernel/store"
@@ -774,6 +776,7 @@ func TestRecoverAgentExecutionsCleansContainerAndPersistsInterruptedReceipt(t *t
 			cleaned = append(cleaned, sandbox.ContainerName(transactionID, runID))
 			return nil
 		},
+		nil,
 		func() time.Time { return recoveredAt },
 	)
 	if err != nil {
@@ -819,6 +822,7 @@ func TestRecoverAgentExecutionsCleansContainerAndPersistsInterruptedReceipt(t *t
 			t.Fatal("terminal execution was cleaned twice")
 			return nil
 		},
+		nil,
 		time.Now,
 	)
 	if err != nil || recovered != 0 {
@@ -838,6 +842,7 @@ func TestRecoverAgentExecutionsFailsClosedBeforeChangingLedger(t *testing.T) {
 		ctx,
 		kernelStore,
 		func(context.Context, string, string) error { return os.ErrPermission },
+		nil,
 		time.Now,
 	)
 	if err == nil {
@@ -853,6 +858,178 @@ func TestRecoverAgentExecutionsFailsClosedBeforeChangingLedger(t *testing.T) {
 	}
 	if restored.Executions[len(restored.Executions)-1].Status != model.AgentExecutionRunning {
 		t.Fatalf("failed cleanup changed the ledger: %#v", restored.Executions)
+	}
+}
+
+func TestRecoverAgentExecutionsSettlesPairedRunAndChargesReceipts(t *testing.T) {
+	ctx := context.Background()
+	kernelStore, err := store.OpenSQLite(filepath.Join(t.TempDir(), "kernel.db"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = kernelStore.Close() })
+	active := createPairedActiveExecution(t, kernelStore, true)
+	execution := active.Transaction.Executions[0]
+	recoveredAt := execution.StartedAt.Add(2500 * time.Millisecond)
+	recovered, err := recoverAgentExecutions(
+		ctx,
+		kernelStore,
+		func(context.Context, string, string) error { return nil },
+		func(
+			context.Context,
+			string,
+			string,
+			string,
+			model.ModelBrokerExecution,
+		) (*model.ModelBrokerExecution, error) {
+			return &model.ModelBrokerExecution{
+				Provider:            "openai",
+				ImageDigest:         testDigest("8"),
+				PolicyDigest:        testDigest("9"),
+				ReceiptLedgerDigest: testDigest("a"),
+				Calls:               2,
+				CompletedCalls:      1,
+				UnknownCalls:        1,
+				InputTokens:         20,
+				OutputTokens:        10,
+			}, nil
+		},
+		func() time.Time { return recoveredAt },
+	)
+	if err != nil || recovered != 1 {
+		t.Fatalf("paired recovery=(%d, %v), want (1, nil)", recovered, err)
+	}
+	run, err := kernelStore.GetRun(
+		ctx,
+		active.Run.Run.Namespace,
+		active.Run.Run.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if run.Run.State != model.RunWaitingForAgent ||
+		run.Run.ActiveExecutionID != "" ||
+		run.Run.BudgetUsage.WallTimeSeconds != 3 ||
+		run.Run.BudgetUsage.ModelCalls != 2 ||
+		run.Run.BudgetUsage.InputTokens != 20 ||
+		run.Run.BudgetUsage.OutputTokens != 10 {
+		t.Fatalf("paired recovery did not settle run usage: %#v", run.Run)
+	}
+	transaction, err := kernelStore.GetTransaction(
+		ctx,
+		active.Transaction.Transaction.Namespace,
+		active.Transaction.Transaction.ID,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	settled := transaction.Executions[len(transaction.Executions)-1]
+	if settled.Status != model.AgentExecutionInterrupted ||
+		settled.ModelBroker == nil || settled.ModelBroker.UnknownCalls != 1 {
+		t.Fatalf("paired recovery did not settle transaction receipt: %#v", settled)
+	}
+	if err := kernelStore.VerifyRun(ctx, run.Run.Namespace, run.Run.ID); err != nil {
+		t.Fatalf("verify recovered run: %v", err)
+	}
+	if err := kernelStore.VerifyTransaction(
+		ctx,
+		transaction.Transaction.Namespace,
+		transaction.Transaction.ID,
+	); err != nil {
+		t.Fatalf("verify recovered transaction: %v", err)
+	}
+}
+
+func TestRecoverModelExecutionFinalizesPendingCallsAsUnknown(t *testing.T) {
+	root := t.TempDir()
+	transactionID := "tx:model-recovery"
+	runID := "run:model-recovery"
+	path := filepath.Join(
+		sandbox.ModelBrokerExecutionEvidenceDirectory(
+			root,
+			transactionID,
+			runID,
+			"execution:model-recovery",
+		),
+		"model-calls.jsonl",
+	)
+	recorder, err := kernelmodelbroker.OpenRecorder(
+		path,
+		transactionID,
+		runID,
+		"openai",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recorder.Start("gpt-test", testDigest("1"), 40, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	recover := recoverModelExecutionFrom(root)
+	receipt, err := recover(
+		context.Background(),
+		transactionID,
+		runID,
+		"execution:model-recovery",
+		model.ModelBrokerExecution{
+			Provider: "openai", ImageDigest: testDigest("2"), PolicyDigest: testDigest("3"),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Calls != 1 || receipt.UnknownCalls != 1 ||
+		receipt.CompletedCalls != 0 || receipt.FailedCalls != 0 ||
+		receipt.OutputTokens != 40 ||
+		!model.IsSHA256Digest(receipt.ReceiptLedgerDigest) {
+		t.Fatalf("pending model call was not recovered fail-closed: %#v", receipt)
+	}
+}
+
+func TestRecoverModelExecutionSupportsActiveLegacyReceiptLayout(t *testing.T) {
+	root := t.TempDir()
+	transactionID := "tx:legacy-model-recovery"
+	runID := "run:legacy-model-recovery"
+	path := filepath.Join(
+		root,
+		".gatemole-model-evidence",
+		sandbox.ModelBrokerContainerName(transactionID, runID),
+		"model-calls.jsonl",
+	)
+	recorder, err := kernelmodelbroker.OpenRecorder(
+		path,
+		transactionID,
+		runID,
+		"openai",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := recorder.Start("gpt-test", testDigest("1"), 12, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := recorder.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	receipt, err := recoverModelExecutionFrom(root)(
+		context.Background(),
+		transactionID,
+		runID,
+		"execution:legacy-model-recovery",
+		model.ModelBrokerExecution{
+			Provider: "openai", ImageDigest: testDigest("2"), PolicyDigest: testDigest("3"),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if receipt.Calls != 1 || receipt.UnknownCalls != 1 || receipt.OutputTokens != 12 {
+		t.Fatalf("legacy pending model call was not recovered: %#v", receipt)
 	}
 }
 
@@ -1123,6 +1300,168 @@ func createActiveExecution(t *testing.T, kernelStore *store.SQLiteStore) transac
 		t.Fatal(err)
 	}
 	return projection
+}
+
+func createPairedActiveExecution(
+	t *testing.T,
+	kernelStore *store.SQLiteStore,
+	withModelBroker bool,
+) store.ExecutionProjection {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Date(2026, 7, 23, 10, 0, 0, 0, time.UTC)
+	actor := model.Principal{ID: "operator:paired-recovery", Kind: model.PrincipalOperator}
+	commandDigest, err := transactionreducer.ComputeCommandDigest([]string{"agent"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	maxWall, maxCalls, maxInput, maxOutput := int64(100), int64(10), int64(1000), int64(1000)
+	resources := []model.ContractResource{{
+		ID: "workspace",
+		Selector: model.ResourceSelector{
+			Kind: "filesystem", Pattern: "workspace/**",
+		},
+		Operations: []string{"filesystem.read", "filesystem.write"},
+		Conditions: model.CapabilityConditions{
+			WorkspaceRoot: "workspace",
+		},
+	}}
+	budgets := model.BudgetLimits{MaxWallTimeSeconds: &maxWall}
+	if withModelBroker {
+		resources = append(resources, model.ContractResource{
+			ID: "model-openai",
+			Selector: model.ResourceSelector{
+				Kind: "model", Pattern: "openai/*",
+			},
+			Operations: []string{"model.invoke"},
+		})
+		budgets.MaxModelCalls = &maxCalls
+		budgets.MaxInputTokens = &maxInput
+		budgets.MaxOutputTokens = &maxOutput
+	}
+	prepared, err := admission.Prepare(
+		"team-runtime",
+		admission.Request{
+			Version:        admission.LegacyRequestVersion,
+			IdempotencyKey: "admission:paired-recovery",
+			TransactionID:  "tx:paired-recovery",
+			RunID:          "run:paired-recovery",
+			Intent:         "recover the exact interrupted execution",
+			AgentProfile: model.AgentTaskProfileBinding{
+				ID: "agent:paired-recovery", Digest: testDigest("4"),
+				RuntimeClass: "oci", ImageDigest: testDigest("5"),
+				CommandDigest: commandDigest,
+			},
+			Sponsor: model.Principal{ID: "human:paired-sponsor", Kind: model.PrincipalHuman},
+			Actor:   actor,
+			Contract: admission.ContractSpec{
+				Risk: "high", Resources: resources, Budgets: budgets,
+			},
+		},
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	admitted, created, err := kernelStore.AdmitTask(ctx, prepared)
+	if err != nil || !created {
+		t.Fatalf("admit paired recovery fixture: created=%t err=%v", created, err)
+	}
+	started, err := transactionreducer.NextEvent(
+		admitted.Transaction,
+		transactionreducer.EventTransactionStateChanged,
+		actor,
+		now.Add(time.Second),
+		transactionreducer.TransactionStateChangedPayload{
+			From: model.TransactionCreated, To: model.TransactionRunning,
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err := kernelStore.AppendTransactionEvents(
+		ctx,
+		prepared.Namespace,
+		admitted.Transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{started},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	binding := model.StageBinding{
+		ID: "stage:paired-recovery", Kind: "git_worktree",
+		Resource: model.ResourceSelector{Kind: "git_repository", Pattern: "/tmp/repository"},
+		Location: "/tmp/worktree", BaseRevision: strings.Repeat("a", 40),
+		CreatedAt: now.Add(2 * time.Second),
+	}
+	bound, err := transactionreducer.NextEvent(
+		transaction,
+		transactionreducer.EventStageBindingCreated,
+		actor,
+		binding.CreatedAt,
+		transactionreducer.StageBindingCreatedPayload{Binding: binding},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	transaction, err = kernelStore.AppendTransactionEvents(
+		ctx,
+		prepared.Namespace,
+		transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{bound},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	execution := model.AgentExecution{
+		Version: model.AgentExecutionVersion,
+		ID: transactionreducer.ExecutionID(
+			transaction.Transaction.ID,
+			transaction.Transaction.EventSequence+1,
+		),
+		TransactionID:       transaction.Transaction.ID,
+		Attempt:             transaction.Transaction.Attempt,
+		RunID:               admitted.Run.Run.ID,
+		StageBindingID:      binding.ID,
+		Program:             "agent",
+		CommandDigest:       commandDigest,
+		RuntimeClass:        "oci",
+		RuntimeConfigDigest: testDigest("6"),
+		ImageDigest:         admitted.Task.AgentProfile.ImageDigest,
+		TaskDigest:          admitted.Task.Digest,
+		Status:              model.AgentExecutionRunning,
+		StartedAt:           now.Add(3 * time.Second),
+	}
+	if withModelBroker {
+		execution.ModelBroker = &model.ModelBrokerExecution{
+			Provider: "openai", ImageDigest: testDigest("8"), PolicyDigest: testDigest("9"),
+		}
+	}
+	executionStarted, err := transactionreducer.NextEvent(
+		transaction,
+		transactionreducer.EventAgentExecutionStarted,
+		actor,
+		execution.StartedAt,
+		transactionreducer.AgentExecutionStartedPayload{Execution: execution},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paired, err := kernelStore.AppendPairedExecutionEvent(
+		ctx,
+		prepared.Namespace,
+		store.ExecutionHeads{
+			TransactionSequence: transaction.Transaction.EventSequence,
+			TransactionDigest:   transaction.LastEventDigest,
+			RunSequence:         admitted.Run.Run.EventSequence,
+			RunDigest:           admitted.Run.LastEventDigest,
+		},
+		executionStarted,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return paired
 }
 
 func testDigest(character string) string {

--- a/internal/kernel/daemon/recovery.go
+++ b/internal/kernel/daemon/recovery.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
 	"github.com/duriantaco/gatemole/internal/kernel/model"
+	kernelmodelbroker "github.com/duriantaco/gatemole/internal/kernel/modelbroker"
 	"github.com/duriantaco/gatemole/internal/kernel/sandbox"
 	"github.com/duriantaco/gatemole/internal/kernel/store"
 	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
@@ -17,18 +20,33 @@ const emptySHA256Digest = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b93
 
 type executionCleanup func(context.Context, string, string) error
 
+type modelExecutionRecovery func(
+	context.Context,
+	string,
+	string,
+	string,
+	model.ModelBrokerExecution,
+) (*model.ModelBrokerExecution, error)
+
+type executionRecoveryKey struct {
+	namespace     string
+	transactionID string
+}
+
 func recoverAgentExecutions(
 	ctx context.Context,
-	transactionStore store.TransactionStore,
+	kernelStore store.Store,
 	cleanup executionCleanup,
+	recoverModelExecution modelExecutionRecovery,
 	now func() time.Time,
 ) (int, error) {
-	projections, err := transactionStore.ListAllTransactions(ctx)
+	projections, err := kernelStore.ListAllTransactions(ctx)
 	if err != nil {
 		return 0, err
 	}
+	runHeads := make(map[executionRecoveryKey]store.ExecutionHeads)
 	for _, projection := range projections {
-		if err := transactionStore.VerifyTransaction(
+		if err := kernelStore.VerifyTransaction(
 			ctx,
 			projection.Transaction.Namespace,
 			projection.Transaction.ID,
@@ -38,6 +56,60 @@ func recoverAgentExecutions(
 				projection.Transaction.ID,
 				err,
 			)
+		}
+		if projection.Transaction.Admission == nil {
+			continue
+		}
+		runID := projection.Transaction.Admission.RunID
+		if err := kernelStore.VerifyRun(
+			ctx,
+			projection.Transaction.Namespace,
+			runID,
+		); err != nil {
+			return 0, fmt.Errorf(
+				"verify admitted run %s before recovery: %w",
+				runID,
+				err,
+			)
+		}
+		run, err := kernelStore.GetRun(
+			ctx,
+			projection.Transaction.Namespace,
+			runID,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("load admitted run %s before recovery: %w", runID, err)
+		}
+		if len(projection.Executions) > 0 {
+			execution := projection.Executions[len(projection.Executions)-1]
+			if execution.Status == model.AgentExecutionRunning {
+				paired := run.Run.State == model.RunRunning &&
+					run.Run.ActiveExecutionID == execution.ID
+				legacyUnpaired := run.Run.State == model.RunAdmitted &&
+					run.Run.ActiveExecutionID == ""
+				if !paired && !legacyUnpaired {
+					return 0, fmt.Errorf(
+						"active execution %s disagrees with admitted run %s",
+						execution.ID,
+						runID,
+					)
+				}
+			} else if run.Run.ActiveExecutionID != "" {
+				return 0, fmt.Errorf(
+					"settled execution %s disagrees with active admitted run %s",
+					execution.ID,
+					runID,
+				)
+			}
+		}
+		runHeads[executionRecoveryKey{
+			namespace:     projection.Transaction.Namespace,
+			transactionID: projection.Transaction.ID,
+		}] = store.ExecutionHeads{
+			TransactionSequence: projection.Transaction.EventSequence,
+			TransactionDigest:   projection.LastEventDigest,
+			RunSequence:         run.Run.EventSequence,
+			RunDigest:           run.LastEventDigest,
 		}
 	}
 	recovered := 0
@@ -55,6 +127,23 @@ func recoverAgentExecutions(
 		if err := cleanup(ctx, projection.Transaction.ID, execution.RunID); err != nil {
 			return recovered, fmt.Errorf("clean up interrupted execution %s: %w", execution.ID, err)
 		}
+		modelExecution := execution.ModelBroker
+		if modelExecution != nil && recoverModelExecution != nil {
+			modelExecution, err = recoverModelExecution(
+				ctx,
+				projection.Transaction.ID,
+				execution.RunID,
+				execution.ID,
+				*modelExecution,
+			)
+			if err != nil {
+				return recovered, fmt.Errorf(
+					"recover model receipts for execution %s: %w",
+					execution.ID,
+					err,
+				)
+			}
+		}
 		event, err := transactionreducer.NextEvent(
 			projection,
 			transactionreducer.EventAgentExecutionFinished,
@@ -65,13 +154,25 @@ func recoverAgentExecutions(
 				Status:       model.AgentExecutionInterrupted,
 				StdoutDigest: emptySHA256Digest,
 				StderrDigest: emptySHA256Digest,
-				ModelBroker:  execution.ModelBroker,
+				ModelBroker:  modelExecution,
 			},
 		)
 		if err != nil {
 			return recovered, fmt.Errorf("build interrupted execution receipt for %s: %w", execution.ID, err)
 		}
-		if _, err := transactionStore.AppendTransactionEvents(
+		if projection.Transaction.Admission != nil {
+			if _, err := kernelStore.AppendPairedExecutionEvent(
+				ctx,
+				projection.Transaction.Namespace,
+				runHeads[executionRecoveryKey{
+					namespace:     projection.Transaction.Namespace,
+					transactionID: projection.Transaction.ID,
+				}],
+				event,
+			); err != nil {
+				return recovered, fmt.Errorf("persist paired interrupted execution receipt for %s: %w", execution.ID, err)
+			}
+		} else if _, err := kernelStore.AppendTransactionEvents(
 			ctx,
 			projection.Transaction.Namespace,
 			projection.Transaction.EventSequence,
@@ -82,6 +183,75 @@ func recoverAgentExecutions(
 		recovered++
 	}
 	return recovered, nil
+}
+
+func recoverModelExecutionFrom(
+	transactionRoot string,
+) modelExecutionRecovery {
+	if strings.TrimSpace(transactionRoot) == "" {
+		return nil
+	}
+	return func(
+		_ context.Context,
+		transactionID string,
+		runID string,
+		executionID string,
+		original model.ModelBrokerExecution,
+	) (*model.ModelBrokerExecution, error) {
+		directory := sandbox.ModelBrokerExecutionEvidenceDirectory(
+			transactionRoot,
+			transactionID,
+			runID,
+			executionID,
+		)
+		path := filepath.Join(directory, "model-calls.jsonl")
+		if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+			if _, directoryErr := os.Stat(directory); directoryErr == nil {
+				copy := original
+				return &copy, nil
+			} else if !errors.Is(directoryErr, os.ErrNotExist) {
+				return nil, fmt.Errorf("inspect model receipt directory: %w", directoryErr)
+			}
+			// An execution started by the previous layout used one flat ledger
+			// for the transaction/run pair. New starts pre-create their scoped
+			// directory, so fallback cannot attach an older retry's flat ledger.
+			path = filepath.Join(
+				transactionRoot,
+				".gatemole-model-evidence",
+				sandbox.ModelBrokerContainerName(transactionID, runID),
+				"model-calls.jsonl",
+			)
+			if _, legacyErr := os.Stat(path); errors.Is(legacyErr, os.ErrNotExist) {
+				copy := original
+				return &copy, nil
+			} else if legacyErr != nil {
+				return nil, fmt.Errorf("inspect legacy model receipt ledger: %w", legacyErr)
+			}
+		} else if err != nil {
+			return nil, fmt.Errorf("inspect model receipt ledger: %w", err)
+		}
+		summary, err := kernelmodelbroker.FinalizeLedger(
+			path,
+			transactionID,
+			runID,
+			original.Provider,
+		)
+		if err != nil {
+			return nil, err
+		}
+		return &model.ModelBrokerExecution{
+			Provider:            original.Provider,
+			ImageDigest:         original.ImageDigest,
+			PolicyDigest:        original.PolicyDigest,
+			ReceiptLedgerDigest: summary.Digest,
+			Calls:               summary.Calls,
+			CompletedCalls:      summary.Completed,
+			FailedCalls:         summary.Failed,
+			UnknownCalls:        summary.Unknown,
+			InputTokens:         summary.InputTokens,
+			OutputTokens:        summary.OutputTokens,
+		}, nil
+	}
 }
 
 func engineExecutionCleanup(enginePath string) executionCleanup {

--- a/internal/kernel/model/types.go
+++ b/internal/kernel/model/types.go
@@ -215,6 +215,7 @@ type AgentRun struct {
 	BudgetUsage            BudgetUsage     `json:"budget_usage"`
 	Workspace              string          `json:"workspace,omitempty"`
 	Runtime                *RuntimeBinding `json:"runtime,omitempty"`
+	ActiveExecutionID      string          `json:"active_execution_id,omitempty"`
 	CapabilityIDs          []string        `json:"capability_ids"`
 	CheckpointID           string          `json:"checkpoint_id,omitempty"`
 	OutstandingApprovalIDs []string        `json:"outstanding_approval_ids"`
@@ -313,6 +314,26 @@ type RunStateChangedPayload struct {
 	From   RunState `json:"from"`
 	To     RunState `json:"to"`
 	Reason string   `json:"reason,omitempty"`
+}
+
+// RunExecutionStartedPayload binds the run ledger to the exact transaction
+// execution that currently owns its supervised workload.
+type RunExecutionStartedPayload struct {
+	TransactionID string `json:"transaction_id"`
+	ExecutionID   string `json:"execution_id"`
+	Attempt       int64  `json:"attempt"`
+}
+
+// RunExecutionFinishedPayload settles one supervised workload and charges the
+// receipt-derived usage against the remaining hard limits. Usage is a bounded
+// delta, not a replacement; the transaction receipt retains the raw counters
+// and timestamps when a charge saturates.
+type RunExecutionFinishedPayload struct {
+	TransactionID string               `json:"transaction_id"`
+	ExecutionID   string               `json:"execution_id"`
+	Attempt       int64                `json:"attempt"`
+	Status        AgentExecutionStatus `json:"status"`
+	Usage         BudgetUsage          `json:"usage"`
 }
 
 type CapabilitiesGrantedPayload struct {

--- a/internal/kernel/model/validate.go
+++ b/internal/kernel/model/validate.go
@@ -270,6 +270,14 @@ func (run AgentRun) Validate() error {
 			return err
 		}
 	}
+	if run.ActiveExecutionID != "" {
+		if err := validateIdentifier(resource, "active_execution_id", run.ActiveExecutionID); err != nil {
+			return err
+		}
+		if run.State != RunRunning {
+			return invalid(resource, "active_execution_id", "an active execution requires running state")
+		}
+	}
 	if err := validateUniqueIdentifiers(resource, "capability_ids", run.CapabilityIDs); err != nil {
 		return err
 	}

--- a/internal/kernel/reducer/reducer.go
+++ b/internal/kernel/reducer/reducer.go
@@ -2,6 +2,7 @@ package reducer
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/duriantaco/gatemole/internal/kernel/model"
 )
@@ -9,6 +10,8 @@ import (
 const (
 	EventRunCreated             = "run.created"
 	EventRunStateChanged        = "run.state_changed"
+	EventRunExecutionStarted    = "run.execution_started"
+	EventRunExecutionFinished   = "run.execution_finished"
 	EventCapabilitiesGranted    = "capabilities.granted"
 	EventActionRequested        = "action.requested"
 	EventActionDenied           = "action.denied"
@@ -178,6 +181,9 @@ func Apply(current *Projection, event model.RunEvent) (Projection, error) {
 		if err := ValidateTransition(payload.From, payload.To, payload.Reason); err != nil {
 			return Projection{}, err
 		}
+		if run.ActiveExecutionID != "" && payload.To != model.RunRunning {
+			return Projection{}, transitionError("an active execution must settle before the run can leave running state")
+		}
 		run.State = payload.To
 		run.StateReason = payload.Reason
 		if payload.To.Terminal() {
@@ -185,6 +191,22 @@ func Apply(current *Projection, event model.RunEvent) (Projection, error) {
 			run.CompletedAt = &completedAt
 		} else {
 			run.CompletedAt = nil
+		}
+	case EventRunExecutionStarted:
+		payload, err := model.DecodePayloadStrict[model.RunExecutionStartedPayload](event)
+		if err != nil {
+			return Projection{}, err
+		}
+		if err := applyExecutionStarted(&run, payload); err != nil {
+			return Projection{}, err
+		}
+	case EventRunExecutionFinished:
+		payload, err := model.DecodePayloadStrict[model.RunExecutionFinishedPayload](event)
+		if err != nil {
+			return Projection{}, err
+		}
+		if err := applyExecutionFinished(&run, payload); err != nil {
+			return Projection{}, err
 		}
 	case EventCapabilitiesGranted:
 		payload, err := model.DecodePayloadStrict[model.CapabilitiesGrantedPayload](event)
@@ -275,6 +297,80 @@ func Apply(current *Projection, event model.RunEvent) (Projection, error) {
 		return Projection{}, err
 	}
 	return Projection{Run: run, LastEventDigest: event.Digest}, nil
+}
+
+func applyExecutionStarted(run *model.AgentRun, payload model.RunExecutionStartedPayload) error {
+	if !model.IsIdentifier(payload.TransactionID) ||
+		!model.IsIdentifier(payload.ExecutionID) || payload.Attempt < 1 {
+		return transitionError("run execution start binding is invalid")
+	}
+	if run.ActiveExecutionID != "" {
+		return transitionError("run already has an active execution")
+	}
+	switch run.State {
+	case model.RunAdmitted, model.RunWaitingForAgent, model.RunWaitingForEvent:
+	default:
+		return transitionError(fmt.Sprintf("execution cannot start while run is %q", run.State))
+	}
+	if err := ValidateTransition(run.State, model.RunRunning, ""); err != nil {
+		return err
+	}
+	run.State = model.RunRunning
+	run.StateReason = ""
+	run.ActiveExecutionID = payload.ExecutionID
+	run.CompletedAt = nil
+	return nil
+}
+
+func applyExecutionFinished(run *model.AgentRun, payload model.RunExecutionFinishedPayload) error {
+	if !model.IsIdentifier(payload.TransactionID) ||
+		!model.IsIdentifier(payload.ExecutionID) || payload.Attempt < 1 ||
+		!payload.Status.Terminal() {
+		return transitionError("run execution settlement binding is invalid")
+	}
+	if run.State != model.RunRunning || run.ActiveExecutionID != payload.ExecutionID {
+		return transitionError("run execution settlement does not match the active execution")
+	}
+	usage, err := addBudgetUsage(run.BudgetUsage, payload.Usage)
+	if err != nil {
+		return err
+	}
+	run.BudgetUsage = usage
+	run.ActiveExecutionID = ""
+	run.StateReason = ""
+	if payload.Status == model.AgentExecutionSucceeded {
+		run.State = model.RunWaitingForEvent
+	} else {
+		run.State = model.RunWaitingForAgent
+	}
+	return nil
+}
+
+func addBudgetUsage(current, delta model.BudgetUsage) (model.BudgetUsage, error) {
+	values := []struct {
+		name    string
+		current *int64
+		delta   int64
+	}{
+		{"input_tokens", &current.InputTokens, delta.InputTokens},
+		{"output_tokens", &current.OutputTokens, delta.OutputTokens},
+		{"model_calls", &current.ModelCalls, delta.ModelCalls},
+		{"tool_calls", &current.ToolCalls, delta.ToolCalls},
+		{"cost_micros", &current.CostMicros, delta.CostMicros},
+		{"wall_time_seconds", &current.WallTimeSeconds, delta.WallTimeSeconds},
+	}
+	for _, value := range values {
+		if value.delta < 0 || value.delta > math.MaxInt64-*value.current {
+			return model.BudgetUsage{}, &model.KernelError{
+				Code:      model.ErrorBudgetExceeded,
+				Operation: "reduce",
+				Field:     "budget_usage." + value.name,
+				Message:   "execution budget charge is negative or overflows",
+			}
+		}
+		*value.current += value.delta
+	}
+	return current, nil
 }
 
 func applyCreation(event model.RunEvent) (Projection, error) {

--- a/internal/kernel/reducer/reducer_test.go
+++ b/internal/kernel/reducer/reducer_test.go
@@ -235,6 +235,129 @@ func TestNonStateEventsAdvanceCursorWithoutChangingState(t *testing.T) {
 	}
 }
 
+func TestRunExecutionLifecycleBindsActiveWorkAndChargesUsage(t *testing.T) {
+	t.Parallel()
+	projection, err := Apply(nil, readCreationEvent(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err = Apply(&projection, stateEvent(t, projection, model.RunAdmitted, "", 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	started := executionEvent(t, projection, EventRunExecutionStarted, model.RunExecutionStartedPayload{
+		TransactionID: "tx:demo-001",
+		ExecutionID:   "execution:demo-001",
+		Attempt:       1,
+	}, 3)
+	projection, err = Apply(&projection, started)
+	if err != nil {
+		t.Fatalf("start execution: %v", err)
+	}
+	if projection.Run.State != model.RunRunning ||
+		projection.Run.ActiveExecutionID != "execution:demo-001" {
+		t.Fatalf("execution was not bound to running run: %#v", projection.Run)
+	}
+
+	manualWait := stateEvent(t, projection, model.RunWaitingForAgent, "", 4)
+	assertKernelCode(t, applyError(projection, manualWait), model.ErrorTransitionInvalid)
+	wrongFinish := executionEvent(t, projection, EventRunExecutionFinished, model.RunExecutionFinishedPayload{
+		TransactionID: "tx:demo-001",
+		ExecutionID:   "execution:other",
+		Attempt:       1,
+		Status:        model.AgentExecutionFailed,
+	}, 4)
+	assertKernelCode(t, applyError(projection, wrongFinish), model.ErrorTransitionInvalid)
+
+	finished := executionEvent(t, projection, EventRunExecutionFinished, model.RunExecutionFinishedPayload{
+		TransactionID: "tx:demo-001",
+		ExecutionID:   "execution:demo-001",
+		Attempt:       1,
+		Status:        model.AgentExecutionSucceeded,
+		Usage: model.BudgetUsage{
+			InputTokens: 11, OutputTokens: 7, ModelCalls: 2,
+			WallTimeSeconds: 3,
+		},
+	}, 4)
+	projection, err = Apply(&projection, finished)
+	if err != nil {
+		t.Fatalf("finish execution: %v", err)
+	}
+	if projection.Run.State != model.RunWaitingForEvent ||
+		projection.Run.ActiveExecutionID != "" ||
+		projection.Run.BudgetUsage.InputTokens != 11 ||
+		projection.Run.BudgetUsage.OutputTokens != 7 ||
+		projection.Run.BudgetUsage.ModelCalls != 2 ||
+		projection.Run.BudgetUsage.WallTimeSeconds != 3 {
+		t.Fatalf("execution settlement was not projected: %#v", projection.Run)
+	}
+
+	second := executionEvent(t, projection, EventRunExecutionStarted, model.RunExecutionStartedPayload{
+		TransactionID: "tx:demo-001",
+		ExecutionID:   "execution:demo-002",
+		Attempt:       2,
+	}, 5)
+	projection, err = Apply(&projection, second)
+	if err != nil {
+		t.Fatalf("restart execution: %v", err)
+	}
+	failed := executionEvent(t, projection, EventRunExecutionFinished, model.RunExecutionFinishedPayload{
+		TransactionID: "tx:demo-001",
+		ExecutionID:   "execution:demo-002",
+		Attempt:       2,
+		Status:        model.AgentExecutionInterrupted,
+		Usage:         model.BudgetUsage{WallTimeSeconds: 1},
+	}, 6)
+	projection, err = Apply(&projection, failed)
+	if err != nil {
+		t.Fatalf("settle interrupted execution: %v", err)
+	}
+	if projection.Run.State != model.RunWaitingForAgent ||
+		projection.Run.BudgetUsage.WallTimeSeconds != 4 {
+		t.Fatalf("retryable settlement was not projected: %#v", projection.Run)
+	}
+}
+
+func TestRunExecutionSettlementFailsClosedOnInvalidUsage(t *testing.T) {
+	t.Parallel()
+	projection, err := Apply(nil, readCreationEvent(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err = Apply(&projection, stateEvent(t, projection, model.RunAdmitted, "", 2))
+	if err != nil {
+		t.Fatal(err)
+	}
+	projection, err = Apply(&projection, executionEvent(
+		t,
+		projection,
+		EventRunExecutionStarted,
+		model.RunExecutionStartedPayload{
+			TransactionID: "tx:demo-001",
+			ExecutionID:   "execution:demo-001",
+			Attempt:       1,
+		},
+		3,
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, usage := range []model.BudgetUsage{
+		{ModelCalls: -1},
+		{ModelCalls: 101},
+	} {
+		event := executionEvent(t, projection, EventRunExecutionFinished, model.RunExecutionFinishedPayload{
+			TransactionID: "tx:demo-001",
+			ExecutionID:   "execution:demo-001",
+			Attempt:       1,
+			Status:        model.AgentExecutionFailed,
+			Usage:         usage,
+		}, 4)
+		assertKernelCode(t, applyError(projection, event), model.ErrorBudgetExceeded)
+	}
+}
+
 type transitionFixture struct {
 	Initial     model.RunState `json:"initial"`
 	Transitions []struct {
@@ -286,6 +409,28 @@ func stateEvent(t *testing.T, projection Projection, to model.RunState, reason s
 		RunID:          projection.Run.ID,
 		Sequence:       int64(sequence),
 		Type:           EventRunStateChanged,
+		Actor:          model.Principal{ID: "service:gatemoled", Kind: model.PrincipalService},
+		OccurredAt:     projection.Run.UpdatedAt.Add(time.Second),
+		Payload:        mustJSON(t, payload),
+		PreviousDigest: projection.LastEventDigest,
+		Digest:         digest(fmt.Sprintf("%x", sequence%16)),
+	}
+}
+
+func executionEvent(
+	t *testing.T,
+	projection Projection,
+	eventType string,
+	payload any,
+	sequence int,
+) model.RunEvent {
+	t.Helper()
+	return model.RunEvent{
+		Version:        model.RunEventVersion,
+		ID:             fmt.Sprintf("event:demo-001:%d", sequence),
+		RunID:          projection.Run.ID,
+		Sequence:       int64(sequence),
+		Type:           eventType,
 		Actor:          model.Principal{ID: "service:gatemoled", Kind: model.PrincipalService},
 		OccurredAt:     projection.Run.UpdatedAt.Add(time.Second),
 		Payload:        mustJSON(t, payload),

--- a/internal/kernel/sandbox/model_broker.go
+++ b/internal/kernel/sandbox/model_broker.go
@@ -233,6 +233,24 @@ func ModelBrokerContainerName(transactionID, runID string) string {
 	return "gatemole-broker-" + resourceSuffix(transactionID, runID)
 }
 
+// ModelBrokerExecutionEvidenceDirectory isolates one execution's receipt
+// chain. A transaction may retry with the same run ID; sharing the old flat
+// ledger would make a later receipt cumulative and charge earlier model usage
+// twice.
+func ModelBrokerExecutionEvidenceDirectory(
+	transactionRoot,
+	transactionID,
+	runID,
+	executionID string,
+) string {
+	return filepath.Join(
+		transactionRoot,
+		".gatemole-model-evidence",
+		ModelBrokerContainerName(transactionID, runID),
+		shortResourceLabel(executionID),
+	)
+}
+
 func resourceSuffix(transactionID, runID string) string {
 	sum := sha256.Sum256([]byte(transactionID + "\x00" + runID))
 	return hex.EncodeToString(sum[:12])

--- a/internal/kernel/sandbox/oci_test.go
+++ b/internal/kernel/sandbox/oci_test.go
@@ -94,6 +94,38 @@ func TestOCIInvocationOverridesImageEntrypointForBoundProfile(t *testing.T) {
 	}
 }
 
+func TestModelBrokerEvidenceDirectoryIsExecutionScoped(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	first := ModelBrokerExecutionEvidenceDirectory(
+		root,
+		"tx:retry",
+		"run:retry",
+		"execution:first",
+	)
+	repeated := ModelBrokerExecutionEvidenceDirectory(
+		root,
+		"tx:retry",
+		"run:retry",
+		"execution:first",
+	)
+	second := ModelBrokerExecutionEvidenceDirectory(
+		root,
+		"tx:retry",
+		"run:retry",
+		"execution:second",
+	)
+	if first != repeated || first == second {
+		t.Fatalf("model evidence paths are not stable and execution-scoped: %q %q %q", first, repeated, second)
+	}
+	for _, path := range []string{first, second} {
+		relative, err := filepath.Rel(root, path)
+		if err != nil || relative == "." || strings.HasPrefix(relative, ".."+string(filepath.Separator)) {
+			t.Fatalf("model evidence path escaped root: path=%q relative=%q err=%v", path, relative, err)
+		}
+	}
+}
+
 func TestOCIRejectsMutableImagesRootAndWeakLimits(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/kernel/store/execution_store.go
+++ b/internal/kernel/store/execution_store.go
@@ -1,0 +1,600 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/duriantaco/gatemole/internal/kernel/eventlog"
+	"github.com/duriantaco/gatemole/internal/kernel/model"
+	"github.com/duriantaco/gatemole/internal/kernel/reducer"
+	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
+)
+
+const (
+	pairedExecutionOperation                   = "append_paired_execution_event"
+	pairedExecutionFaultAfterRunUpdate         = "after_run_update"
+	pairedExecutionFaultAfterRunEvent          = "after_run_event"
+	pairedExecutionFaultAfterTransactionUpdate = "after_transaction_update"
+	pairedExecutionFaultAfterTransactionEvent  = "after_transaction_event"
+	pairedExecutionFaultBeforeCommit           = "before_commit"
+)
+
+var pairedExecutionFaultPoints = []string{
+	pairedExecutionFaultAfterRunUpdate,
+	pairedExecutionFaultAfterRunEvent,
+	pairedExecutionFaultAfterTransactionUpdate,
+	pairedExecutionFaultAfterTransactionEvent,
+	pairedExecutionFaultBeforeCommit,
+}
+
+// AppendPairedExecutionEvent advances the admitted run and its transaction in
+// one SQLite commit. The transaction event is caller-authored because it
+// contains the supervised receipt; the matching run event and budget charge
+// are derived inside this boundary. Charges saturate at remaining hard limits
+// so an overrun cannot make the terminal receipt impossible to persist.
+func (s *SQLiteStore) AppendPairedExecutionEvent(
+	ctx context.Context,
+	namespace string,
+	heads ExecutionHeads,
+	transactionEvent model.TransactionEvent,
+) (ExecutionProjection, error) {
+	if err := validateNamespace(namespace); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if heads.TransactionSequence < 1 || heads.RunSequence < 1 ||
+		!digestPattern.MatchString(heads.TransactionDigest) ||
+		!digestPattern.MatchString(heads.RunDigest) {
+		return ExecutionProjection{}, storeError(
+			model.ErrorSchemaInvalid,
+			pairedExecutionOperation,
+			transactionEvent.TransactionID,
+			"both execution ledger heads must be valid",
+			nil,
+		)
+	}
+	if transactionEvent.Type != transactionreducer.EventAgentExecutionStarted &&
+		transactionEvent.Type != transactionreducer.EventAgentExecutionFinished {
+		return ExecutionProjection{}, storeError(
+			model.ErrorSchemaInvalid,
+			pairedExecutionOperation,
+			transactionEvent.ID,
+			"only agent execution start and finish events can be paired",
+			nil,
+		)
+	}
+	if err := verifyTransactionEventDigest(transactionEvent); err != nil {
+		return ExecutionProjection{}, err
+	}
+
+	tx, err := s.db.BeginTx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return ExecutionProjection{}, storeError(
+			model.ErrorInternal,
+			pairedExecutionOperation,
+			transactionEvent.TransactionID,
+			"begin paired execution transaction",
+			err,
+		)
+	}
+	defer tx.Rollback()
+
+	currentTransaction, err := loadTransactionProjection(
+		ctx,
+		tx,
+		namespace,
+		transactionEvent.TransactionID,
+	)
+	if err != nil {
+		return ExecutionProjection{}, err
+	}
+	if currentTransaction.Transaction.EventSequence != heads.TransactionSequence ||
+		currentTransaction.LastEventDigest != heads.TransactionDigest {
+		return ExecutionProjection{}, conflict(
+			pairedExecutionOperation,
+			transactionEvent.TransactionID,
+			"transaction changed after execution authority was loaded",
+			nil,
+		)
+	}
+	currentRun, err := loadAdmittedExecutionRun(
+		ctx,
+		tx,
+		namespace,
+		currentTransaction,
+	)
+	if err != nil {
+		return ExecutionProjection{}, err
+	}
+	if currentRun.Run.EventSequence != heads.RunSequence ||
+		currentRun.LastEventDigest != heads.RunDigest {
+		return ExecutionProjection{}, conflict(
+			pairedExecutionOperation,
+			currentRun.Run.ID,
+			"admitted run changed after execution authority was loaded",
+			nil,
+		)
+	}
+
+	nextTransaction, err := transactionreducer.Apply(
+		&currentTransaction,
+		transactionEvent,
+	)
+	if err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := nextTransaction.Validate(); err != nil {
+		return ExecutionProjection{}, err
+	}
+	execution, err := pairedExecutionReceipt(
+		transactionEvent,
+		nextTransaction,
+		currentRun.Run.ID,
+	)
+	if err != nil {
+		return ExecutionProjection{}, err
+	}
+	runEvents, nextRun, err := pairedRunEvents(
+		currentRun,
+		transactionEvent,
+		execution,
+	)
+	if err != nil {
+		return ExecutionProjection{}, err
+	}
+	for _, runEvent := range runEvents {
+		if err := verifyEventDigest(runEvent); err != nil {
+			return ExecutionProjection{}, err
+		}
+	}
+
+	runJSON, err := json.Marshal(nextRun.Run)
+	if err != nil {
+		return ExecutionProjection{}, storeError(
+			model.ErrorInternal,
+			pairedExecutionOperation,
+			currentRun.Run.ID,
+			"encode paired run projection",
+			err,
+		)
+	}
+	runEventJSON := make([][]byte, len(runEvents))
+	for index, runEvent := range runEvents {
+		runEventJSON[index], err = json.Marshal(runEvent)
+		if err != nil {
+			return ExecutionProjection{}, storeError(
+				model.ErrorInternal,
+				pairedExecutionOperation,
+				runEvent.ID,
+				"encode paired run event",
+				err,
+			)
+		}
+	}
+	transactionJSON, err := json.Marshal(nextTransaction)
+	if err != nil {
+		return ExecutionProjection{}, storeError(
+			model.ErrorInternal,
+			pairedExecutionOperation,
+			currentTransaction.Transaction.ID,
+			"encode paired transaction projection",
+			err,
+		)
+	}
+	transactionEventJSON, err := json.Marshal(transactionEvent)
+	if err != nil {
+		return ExecutionProjection{}, storeError(
+			model.ErrorInternal,
+			pairedExecutionOperation,
+			transactionEvent.ID,
+			"encode paired transaction event",
+			err,
+		)
+	}
+
+	if err := updatePairedRun(
+		ctx,
+		tx,
+		namespace,
+		currentRun,
+		nextRun,
+		runJSON,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := s.runPairedExecutionFault(
+		pairedExecutionFaultAfterRunUpdate,
+		execution.ID,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	for index, runEvent := range runEvents {
+		if err := insertEvent(
+			ctx,
+			tx,
+			namespace,
+			runEvent,
+			runEventJSON[index],
+		); err != nil {
+			return ExecutionProjection{}, err
+		}
+		if err := s.runPairedExecutionFault(
+			pairedExecutionFaultAfterRunEvent,
+			execution.ID,
+		); err != nil {
+			return ExecutionProjection{}, err
+		}
+	}
+	if err := updatePairedTransaction(
+		ctx,
+		tx,
+		namespace,
+		currentTransaction,
+		nextTransaction,
+		transactionJSON,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := s.runPairedExecutionFault(
+		pairedExecutionFaultAfterTransactionUpdate,
+		execution.ID,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := insertTransactionEvent(
+		ctx,
+		tx,
+		namespace,
+		transactionEvent,
+		transactionEventJSON,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := s.runPairedExecutionFault(
+		pairedExecutionFaultAfterTransactionEvent,
+		execution.ID,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := s.runPairedExecutionFault(
+		pairedExecutionFaultBeforeCommit,
+		execution.ID,
+	); err != nil {
+		return ExecutionProjection{}, err
+	}
+	if err := tx.Commit(); err != nil {
+		return ExecutionProjection{}, classifyWriteError(
+			pairedExecutionOperation,
+			execution.ID,
+			err,
+		)
+	}
+	return ExecutionProjection{Run: nextRun, Transaction: nextTransaction}, nil
+}
+
+func loadAdmittedExecutionRun(
+	ctx context.Context,
+	tx *sql.Tx,
+	namespace string,
+	transaction transactionreducer.Projection,
+) (reducer.Projection, error) {
+	binding := transaction.Transaction.Admission
+	task := transaction.Transaction.Task
+	if binding == nil || task == nil {
+		return reducer.Projection{}, storeError(
+			model.ErrorCapabilityDenied,
+			pairedExecutionOperation,
+			transaction.Transaction.ID,
+			"paired execution requires atomic task admission",
+			nil,
+		)
+	}
+	var runID, taskDigest, contractDigest string
+	err := tx.QueryRowContext(
+		ctx,
+		`SELECT run_id, task_digest, contract_digest
+		 FROM task_admissions
+		 WHERE namespace = ? AND transaction_id = ?`,
+		namespace,
+		transaction.Transaction.ID,
+	).Scan(&runID, &taskDigest, &contractDigest)
+	if errors.Is(err, sql.ErrNoRows) {
+		return reducer.Projection{}, storeError(
+			model.ErrorNotFound,
+			pairedExecutionOperation,
+			transaction.Transaction.ID,
+			"transaction has no admitted run in namespace",
+			err,
+		)
+	}
+	if err != nil {
+		return reducer.Projection{}, storeError(
+			model.ErrorInternal,
+			pairedExecutionOperation,
+			transaction.Transaction.ID,
+			"query admitted run binding",
+			err,
+		)
+	}
+	if runID != binding.RunID || runID != task.RunID ||
+		taskDigest != binding.TaskDigest || taskDigest != task.Digest ||
+		contractDigest != binding.ContractDigest {
+		return reducer.Projection{}, storeError(
+			model.ErrorEventChain,
+			pairedExecutionOperation,
+			transaction.Transaction.ID,
+			"admission and transaction execution bindings disagree",
+			nil,
+		)
+	}
+	return loadProjection(ctx, tx, namespace, runID)
+}
+
+func pairedExecutionReceipt(
+	event model.TransactionEvent,
+	projection transactionreducer.Projection,
+	runID string,
+) (model.AgentExecution, error) {
+	var execution model.AgentExecution
+	switch event.Type {
+	case transactionreducer.EventAgentExecutionStarted:
+		if len(projection.Executions) == 0 {
+			return model.AgentExecution{}, storeError(
+				model.ErrorEventChain,
+				pairedExecutionOperation,
+				event.ID,
+				"execution start produced no receipt",
+				nil,
+			)
+		}
+		execution = projection.Executions[len(projection.Executions)-1]
+	case transactionreducer.EventAgentExecutionFinished:
+		payload, err := model.DecodeStrict[transactionreducer.AgentExecutionFinishedPayload](event.Payload)
+		if err != nil {
+			return model.AgentExecution{}, err
+		}
+		for index := range projection.Executions {
+			if projection.Executions[index].ID == payload.ExecutionID {
+				execution = projection.Executions[index]
+				break
+			}
+		}
+	}
+	if execution.ID == "" || execution.RunID != runID || execution.Attempt < 1 {
+		return model.AgentExecution{}, storeError(
+			model.ErrorIdentityInvalid,
+			pairedExecutionOperation,
+			event.ID,
+			"transaction execution does not match the admitted run",
+			nil,
+		)
+	}
+	return execution, nil
+}
+
+func pairedRunEvents(
+	projection reducer.Projection,
+	transactionEvent model.TransactionEvent,
+	execution model.AgentExecution,
+) ([]model.RunEvent, reducer.Projection, error) {
+	events := []model.RunEvent{}
+	current := projection
+	appendEvent := func(eventType string, occurredAt time.Time, payload any) error {
+		event, err := eventlog.Next(
+			current,
+			eventType,
+			transactionEvent.Actor,
+			occurredAt,
+			payload,
+		)
+		if err != nil {
+			return err
+		}
+		next, err := reducer.Apply(&current, event)
+		if err != nil {
+			return err
+		}
+		events = append(events, event)
+		current = next
+		return nil
+	}
+	startPayload := model.RunExecutionStartedPayload{
+		TransactionID: execution.TransactionID,
+		ExecutionID:   execution.ID,
+		Attempt:       execution.Attempt,
+	}
+	switch transactionEvent.Type {
+	case transactionreducer.EventAgentExecutionStarted:
+		if err := appendEvent(
+			reducer.EventRunExecutionStarted,
+			transactionEvent.OccurredAt,
+			startPayload,
+		); err != nil {
+			return nil, reducer.Projection{}, err
+		}
+	case transactionreducer.EventAgentExecutionFinished:
+		// Before paired lifecycle existed, a crash could leave an admitted run
+		// beside an already-running transaction execution. Reconstruct that
+		// missing run-side start in the same commit as recovery settlement.
+		if current.Run.ActiveExecutionID == "" && current.Run.State == model.RunAdmitted {
+			if err := appendEvent(
+				reducer.EventRunExecutionStarted,
+				execution.StartedAt,
+				startPayload,
+			); err != nil {
+				return nil, reducer.Projection{}, err
+			}
+		}
+		if err := appendEvent(
+			reducer.EventRunExecutionFinished,
+			transactionEvent.OccurredAt,
+			model.RunExecutionFinishedPayload{
+				TransactionID: execution.TransactionID,
+				ExecutionID:   execution.ID,
+				Attempt:       execution.Attempt,
+				Status:        execution.Status,
+				Usage:         executionBudgetUsage(execution, current.Run),
+			},
+		); err != nil {
+			return nil, reducer.Projection{}, err
+		}
+	default:
+		return nil, reducer.Projection{}, fmt.Errorf("unsupported paired event %q", transactionEvent.Type)
+	}
+	return events, current, nil
+}
+
+func executionBudgetUsage(
+	execution model.AgentExecution,
+	run model.AgentRun,
+) model.BudgetUsage {
+	usage := model.BudgetUsage{}
+	if execution.CompletedAt != nil {
+		duration := execution.CompletedAt.Sub(execution.StartedAt)
+		usage.WallTimeSeconds = int64(duration / time.Second)
+		if duration%time.Second != 0 {
+			usage.WallTimeSeconds++
+		}
+	}
+	if execution.ModelBroker != nil {
+		usage.ModelCalls = execution.ModelBroker.Calls
+		usage.InputTokens = execution.ModelBroker.InputTokens
+		usage.OutputTokens = execution.ModelBroker.OutputTokens
+	}
+	usage.InputTokens = boundedBudgetCharge(
+		usage.InputTokens, run.BudgetUsage.InputTokens, run.BudgetLimits.MaxInputTokens,
+	)
+	usage.OutputTokens = boundedBudgetCharge(
+		usage.OutputTokens, run.BudgetUsage.OutputTokens, run.BudgetLimits.MaxOutputTokens,
+	)
+	usage.ModelCalls = boundedBudgetCharge(
+		usage.ModelCalls, run.BudgetUsage.ModelCalls, run.BudgetLimits.MaxModelCalls,
+	)
+	usage.ToolCalls = boundedBudgetCharge(
+		usage.ToolCalls, run.BudgetUsage.ToolCalls, run.BudgetLimits.MaxToolCalls,
+	)
+	usage.CostMicros = boundedBudgetCharge(
+		usage.CostMicros, run.BudgetUsage.CostMicros, run.BudgetLimits.MaxCostMicros,
+	)
+	usage.WallTimeSeconds = boundedBudgetCharge(
+		usage.WallTimeSeconds,
+		run.BudgetUsage.WallTimeSeconds,
+		run.BudgetLimits.MaxWallTimeSeconds,
+	)
+	return usage
+}
+
+func boundedBudgetCharge(actual, current int64, limit *int64) int64 {
+	if actual <= 0 {
+		return 0
+	}
+	remaining := int64(math.MaxInt64)
+	if current >= 0 {
+		remaining -= current
+	} else {
+		return 0
+	}
+	if limit != nil {
+		limitedRemaining := *limit - current
+		if limitedRemaining < remaining {
+			remaining = limitedRemaining
+		}
+	}
+	if remaining <= 0 {
+		return 0
+	}
+	if actual > remaining {
+		return remaining
+	}
+	return actual
+}
+
+func updatePairedRun(
+	ctx context.Context,
+	tx *sql.Tx,
+	namespace string,
+	current, next reducer.Projection,
+	projectionJSON []byte,
+) error {
+	result, err := tx.ExecContext(
+		ctx,
+		`UPDATE runs
+		 SET event_sequence = ?, last_event_digest = ?, state_json = ?, updated_at = ?
+		 WHERE namespace = ? AND run_id = ?
+		   AND event_sequence = ? AND last_event_digest = ?`,
+		next.Run.EventSequence,
+		next.LastEventDigest,
+		projectionJSON,
+		next.Run.UpdatedAt.Format(timeFormat),
+		namespace,
+		current.Run.ID,
+		current.Run.EventSequence,
+		current.LastEventDigest,
+	)
+	if err != nil {
+		return classifyWriteError(pairedExecutionOperation, current.Run.ID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return storeError(model.ErrorInternal, pairedExecutionOperation, current.Run.ID, "read run update result", err)
+	}
+	if rows != 1 {
+		return conflict(pairedExecutionOperation, current.Run.ID, "run changed during paired append", nil)
+	}
+	return nil
+}
+
+func updatePairedTransaction(
+	ctx context.Context,
+	tx *sql.Tx,
+	namespace string,
+	current, next transactionreducer.Projection,
+	projectionJSON []byte,
+) error {
+	result, err := tx.ExecContext(
+		ctx,
+		`UPDATE agent_transactions
+		 SET event_sequence = ?, last_event_digest = ?, projection_json = ?, updated_at = ?
+		 WHERE namespace = ? AND transaction_id = ?
+		   AND event_sequence = ? AND last_event_digest = ?`,
+		next.Transaction.EventSequence,
+		next.LastEventDigest,
+		projectionJSON,
+		next.Transaction.UpdatedAt.Format(timeFormat),
+		namespace,
+		current.Transaction.ID,
+		current.Transaction.EventSequence,
+		current.LastEventDigest,
+	)
+	if err != nil {
+		return classifyWriteError(pairedExecutionOperation, current.Transaction.ID, err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return storeError(model.ErrorInternal, pairedExecutionOperation, current.Transaction.ID, "read transaction update result", err)
+	}
+	if rows != 1 {
+		return conflict(pairedExecutionOperation, current.Transaction.ID, "transaction changed during paired append", nil)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) runPairedExecutionFault(point, executionID string) error {
+	if s.pairedExecutionFault == nil {
+		return nil
+	}
+	if err := s.pairedExecutionFault(point); err != nil {
+		return storeError(
+			model.ErrorInternal,
+			pairedExecutionOperation,
+			executionID,
+			fmt.Sprintf("paired execution persistence fault at %s", point),
+			err,
+		)
+	}
+	return nil
+}

--- a/internal/kernel/store/launch_claim_store_test.go
+++ b/internal/kernel/store/launch_claim_store_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,23 +15,27 @@ import (
 	transactionreducer "github.com/duriantaco/gatemole/internal/kernel/transaction"
 )
 
-func TestAppendTransactionEventsIfRunCurrentClaimsLaunch(t *testing.T) {
+func TestAppendPairedExecutionEventClaimsBothLedgers(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	kernelStore := openTestStore(t)
 	fixture := prepareLaunchClaim(t, ctx, kernelStore, "claim-success")
 
-	claimed, err := kernelStore.AppendTransactionEventsIfRunCurrent(
+	paired, err := kernelStore.AppendPairedExecutionEvent(
 		ctx,
 		fixture.admission.Task.Namespace,
-		fixture.transaction.Transaction.EventSequence,
-		fixture.admission.Run.Run.EventSequence,
-		fixture.admission.Run.LastEventDigest,
-		[]model.TransactionEvent{fixture.startEvent},
+		ExecutionHeads{
+			TransactionSequence: fixture.transaction.Transaction.EventSequence,
+			TransactionDigest:   fixture.transaction.LastEventDigest,
+			RunSequence:         fixture.admission.Run.Run.EventSequence,
+			RunDigest:           fixture.admission.Run.LastEventDigest,
+		},
+		fixture.startEvent,
 	)
 	if err != nil {
 		t.Fatalf("claim launch: %v", err)
 	}
+	claimed := paired.Transaction
 	if claimed.Transaction.EventSequence !=
 		fixture.transaction.Transaction.EventSequence+1 ||
 		len(claimed.Executions) != 1 ||
@@ -38,16 +43,10 @@ func TestAppendTransactionEventsIfRunCurrentClaimsLaunch(t *testing.T) {
 		claimed.Executions[0].RunID != fixture.admission.Run.Run.ID {
 		t.Fatalf("unexpected claimed projection: %#v", claimed)
 	}
-	currentRun, err := kernelStore.GetRun(
-		ctx,
-		fixture.admission.Task.Namespace,
-		fixture.admission.Run.Run.ID,
-	)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !reflect.DeepEqual(currentRun, fixture.admission.Run) {
-		t.Fatal("launch claim mutated the admitted run")
+	if paired.Run.Run.State != model.RunRunning ||
+		paired.Run.Run.ActiveExecutionID != claimed.Executions[0].ID ||
+		paired.Run.Run.EventSequence != fixture.admission.Run.Run.EventSequence+1 {
+		t.Fatalf("run was not paired with launch: %#v", paired.Run)
 	}
 	events, err := kernelStore.TransactionEvents(
 		ctx,
@@ -63,9 +62,22 @@ func TestAppendTransactionEventsIfRunCurrentClaimsLaunch(t *testing.T) {
 			transactionreducer.EventAgentExecutionStarted {
 		t.Fatalf("launch event was not durably appended: %#v", events)
 	}
+	runEvents, err := kernelStore.Events(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Run.Run.ID,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(runEvents) != int(paired.Run.Run.EventSequence) ||
+		runEvents[len(runEvents)-1].Type != reducer.EventRunExecutionStarted {
+		t.Fatalf("paired run event was not durably appended: %#v", runEvents)
+	}
 }
 
-func TestAppendTransactionEventsIfRunCurrentConflictsWithoutAppend(
+func TestAppendPairedExecutionEventConflictsWithoutPartialAppend(
 	t *testing.T,
 ) {
 	t.Parallel()
@@ -107,13 +119,16 @@ func TestAppendTransactionEventsIfRunCurrentConflictsWithoutAppend(
 		t.Fatalf("advance run before launch claim: %v", err)
 	}
 
-	_, err = kernelStore.AppendTransactionEventsIfRunCurrent(
+	_, err = kernelStore.AppendPairedExecutionEvent(
 		ctx,
 		fixture.admission.Task.Namespace,
-		fixture.transaction.Transaction.EventSequence,
-		fixture.admission.Run.Run.EventSequence,
-		fixture.admission.Run.LastEventDigest,
-		[]model.TransactionEvent{fixture.startEvent},
+		ExecutionHeads{
+			TransactionSequence: fixture.transaction.Transaction.EventSequence,
+			TransactionDigest:   fixture.transaction.LastEventDigest,
+			RunSequence:         fixture.admission.Run.Run.EventSequence,
+			RunDigest:           fixture.admission.Run.LastEventDigest,
+		},
+		fixture.startEvent,
 	)
 	assertKernelCode(t, err, model.ErrorConflict)
 
@@ -139,6 +154,285 @@ func TestAppendTransactionEventsIfRunCurrentConflictsWithoutAppend(
 	}
 	if !reflect.DeepEqual(afterEvents, beforeEvents) {
 		t.Fatal("run-head conflict appended a transaction event")
+	}
+}
+
+func TestAppendPairedExecutionEventSettlesRunAndChargesWallTime(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	fixture := prepareLaunchClaim(t, ctx, kernelStore, "settle")
+	paired, err := kernelStore.AppendPairedExecutionEvent(
+		ctx,
+		fixture.admission.Task.Namespace,
+		ExecutionHeads{
+			TransactionSequence: fixture.transaction.Transaction.EventSequence,
+			TransactionDigest:   fixture.transaction.LastEventDigest,
+			RunSequence:         fixture.admission.Run.Run.EventSequence,
+			RunDigest:           fixture.admission.Run.LastEventDigest,
+		},
+		fixture.startEvent,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exitCode := 17
+	completedAt := paired.Transaction.Executions[0].StartedAt.Add(2500 * time.Millisecond)
+	finished, err := transactionreducer.NextEvent(
+		paired.Transaction,
+		transactionreducer.EventAgentExecutionFinished,
+		model.Principal{ID: "service:gatemoled-runtime", Kind: model.PrincipalService},
+		completedAt,
+		transactionreducer.AgentExecutionFinishedPayload{
+			ExecutionID:  paired.Transaction.Executions[0].ID,
+			Status:       model.AgentExecutionFailed,
+			ExitCode:     &exitCode,
+			StdoutDigest: "sha256:" + strings.Repeat("e", 64),
+			StderrDigest: "sha256:" + strings.Repeat("f", 64),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paired, err = kernelStore.AppendPairedExecutionEvent(
+		ctx,
+		fixture.admission.Task.Namespace,
+		ExecutionHeads{
+			TransactionSequence: paired.Transaction.Transaction.EventSequence,
+			TransactionDigest:   paired.Transaction.LastEventDigest,
+			RunSequence:         paired.Run.Run.EventSequence,
+			RunDigest:           paired.Run.LastEventDigest,
+		},
+		finished,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paired.Transaction.Executions[0].Status != model.AgentExecutionFailed ||
+		paired.Run.Run.State != model.RunWaitingForAgent ||
+		paired.Run.Run.ActiveExecutionID != "" ||
+		paired.Run.Run.BudgetUsage.WallTimeSeconds != 3 {
+		t.Fatalf("execution did not settle both ledgers: %#v", paired)
+	}
+	if err := kernelStore.VerifyRun(
+		ctx,
+		fixture.admission.Task.Namespace,
+		paired.Run.Run.ID,
+	); err != nil {
+		t.Fatalf("verify settled run: %v", err)
+	}
+	if err := kernelStore.VerifyTransaction(
+		ctx,
+		fixture.admission.Task.Namespace,
+		paired.Transaction.Transaction.ID,
+	); err != nil {
+		t.Fatalf("verify settled transaction: %v", err)
+	}
+}
+
+func TestPairedSettlementReconcilesLegacyUnpairedActiveExecution(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	kernelStore := openTestStore(t)
+	fixture := prepareLaunchClaim(t, ctx, kernelStore, "legacy-active")
+	legacyTransaction, err := kernelStore.AppendTransactionEvents(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.transaction.Transaction.EventSequence,
+		[]model.TransactionEvent{fixture.startEvent},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	exitCode := 9
+	finished, err := transactionreducer.NextEvent(
+		legacyTransaction,
+		transactionreducer.EventAgentExecutionFinished,
+		model.Principal{ID: "service:gatemoled-recovery", Kind: model.PrincipalService},
+		legacyTransaction.Executions[0].StartedAt.Add(2*time.Second),
+		transactionreducer.AgentExecutionFinishedPayload{
+			ExecutionID:  legacyTransaction.Executions[0].ID,
+			Status:       model.AgentExecutionFailed,
+			ExitCode:     &exitCode,
+			StdoutDigest: "sha256:" + strings.Repeat("e", 64),
+			StderrDigest: "sha256:" + strings.Repeat("f", 64),
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	paired, err := kernelStore.AppendPairedExecutionEvent(
+		ctx,
+		fixture.admission.Task.Namespace,
+		ExecutionHeads{
+			TransactionSequence: legacyTransaction.Transaction.EventSequence,
+			TransactionDigest:   legacyTransaction.LastEventDigest,
+			RunSequence:         fixture.admission.Run.Run.EventSequence,
+			RunDigest:           fixture.admission.Run.LastEventDigest,
+		},
+		finished,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if paired.Run.Run.State != model.RunWaitingForAgent ||
+		paired.Run.Run.ActiveExecutionID != "" ||
+		paired.Run.Run.EventSequence != fixture.admission.Run.Run.EventSequence+2 ||
+		paired.Run.Run.BudgetUsage.WallTimeSeconds != 2 {
+		t.Fatalf("legacy execution was not reconciled: %#v", paired.Run)
+	}
+	events, err := kernelStore.Events(
+		ctx,
+		fixture.admission.Task.Namespace,
+		fixture.admission.Run.Run.ID,
+		fixture.admission.Run.Run.EventSequence,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 2 || events[0].Type != reducer.EventRunExecutionStarted ||
+		events[1].Type != reducer.EventRunExecutionFinished {
+		t.Fatalf("legacy reconciliation events=%#v", events)
+	}
+}
+
+func TestPairedExecutionFaultsRollBackBothLedgers(t *testing.T) {
+	t.Parallel()
+	for _, point := range pairedExecutionFaultPoints {
+		point := point
+		t.Run(point, func(t *testing.T) {
+			t.Parallel()
+			ctx := context.Background()
+			kernelStore := openTestStore(t)
+			fixture := prepareLaunchClaim(
+				t,
+				ctx,
+				kernelStore,
+				"fault-"+strings.ReplaceAll(point, "_", "-"),
+			)
+			beforeRunEvents, err := kernelStore.Events(
+				ctx,
+				fixture.admission.Task.Namespace,
+				fixture.admission.Run.Run.ID,
+				0,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			beforeTransactionEvents, err := kernelStore.TransactionEvents(
+				ctx,
+				fixture.admission.Task.Namespace,
+				fixture.transaction.Transaction.ID,
+				0,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			injected := errors.New("injected paired execution failure")
+			kernelStore.pairedExecutionFault = func(candidate string) error {
+				if candidate == point {
+					return injected
+				}
+				return nil
+			}
+			_, err = kernelStore.AppendPairedExecutionEvent(
+				ctx,
+				fixture.admission.Task.Namespace,
+				ExecutionHeads{
+					TransactionSequence: fixture.transaction.Transaction.EventSequence,
+					TransactionDigest:   fixture.transaction.LastEventDigest,
+					RunSequence:         fixture.admission.Run.Run.EventSequence,
+					RunDigest:           fixture.admission.Run.LastEventDigest,
+				},
+				fixture.startEvent,
+			)
+			if !errors.Is(err, injected) {
+				t.Fatalf("paired append error=%v, want injected fault", err)
+			}
+			afterRun, getErr := kernelStore.GetRun(
+				ctx,
+				fixture.admission.Task.Namespace,
+				fixture.admission.Run.Run.ID,
+			)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			afterTransaction, getErr := kernelStore.GetTransaction(
+				ctx,
+				fixture.admission.Task.Namespace,
+				fixture.transaction.Transaction.ID,
+			)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			afterRunEvents, getErr := kernelStore.Events(
+				ctx,
+				fixture.admission.Task.Namespace,
+				fixture.admission.Run.Run.ID,
+				0,
+			)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			afterTransactionEvents, getErr := kernelStore.TransactionEvents(
+				ctx,
+				fixture.admission.Task.Namespace,
+				fixture.transaction.Transaction.ID,
+				0,
+			)
+			if getErr != nil {
+				t.Fatal(getErr)
+			}
+			if !reflect.DeepEqual(afterRun, fixture.admission.Run) ||
+				!reflect.DeepEqual(afterTransaction, fixture.transaction) ||
+				!reflect.DeepEqual(afterRunEvents, beforeRunEvents) ||
+				!reflect.DeepEqual(afterTransactionEvents, beforeTransactionEvents) {
+				t.Fatal("fault left a partial paired execution mutation")
+			}
+		})
+	}
+}
+
+func TestExecutionBudgetUsageIncludesModelReceiptAndRoundsWallTimeUp(t *testing.T) {
+	t.Parallel()
+	startedAt := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(time.Second + time.Nanosecond)
+	usage := executionBudgetUsage(model.AgentExecution{
+		StartedAt:   startedAt,
+		CompletedAt: &completedAt,
+		ModelBroker: &model.ModelBrokerExecution{
+			Calls: 4, InputTokens: 120, OutputTokens: 45,
+		},
+	}, model.AgentRun{})
+	if usage.WallTimeSeconds != 2 || usage.ModelCalls != 4 ||
+		usage.InputTokens != 120 || usage.OutputTokens != 45 {
+		t.Fatalf("unexpected execution budget charge: %#v", usage)
+	}
+}
+
+func TestExecutionBudgetUsageSaturatesAtRemainingHardLimits(t *testing.T) {
+	t.Parallel()
+	startedAt := time.Date(2026, 7, 27, 12, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(10 * time.Second)
+	maxCalls, maxInput, maxOutput, maxWall := int64(5), int64(100), int64(80), int64(20)
+	usage := executionBudgetUsage(model.AgentExecution{
+		StartedAt:   startedAt,
+		CompletedAt: &completedAt,
+		ModelBroker: &model.ModelBrokerExecution{
+			Calls: 4, InputTokens: 120, OutputTokens: 45,
+		},
+	}, model.AgentRun{
+		BudgetLimits: model.BudgetLimits{
+			MaxModelCalls: &maxCalls, MaxInputTokens: &maxInput,
+			MaxOutputTokens: &maxOutput, MaxWallTimeSeconds: &maxWall,
+		},
+		BudgetUsage: model.BudgetUsage{
+			ModelCalls: 3, InputTokens: 90, OutputTokens: 70, WallTimeSeconds: 18,
+		},
+	})
+	if usage.ModelCalls != 2 || usage.InputTokens != 10 ||
+		usage.OutputTokens != 10 || usage.WallTimeSeconds != 2 {
+		t.Fatalf("execution charge did not saturate at hard limits: %#v", usage)
 	}
 }
 

--- a/internal/kernel/store/sqlite.go
+++ b/internal/kernel/store/sqlite.go
@@ -20,8 +20,9 @@ import (
 const sqliteSchemaVersion = 3
 
 type SQLiteStore struct {
-	db             *sql.DB
-	admissionFault func(string) error
+	db                   *sql.DB
+	admissionFault       func(string) error
+	pairedExecutionFault func(string) error
 }
 
 // Health performs a bounded, constant-work database readiness check. It does

--- a/internal/kernel/store/store.go
+++ b/internal/kernel/store/store.go
@@ -41,7 +41,28 @@ type AdmissionStore interface {
 	GetTaskAdmission(context.Context, string, string) (admission.Result, string, error)
 	GetExecutionAuthority(context.Context, string, string) (ExecutionAuthoritySnapshot, error)
 	GetExecutionAuthorityForRun(context.Context, string, string) (ExecutionAuthoritySnapshot, error)
-	AppendTransactionEventsIfRunCurrent(context.Context, string, int64, int64, string, []model.TransactionEvent) (transactionreducer.Projection, error)
+}
+
+// ExecutionHeads pins both ledgers at one authority snapshot. A paired append
+// must reject the whole mutation when either head has changed.
+type ExecutionHeads struct {
+	TransactionSequence int64
+	TransactionDigest   string
+	RunSequence         int64
+	RunDigest           string
+}
+
+// ExecutionProjection is the result of one atomically paired execution event.
+type ExecutionProjection struct {
+	Run         reducer.Projection
+	Transaction transactionreducer.Projection
+}
+
+// ExecutionStore owns the cross-ledger execution lifecycle. Implementations
+// must append the run and transaction events and update both projections in
+// one database transaction.
+type ExecutionStore interface {
+	AppendPairedExecutionEvent(context.Context, string, ExecutionHeads, model.TransactionEvent) (ExecutionProjection, error)
 }
 
 // ExecutionAuthoritySnapshot is the consistently read authority envelope used
@@ -63,6 +84,7 @@ type Store interface {
 	EventStore
 	TransactionStore
 	AdmissionStore
+	ExecutionStore
 	Health(context.Context) error
 	Close() error
 }

--- a/internal/kernel/store/transaction_store.go
+++ b/internal/kernel/store/transaction_store.go
@@ -83,59 +83,7 @@ func (s *SQLiteStore) AppendTransactionEvents(
 		expectedSequence,
 		events,
 		"append_transaction_events",
-		nil,
 	)
-}
-
-// AppendTransactionEventsIfRunCurrent atomically claims launch in the
-// transaction ledger only while the run admitted with that transaction still
-// has the exact event head verified by the caller's authority snapshot.
-func (s *SQLiteStore) AppendTransactionEventsIfRunCurrent(
-	ctx context.Context,
-	namespace string,
-	expectedTransactionSequence int64,
-	expectedRunSequence int64,
-	expectedRunDigest string,
-	events []model.TransactionEvent,
-) (transactionreducer.Projection, error) {
-	const operation = "append_transaction_events_if_run_current"
-	if expectedTransactionSequence < 1 ||
-		expectedRunSequence < 1 ||
-		!digestPattern.MatchString(expectedRunDigest) {
-		return transactionreducer.Projection{}, storeError(
-			model.ErrorSchemaInvalid,
-			operation,
-			"",
-			"expected transaction and run heads are invalid",
-			nil,
-		)
-	}
-	if len(events) != 1 ||
-		events[0].Type != transactionreducer.EventAgentExecutionStarted {
-		return transactionreducer.Projection{}, storeError(
-			model.ErrorSchemaInvalid,
-			operation,
-			"",
-			"guarded run-head append requires one agent execution start event",
-			nil,
-		)
-	}
-	return s.appendTransactionEvents(
-		ctx,
-		namespace,
-		expectedTransactionSequence,
-		events,
-		operation,
-		&expectedRunHead{
-			sequence: expectedRunSequence,
-			digest:   expectedRunDigest,
-		},
-	)
-}
-
-type expectedRunHead struct {
-	sequence int64
-	digest   string
 }
 
 func (s *SQLiteStore) appendTransactionEvents(
@@ -144,7 +92,6 @@ func (s *SQLiteStore) appendTransactionEvents(
 	expectedSequence int64,
 	events []model.TransactionEvent,
 	operation string,
-	runHead *expectedRunHead,
 ) (transactionreducer.Projection, error) {
 	if err := validateNamespace(namespace); err != nil {
 		return transactionreducer.Projection{}, err
@@ -173,18 +120,6 @@ func (s *SQLiteStore) appendTransactionEvents(
 			fmt.Sprintf("expected transaction sequence %d, current sequence is %d", expectedSequence, current.Transaction.EventSequence),
 			nil,
 		)
-	}
-	if runHead != nil {
-		if err := verifyAdmittedRunHead(
-			ctx,
-			tx,
-			namespace,
-			current,
-			*runHead,
-			operation,
-		); err != nil {
-			return transactionreducer.Projection{}, err
-		}
 	}
 	next := current
 	eventJSON := make([][]byte, len(events))
@@ -241,70 +176,6 @@ func (s *SQLiteStore) appendTransactionEvents(
 		return transactionreducer.Projection{}, classifyWriteError(operation, current.Transaction.ID, err)
 	}
 	return next, nil
-}
-
-func verifyAdmittedRunHead(
-	ctx context.Context,
-	tx *sql.Tx,
-	namespace string,
-	transaction transactionreducer.Projection,
-	expected expectedRunHead,
-	operation string,
-) error {
-	transactionID := transaction.Transaction.ID
-	var runID, lastDigest string
-	var sequence int64
-	err := tx.QueryRowContext(
-		ctx,
-		`SELECT a.run_id, r.event_sequence, r.last_event_digest
-		 FROM task_admissions AS a
-		 JOIN runs AS r
-		   ON r.namespace = a.namespace AND r.run_id = a.run_id
-		 WHERE a.namespace = ? AND a.transaction_id = ?`,
-		namespace,
-		transactionID,
-	).Scan(&runID, &sequence, &lastDigest)
-	if errors.Is(err, sql.ErrNoRows) {
-		return storeError(
-			model.ErrorNotFound,
-			operation,
-			transactionID,
-			"transaction has no admitted run in namespace",
-			err,
-		)
-	}
-	if err != nil {
-		return storeError(
-			model.ErrorInternal,
-			operation,
-			transactionID,
-			"query admitted run head",
-			err,
-		)
-	}
-	binding := transaction.Transaction.Admission
-	if binding == nil ||
-		binding.RunID != runID ||
-		!identifierPattern.MatchString(runID) ||
-		sequence < 1 ||
-		!digestPattern.MatchString(lastDigest) {
-		return storeError(
-			model.ErrorEventChain,
-			operation,
-			transactionID,
-			"admitted run binding or event head is invalid",
-			nil,
-		)
-	}
-	if sequence != expected.sequence || lastDigest != expected.digest {
-		return conflict(
-			operation,
-			runID,
-			"admitted run changed after execution authority was loaded",
-			nil,
-		)
-	}
-	return nil
 }
 
 func (s *SQLiteStore) GetTransaction(ctx context.Context, namespace, transactionID string) (transactionreducer.Projection, error) {

--- a/internal/kernel/transaction/gitstage/gitstage.go
+++ b/internal/kernel/transaction/gitstage/gitstage.go
@@ -80,6 +80,26 @@ type Snapshot struct {
 	InspectedAt       time.Time      `json:"inspected_at"`
 }
 
+const (
+	DiffMetadataVersion = "gatemole.git_transaction_diff.v1"
+	DiffMetadataHeader  = "Gatemole-Transaction-Diff"
+)
+
+// DiffMetadata binds a rendered patch to the exact transaction projection and
+// immutable Git tree from which the daemon produced it.
+type DiffMetadata struct {
+	Version           string `json:"version"`
+	Namespace         string `json:"namespace"`
+	TransactionID     string `json:"transaction_id"`
+	Attempt           int64  `json:"attempt"`
+	EventSequence     int64  `json:"event_sequence"`
+	StagedStateDigest string `json:"staged_state_digest"`
+	EffectSetDigest   string `json:"effect_set_digest"`
+	PatchDigest       string `json:"patch_digest"`
+	BaseRevision      string `json:"base_revision"`
+	TreeRevision      string `json:"tree_revision"`
+}
+
 type PreparedCommit struct {
 	TargetRef        string `json:"target_ref"`
 	ExpectedRevision string `json:"expected_revision"`
@@ -752,6 +772,45 @@ func (manager *Manager) Inspect(ctx context.Context, workspace Workspace, now ti
 		PatchDigest:       patchDigest,
 		InspectedAt:       now.UTC(),
 	}, nil
+}
+
+// CapturePatch renders the exact base-to-tree patch already bound by a
+// snapshot. The tree is immutable in Git's object database; recomputing and
+// checking the digest prevents the review surface from drifting from the
+// snapshot that policy and approval consumed.
+func (manager *Manager) CapturePatch(ctx context.Context, snapshot Snapshot) ([]byte, error) {
+	if err := manager.validateWorkspace(ctx, snapshot.Workspace); err != nil {
+		return nil, err
+	}
+	if !validObjectID(snapshot.TreeRevision) || snapshot.PatchDigest == "" {
+		return nil, errors.New("Git snapshot is missing an immutable tree or patch digest")
+	}
+	patch, exceeded, err := manager.runLimited(
+		ctx,
+		snapshot.Workspace.Path,
+		manager.limits.MaxCapturedDiffBytes,
+		"diff", "--no-ext-diff", "--no-textconv", "--binary", "--full-index", "--no-renames",
+		snapshot.Workspace.BaseRevision, snapshot.TreeRevision, "--",
+	)
+	if exceeded {
+		return nil, resourceLimitError(
+			snapshot.Workspace.TransactionID,
+			"captured_diff_bytes",
+			"Git diff exceeds the configured captured byte limit",
+		)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read frozen Git diff: %w", err)
+	}
+	if digestBytes(patch) != snapshot.PatchDigest {
+		return nil, &model.KernelError{
+			Code:      model.ErrorTransactionConflict,
+			Operation: "capture_git_diff",
+			Resource:  snapshot.Workspace.TransactionID,
+			Message:   "rendered Git diff does not match the frozen patch digest",
+		}
+	}
+	return patch, nil
 }
 
 // Verify re-inspects the worktree and fails if anything changed after the

--- a/internal/kernel/transaction/gitstage/gitstage_test.go
+++ b/internal/kernel/transaction/gitstage/gitstage_test.go
@@ -111,6 +111,19 @@ func TestWorktreeStagesExactEffectsWithoutMutatingSource(t *testing.T) {
 	if symlink.StageRef.Digest == digestBytes([]byte("must-not-be-read")) {
 		t.Fatal("stage inspection leaked the external symlink target content")
 	}
+	patch, err := manager.CapturePatch(context.Background(), snapshot)
+	if err != nil {
+		t.Fatalf("capture frozen patch: %v", err)
+	}
+	if !bytes.Contains(patch, []byte("func Allowed() bool { return true }")) ||
+		!bytes.Contains(patch, []byte("new staged data")) {
+		t.Fatalf("frozen patch does not contain staged changes:\n%s", patch)
+	}
+	tamperedSnapshot := snapshot
+	tamperedSnapshot.PatchDigest = digestBytes([]byte("different patch"))
+	if _, err := manager.CapturePatch(context.Background(), tamperedSnapshot); err == nil {
+		t.Fatal("capture accepted a patch digest that did not bind the frozen tree")
+	}
 
 	if err := manager.Verify(context.Background(), snapshot, now.Add(2*time.Minute)); err != nil {
 		t.Fatalf("unchanged snapshot failed verification: %v", err)

--- a/schemas/gatemole.agent_run.v0.schema.json
+++ b/schemas/gatemole.agent_run.v0.schema.json
@@ -37,6 +37,7 @@
     "budget_usage": { "$ref": "gatemole.kernel.common.v0.schema.json#/$defs/budget_usage" },
     "workspace": { "type": "string", "minLength": 1 },
     "runtime": { "$ref": "gatemole.kernel.common.v0.schema.json#/$defs/runtime_binding" },
+    "active_execution_id": { "$ref": "gatemole.kernel.common.v0.schema.json#/$defs/identifier" },
     "capability_ids": {
       "type": "array",
       "uniqueItems": true,

--- a/scripts/gatemoleci-plan-test.sh
+++ b/scripts/gatemoleci-plan-test.sh
@@ -66,6 +66,11 @@ assert_output "$schema_plan" "docs=true"
 assert_output "$schema_plan" "gatemolebench=true"
 assert_output "$schema_plan" "production=true"
 
+paired_demo_plan="$(run_plan paired-demo scripts/gatemolepairedexecutiondemo.sh)"
+assert_output "$paired_demo_plan" "production=true"
+assert_output "$paired_demo_plan" "gatemolebench=false"
+assert_output "$paired_demo_plan" "kernelbench=false"
+
 critical_paths=(
   internal/kernel/sandbox/oci.go
   internal/kernel/identity/oidc.go

--- a/scripts/gatemoleci-plan-test.sh
+++ b/scripts/gatemoleci-plan-test.sh
@@ -55,6 +55,12 @@ assert_output "$transaction_plan" "kernelbench=false"
 assert_output "$transaction_plan" "transactionbench=true"
 assert_output "$transaction_plan" "runtimebench=false"
 
+review_plan="$(run_plan review-shell internal/gatemole/transaction_review_cli.go)"
+assert_output "$review_plan" "gatemolebench=false"
+assert_output "$review_plan" "transactionbench=true"
+assert_output "$review_plan" "runtimebench=false"
+assert_output "$review_plan" "production=true"
+
 schema_plan="$(run_plan schema schemas/gatemole.agent_task.v0.schema.json)"
 assert_output "$schema_plan" "docs=true"
 assert_output "$schema_plan" "gatemolebench=true"

--- a/scripts/gatemoleci-plan.sh
+++ b/scripts/gatemoleci-plan.sh
@@ -123,7 +123,7 @@ while IFS= read -r path || [[ -n "$path" ]]; do
       kernelbench=true
       production=true
       ;;
-    internal/gatemole/transaction_cli.go)
+    internal/gatemole/transaction_cli.go|internal/gatemole/transaction_review_cli*.go)
       transactionbench=true
       production=true
       ;;

--- a/scripts/gatemoleci-plan.sh
+++ b/scripts/gatemoleci-plan.sh
@@ -160,7 +160,8 @@ while IFS= read -r path || [[ -n "$path" ]]; do
       runtimebench=true
       production=true
       ;;
-    build/*|scripts/gatemoleproductionbench.sh|scripts/gatemoleproductionfixture.sh)
+    build/*|scripts/gatemoleproductionbench.sh|scripts/gatemoleproductionfixture.sh|\
+    scripts/gatemolepairedexecutiondemo.sh)
       production=true
       ;;
     .gitignore|.editorconfig|CODEOWNERS|.github/CODEOWNERS)

--- a/scripts/gatemolepairedexecutiondemo.sh
+++ b/scripts/gatemolepairedexecutiondemo.sh
@@ -1,0 +1,261 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+for command in docker git go jq; do
+  command -v "$command" >/dev/null || {
+    echo "missing required command: $command" >&2
+    exit 1
+  }
+done
+
+DEMO_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/gatemole-paired-demo.XXXXXX")"
+REPOSITORY="$DEMO_ROOT/payments-api"
+RUNTIME_ROOT="$DEMO_ROOT/runtime"
+SOCKET_PATH="$RUNTIME_ROOT/gatemoled.sock"
+DATABASE_PATH="$RUNTIME_ROOT/kernel.db"
+TRANSACTION_ROOT="$RUNTIME_ROOT/transactions"
+GATEMOLE_BIN="$DEMO_ROOT/gatemole"
+GATEMOLED_BIN="$DEMO_ROOT/gatemoled"
+DAEMON_LOG="$RUNTIME_ROOT/gatemoled.log"
+DAEMON_PID=""
+IMAGE_TAG="gatemole-paired-execution-demo:run-$$"
+
+cleanup() {
+  if [[ -n "$DAEMON_PID" ]] && kill -0 "$DAEMON_PID" 2>/dev/null; then
+    kill "$DAEMON_PID" 2>/dev/null || true
+    wait "$DAEMON_PID" 2>/dev/null || true
+  fi
+  docker image rm "$IMAGE_TAG" >/dev/null 2>&1 || true
+  rm -rf "$DEMO_ROOT"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "paired execution demo failed: $1" >&2
+  if [[ -d "$TRANSACTION_ROOT/.gatemole-agent-evidence" ]]; then
+    while IFS= read -r evidence; do
+      echo "--- $evidence" >&2
+      tail -80 "$evidence" >&2 || true
+    done < <(find "$TRANSACTION_ROOT/.gatemole-agent-evidence" -name stderr.log -type f | sort)
+  fi
+  if [[ -f "$DAEMON_LOG" ]]; then
+    tail -80 "$DAEMON_LOG" >&2 || true
+  fi
+  exit 1
+}
+
+progress() {
+  printf '\n==> %s\n' "$1" >&2
+}
+
+start_daemon() {
+  mkdir -p "$RUNTIME_ROOT"
+  "$GATEMOLED_BIN" \
+    --repo "$REPOSITORY" \
+    --db "$DATABASE_PATH" \
+    --socket "$SOCKET_PATH" \
+    --transaction-root "$TRANSACTION_ROOT" \
+    >"$DAEMON_LOG" 2>&1 &
+  DAEMON_PID=$!
+  for _ in $(seq 1 100); do
+    [[ -S "$SOCKET_PATH" ]] && return 0
+    kill -0 "$DAEMON_PID" 2>/dev/null || fail "daemon exited before opening its socket"
+    sleep 0.05
+  done
+  fail "daemon did not become ready"
+}
+
+stop_daemon() {
+  kill "$DAEMON_PID"
+  wait "$DAEMON_PID" || true
+  DAEMON_PID=""
+  for _ in $(seq 1 100); do
+    [[ ! -e "$SOCKET_PATH" ]] && return 0
+    sleep 0.05
+  done
+  fail "daemon socket remained after shutdown"
+}
+
+progress "Creating a temporary payments API with a failing refresh-token test"
+mkdir -p "$REPOSITORY/internal/auth"
+git -C "$REPOSITORY" init --initial-branch=main >/dev/null
+printf 'module example.com/payments-api\n\ngo 1.26\n' >"$REPOSITORY/go.mod"
+printf 'package auth\n\nfunc RefreshAllowed() bool { return false }\n' \
+  >"$REPOSITORY/internal/auth/refresh.go"
+printf 'package auth\n\nimport "testing"\n\nfunc TestRefreshAllowed(t *testing.T) {\n\tif !RefreshAllowed() {\n\t\tt.Fatal("valid refresh token was rejected")\n\t}\n}\n' \
+  >"$REPOSITORY/internal/auth/refresh_test.go"
+git -C "$REPOSITORY" add -- go.mod internal/auth
+git -C "$REPOSITORY" \
+  -c user.name='Payments Developer' \
+  -c user.email='payments@example.invalid' \
+  commit -m 'reproduce PAY-1842 refresh-token rejection' >/dev/null
+
+AGENT_SOURCE="$DEMO_ROOT/auth-hotfix-agent"
+mkdir -p "$AGENT_SOURCE"
+cat >"$AGENT_SOURCE/main.go" <<'GO'
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+func main() {
+	if _, err := os.ReadFile(os.Getenv("GATEMOLE_TASK_PATH")); err != nil {
+		panic(err)
+	}
+	path := "/workspace/internal/auth/refresh.go"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		panic(err)
+	}
+	if bytes.Contains(data, []byte("return false")) {
+		updated := bytes.Replace(data, []byte("return false"), []byte("return true"), 1)
+		if err := os.WriteFile(path, updated, 0o600); err != nil {
+			panic(err)
+		}
+		fmt.Fprintln(os.Stderr, "candidate patch saved; simulated agent crash before verification")
+		os.Exit(42)
+	}
+	if !bytes.Contains(data, []byte("return true")) {
+		panic("candidate patch is not in the expected state")
+	}
+	testRoot := "/workspace/.gatemole-demo-test"
+	if err := os.MkdirAll(testRoot+"/tmp", 0o700); err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(testRoot)
+	command := exec.Command("go", "test", "./internal/auth")
+	command.Dir = "/workspace"
+	command.Env = append(
+		os.Environ(),
+		"GOCACHE="+testRoot+"/cache",
+		"GOTMPDIR="+testRoot+"/tmp",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "regression test failed: %v\n%s", err, output)
+		os.Exit(1)
+	}
+	fmt.Print(string(output))
+	fmt.Println("resumed the existing candidate patch; regression test passed")
+}
+GO
+
+progress "Building the digest-pinned agent image (the first run may download golang:1.26-alpine)"
+case "$(docker version --format '{{.Server.Arch}}')" in
+  amd64|x86_64) ENGINE_ARCH=amd64 ;;
+  arm64|aarch64) ENGINE_ARCH=arm64 ;;
+  *) fail "Docker server architecture is not supported by this demo" ;;
+esac
+CGO_ENABLED=0 GOOS=linux GOARCH="$ENGINE_ARCH" \
+  go build -trimpath -o "$AGENT_SOURCE/auth-hotfix-agent" "$AGENT_SOURCE/main.go"
+cat >"$AGENT_SOURCE/Dockerfile" <<'DOCKER'
+FROM golang:1.26-alpine
+COPY auth-hotfix-agent /auth-hotfix-agent
+DOCKER
+docker build --quiet --network=none --pull=false --tag "$IMAGE_TAG" "$AGENT_SOURCE" >/dev/null
+AGENT_IMAGE="$(docker image inspect --format '{{.Id}}' "$IMAGE_TAG")"
+
+progress "Building gatemole and gatemoled from this checkout"
+go build -o "$GATEMOLE_BIN" ./cmd/gatemole
+go build -o "$GATEMOLED_BIN" ./cmd/gatemoled
+"$GATEMOLE_BIN" --repo "$REPOSITORY" runtime init >/dev/null
+
+progress "Starting gatemoled with a fresh durable ledger"
+start_daemon
+
+RUN_ARGUMENTS=(
+  --socket "$SOCKET_PATH"
+  --namespace payments
+  --id tx:pay-1842
+  --run run:pay-1842
+  --timeout 2m
+  --intent "Fix PAY-1842: valid refresh tokens are rejected"
+  --runtime oci
+  --image "$AGENT_IMAGE"
+  -- /auth-hotfix-agent
+)
+
+progress "Attempt 1: the agent saves the auth fix, then simulates a crash"
+set +e
+"$GATEMOLE_BIN" --repo "$REPOSITORY" --json run "${RUN_ARGUMENTS[@]}" \
+  >"$DEMO_ROOT/first-attempt.json" 2>"$DEMO_ROOT/first-attempt.err"
+FIRST_EXIT=$?
+set -e
+[[ "$FIRST_EXIT" -eq 42 ]] || fail "first agent exit=$FIRST_EXIT, want 42"
+jq -e '.execution.status == "failed"' "$DEMO_ROOT/first-attempt.json" >/dev/null \
+  || fail "first execution was not durably failed"
+
+"$GATEMOLE_BIN" --repo "$REPOSITORY" --json kernel run get \
+  --socket "$SOCKET_PATH" --namespace payments --id run:pay-1842 \
+  >"$DEMO_ROOT/run-after-failure.json"
+jq -e '.run.state == "waiting_for_agent" and .run.active_execution_id == null' \
+  "$DEMO_ROOT/run-after-failure.json" >/dev/null \
+  || fail "failed execution did not settle the run for retry"
+printf '    receipt=failed  run=waiting_for_agent  active_execution=null\n' >&2
+
+progress "Restarting gatemoled against the same ledger and transaction worktree"
+stop_daemon
+start_daemon
+
+progress "Attempt 2: the agent resumes the saved patch and runs go test ./internal/auth"
+set +e
+"$GATEMOLE_BIN" --repo "$REPOSITORY" --json run "${RUN_ARGUMENTS[@]}" \
+  >"$DEMO_ROOT/retry.json" 2>"$DEMO_ROOT/retry.err"
+RETRY_EXIT=$?
+set -e
+[[ "$RETRY_EXIT" -eq 0 ]] || fail "retry agent exit=$RETRY_EXIT, want 0"
+jq -e '.execution.status == "succeeded"' "$DEMO_ROOT/retry.json" >/dev/null \
+  || fail "resumed execution did not succeed"
+printf '    receipt=succeeded  regression_test=passed\n' >&2
+
+progress "Inspecting both immutable receipts, the paired run events, and budget usage"
+"$GATEMOLE_BIN" --repo "$REPOSITORY" --json kernel run get \
+  --socket "$SOCKET_PATH" --namespace payments --id run:pay-1842 \
+  >"$DEMO_ROOT/run-after-retry.json"
+"$GATEMOLE_BIN" --repo "$REPOSITORY" --json kernel run events \
+  --socket "$SOCKET_PATH" --namespace payments --id run:pay-1842 \
+  >"$DEMO_ROOT/run-events.json"
+"$GATEMOLE_BIN" --repo "$REPOSITORY" --json tx get \
+  --socket "$SOCKET_PATH" --namespace payments --id tx:pay-1842 \
+  >"$DEMO_ROOT/transaction.json"
+
+jq -e '.run.state == "waiting_for_event" and .run.active_execution_id == null' \
+  "$DEMO_ROOT/run-after-retry.json" >/dev/null \
+  || fail "successful retry did not settle the run"
+jq -e '[.[] | select(.type | startswith("run.execution_"))] | length == 4' \
+  "$DEMO_ROOT/run-events.json" >/dev/null \
+  || fail "run does not contain two paired execution attempts"
+jq -e '[.executions[].status] == ["failed", "succeeded"]' \
+  "$DEMO_ROOT/transaction.json" >/dev/null \
+  || fail "transaction receipts do not preserve both attempts"
+git -C "$REPOSITORY" diff --exit-code >/dev/null \
+  || fail "agent changed the source checkout instead of its private worktree"
+
+progress "Demo complete; durable incident report"
+jq -n \
+  --slurpfile failed "$DEMO_ROOT/run-after-failure.json" \
+  --slurpfile resumed "$DEMO_ROOT/run-after-retry.json" \
+  --slurpfile events "$DEMO_ROOT/run-events.json" \
+  --slurpfile transaction "$DEMO_ROOT/transaction.json" \
+  '{
+    incident: "PAY-1842 refresh-token rejection",
+    first_attempt: $transaction[0].executions[0].status,
+    state_after_failure: $failed[0].run.state,
+    daemon_restarted: true,
+    retry: $transaction[0].executions[1].status,
+    regression_test: "go test ./internal/auth (passed on retry)",
+    final_run_state: $resumed[0].run.state,
+    active_execution_id: ($resumed[0].run.active_execution_id // null),
+    cumulative_budget_usage: $resumed[0].run.budget_usage,
+    paired_execution_events: [
+      $events[0][]
+      | select(.type | startswith("run.execution_"))
+      | {sequence, type, execution_id: .payload.execution_id,
+         status: .payload.status, usage: .payload.usage}
+    ],
+    source_checkout_unchanged: true
+  }'

--- a/skills.md
+++ b/skills.md
@@ -94,10 +94,11 @@ It does not currently push, open or merge pull requests, deploy, coordinate
 database/Kubernetes effects, provide remote multi-tenant service, or provide
 HA. Stable release packaging is pending.
 
-Runtime profile initialization and diagnostics exist. A maintained agent
-adapter, asynchronous supervision, live cancellation, friendly diff/apply and
-stable packaging remain in progress or planned; do not call the current
-low-level integration a self-serve developer preview yet.
+Runtime profile initialization, diagnostics and the exact local
+review/diff/apply/reject shell exist. A maintained agent adapter, asynchronous
+supervision, live cancellation and stable packaging remain in progress or
+planned; do not call the current low-level integration a self-serve developer
+preview yet.
 
 ## Good work
 
@@ -188,14 +189,16 @@ it.
 ## Near-term order
 
 1. Pair the admitted run and transaction lifecycle and durably charge budgets.
-2. Complete the Gatemole Developer Runtime shell: maintained adapter, supervision,
-   watch/cancel, diff and explicit apply/reject.
+2. Complete the Gatemole Developer Runtime shell: maintained adapter,
+   supervision and watch/cancel; preserve the existing exact review and
+   apply/reject path.
 3. Stabilize the authenticated action protocol and connector coordinator.
 4. Deliver one deep remote-Git/GitHub connector and approval experience.
 5. Prove paid design-partner demand for fleet policy, audit and approvals.
-6. Build the Gatemole Control Plane around customer-side Gatemole Runtimes.
-7. Add Kubernetes and PostgreSQL transaction packs only after Git release and
+6. Add Kubernetes and PostgreSQL transaction packs only after Git release and
    reconciliation are deep.
+7. Build the Gatemole Control Plane around customer-side Gatemole Runtimes only
+   after paid pilot evidence and multi-system Runtime proof.
 
 Developer success means a new user repeatedly reaches a controlled local
 outcome without low-level transaction surgery. Enterprise success means


### PR DESCRIPTION
## Summary

- atomically pair admitted run and transaction execution start and settlement
- add digest-bound review, diff, apply, and reject operator commands
- make help and version discovery independent of repository state
- exercise crash, restart, and retry recovery in production CI
- document the current workflow and the durable supervisor follow-up

## Validation

- go test -p 1 -count=1 ./...
- go vet -p 1 ./...
- kernel race tests
- transaction and runtime benches, 10 of 10 each
- Docker-backed paired execution recovery demo
- CI planner routing tests
- sample payments API tests
- git diff --check