### PR TITLE
feat(cli): auto-host local development runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,16 +276,22 @@ those Runtimes.
 
 ## Developer Runtime: current local-Git integration
 
-The current runtime requires Git, an OCI engine such as Docker, a running
-`gatemoled`, and a digest-pinned agent image.
+The current runtime requires Git, an OCI engine such as Docker, and a
+digest-pinned agent image. On the default repository-local socket, the primary
+local commands host a temporary development `gatemoled` automatically and stop
+it when the command finishes. A separately managed daemon is still required for
+production enforcement, a custom socket, model brokering, or a long-lived edge
+installation.
 
-This is a low-level developer integration, not yet a self-serve desktop agent
+This remains a developer integration rather than a packaged desktop agent
 environment. `gatemole runtime init` creates a strict repository-owned profile
-and a local Runtime identity. `gatemole doctor` diagnoses Git, OCI, profile,
-local-image and daemon readiness. `gatemole review` shows the daemon-bound
-status, exact effects, evidence IDs and frozen patch; `diff`, `apply` and
-`reject` expose the corresponding task-oriented operations. Packaged adapters,
-daemon supervision, `watch` and live cancellation remain roadmap work.
+and a local Runtime identity; repeating it with a new agent name adds that
+profile without replacing existing agents. `gatemole doctor` diagnoses Git,
+OCI, profile, local-image and daemon readiness. `gatemole review` shows the
+daemon-bound status, exact effects, evidence IDs and frozen patch; `diff`,
+`apply` and `reject` expose the corresponding task-oriented operations.
+Packaged adapters, operating-system service installation, `watch` and live
+cancellation remain roadmap work.
 
 Build the CLI from source:
 
@@ -319,7 +325,14 @@ rehashes old configuration, ledgers, evidence, or signatures automatically.
 Archive or remove the legacy directory deliberately, then initialize
 `.gatemole`.
 
-Start the repository-local development daemon in one terminal:
+For normal local development, no daemon terminal is needed. `run`, `status`,
+`review`, `diff`, `approve`, `apply`, `release`, and `reject` start the default
+development Runtime for the duration of that command when no listener already
+exists. The SQLite ledger and transaction worktrees remain durable between
+invocations.
+
+Start a persistent daemon when an agent needs configured model brokering, when
+using a custom socket, or when a supervisor should keep the Runtime alive:
 
 ```sh
 gatemole --repo /path/to/service daemon
@@ -330,7 +343,7 @@ directory beneath the current user's validated runtime or cache directory,
 not in a shared predictable `/tmp/gatemole-transactions` path. A custom
 `--transaction-root` is validated before the ledger opens.
 
-In another terminal, diagnose the selected integration and run it:
+Diagnose the selected integration and run it:
 
 ```sh
 gatemole --repo /path/to/service doctor --agent coding-agent
@@ -340,9 +353,9 @@ gatemole --repo /path/to/service run \
   --agent coding-agent
 ```
 
-Doctor warnings, such as an intentionally stopped daemon or omitting
-`--agent`, do not make the command fail. A selected missing image, invalid
-profile, unavailable OCI engine or unready existing daemon does.
+Doctor warnings, such as no persistent daemon or omitting `--agent`, do not make
+the command fail. A selected missing image, invalid profile, unavailable OCI
+engine or unready existing daemon does.
 When the socket exists, doctor uses the daemon's authoritative Runtime
 preflight instead of treating a separate CLI-side OCI probe as proof.
 
@@ -351,8 +364,9 @@ For a developer, the integration contract is deliberately small:
 1. Package the existing agent as a digest-pinned OCI image.
 2. Make its command read the retained task at `$GATEMOLE_TASK_PATH`.
 3. Let it edit only `/workspace` and return a normal process exit code.
-4. Start it with `gatemole run`; do not give the container the daemon socket,
-   repository credentials or downstream production credentials.
+4. Start it with `gatemole run`; the local development Runtime is automatic.
+   Do not give the container the daemon socket, repository credentials or
+   downstream production credentials.
 5. Inspect the transaction and its hash-chained events before verification,
    approval and release.
 
@@ -419,6 +433,57 @@ gatemole --repo /path/to/service run \
   --model-provider openai
 ```
 
+### Using the included Codex adapter
+
+[`examples/codex-agent`](examples/codex-agent) turns Codex into the same worker
+contract: it reads the admitted intent, edits `/workspace`, and can reach the
+model only through Gatemole's transaction broker. Publish that image to a
+registry, pin the resulting manifest digest, and register it without replacing
+other repository agents:
+
+```sh
+gatemole --repo /path/to/service runtime init \
+  --agent codex \
+  --image registry.example/codex-agent@sha256:<64-hex-manifest-digest> \
+  --source-digest sha256:<64-hex-source-digest> \
+  -- --model gpt-5.6
+```
+
+Because Codex needs model access, run a configured persistent daemon with a
+digest-pinned `gatemole-model-broker` image and policy, then admit only the
+provider needed by this task:
+
+```sh
+export OPENAI_API_KEY='provider-secret-visible-only-to-gatemoled'
+gatemole --repo /path/to/service daemon \
+  --model-broker-image registry.example/gatemole-model-broker@sha256:<64-hex-manifest-digest> \
+  --model-broker-policy /path/to/model-policy.json
+
+# In another terminal:
+gatemole --repo /path/to/service run \
+  --intent "Fix the failing authentication test" \
+  --agent codex \
+  --model-provider openai
+```
+
+The automatic development Runtime deliberately does not invent broker policy or
+inherit model authority. If `--model-provider` is requested and no daemon is
+running, the CLI tells the operator to start the configured Runtime first.
+
+### Repository and edge usage
+
+On a developer repository, use the automatic command-scoped Runtime: initialize
+once, then call `run`, `review`, and `reject` or the later approval/application
+steps. On an edge device or shared runner, keep `gatemole daemon` under the
+device's service supervisor, preload every digest-pinned image, and invoke the
+same CLI against its local Unix socket. The agent container never receives that
+socket.
+
+Gatemole does not yet expose a remote daemon API or fleet control plane. An edge
+installation is therefore one trusted node and one security tenant; remote job
+routing, device enrollment, updates, and cross-device world state remain future
+product layers.
+
 At launch, the kernel derives the run identity, image, command, workspace
 access, broker access and deadline from live admitted state. A stale run, an
 expired grant, a changed image or command, a narrower unsupported workspace
@@ -431,8 +496,9 @@ That guide separately labels its runnable deterministic fixtures as acceptance
 proofs rather than presenting them as the normal user experience.
 
 `gatemole run` then creates the isolated worktree, runs the agent, freezes its Git
-effects, and performs deterministic sequence validation. Inspect the result
-with:
+effects, and performs deterministic sequence validation. Its output includes
+the durable transaction ID and the exact next `gatemole review` command. Inspect
+the result with:
 
 ```sh
 gatemole --repo /path/to/service review <transaction-id> \

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,9 +67,11 @@ The repository contains a substantial foundation:
 
 The supported profile remains one node, one security tenant and publication to
 an allowed local Git ref. It does not yet control a remote enterprise system.
-Its developer integration is also low-level: the user must operate the daemon,
-provide a digest-pinned OCI image and use transaction-oriented inspection
-commands.
+Its developer integration is also low-level: product-facing local commands can
+host a command-scoped development daemon, but the user must still provide a
+digest-pinned OCI image and use transaction-oriented inspection commands.
+Configured model access, production operation and edge deployment still require
+a separately supervised daemon.
 
 ### Next architecture gap
 

--- a/docs/TRANSACTIONS.md
+++ b/docs/TRANSACTIONS.md
@@ -61,8 +61,11 @@ adds ignore rules for the identity, SQLite/WAL state, locks and socket. Commit
 `.gatemole/agent-profiles.json` and `.gatemole/.gitignore`; do not commit
 `.gatemole/runtime.json`.
 
-Start the local daemon. The convenience command keeps its transaction root
-outside the repository:
+For the default local development socket, the product commands start a
+temporary daemon when needed and stop it after each invocation. The durable
+ledger and isolated worktrees survive between commands. To keep the Runtime
+alive, configure model brokering, or use a custom socket, start the daemon
+explicitly; its transaction root remains outside the repository:
 
 ```sh
 gatemole --repo /path/to/service daemon
@@ -73,8 +76,8 @@ private per-user runtime or cache directory. If `--transaction-root` is
 provided, the CLI resolves it and the daemon validates the complete path,
 ownership and permissions before opening the ledger.
 
-In another terminal, diagnose the selected profile and run a task through the
-primary Runtime surface:
+Diagnose the selected profile and run a task through the primary Runtime
+surface:
 
 ```sh
 gatemole --repo /path/to/service doctor --agent coding-agent

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -100,11 +100,13 @@ gatemole --repo /path/to/service runtime init \
   --image registry.example/coding-agent@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef \
   --source-digest sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb \
   -- /usr/local/bin/agent
-
-gatemole --repo /path/to/service daemon
 ```
 
-In another terminal:
+The primary commands automatically host the default local development Runtime
+for each invocation. Start `gatemole daemon` separately only for persistent,
+custom-socket, model-broker, production, or edge operation.
+
+Run and review the agent:
 
 ```sh
 gatemole --repo /path/to/service doctor --agent coding-agent
@@ -120,7 +122,8 @@ gatemole --repo /path/to/service diff <transaction-id>
 ```
 
 This development command creates the isolated worktree, runs the agent, freezes
-its Git effects and performs sequence validation. Production verification,
+its Git effects and performs sequence validation. It prints the transaction ID
+and next review command. Production verification,
 approval and local-ref release require the hardened runtime configuration.
 Runtime initialization creates a strict repository-owned agent profile and an
 ignored local identity at `.gatemole/runtime.json`. Commit the agent profile and

--- a/internal/gatemole/local_runtime_cli.go
+++ b/internal/gatemole/local_runtime_cli.go
@@ -1,0 +1,268 @@
+package gatemole
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	kernelclient "github.com/duriantaco/gatemole/internal/kernel/client"
+	"github.com/duriantaco/gatemole/internal/kernel/daemon"
+	"github.com/duriantaco/gatemole/internal/kernel/runtimeidentity"
+)
+
+const (
+	localRuntimeStartupTimeout  = 10 * time.Second
+	localRuntimeShutdownTimeout = 6 * time.Second
+)
+
+type automaticLocalRuntimeOptions struct {
+	command                  string
+	socketPath               string
+	runtimeEngine            string
+	allowUnsafeHostExecution bool
+	externallyManagedReason  string
+}
+
+// withAutomaticLocalRuntime makes the product-facing local workflow usable
+// without asking the operator to keep a second terminal open. It only hosts
+// the default development Runtime. An explicitly selected socket, production
+// enforcement, or model-broker access remains the responsibility of a
+// separately configured daemon.
+func withAutomaticLocalRuntime(
+	repo string,
+	options automaticLocalRuntimeOptions,
+	stderr io.Writer,
+	operation func() int,
+) int {
+	if options.socketPath == "" {
+		options.socketPath = defaultKernelSocket(repo)
+	}
+	if options.runtimeEngine == "" {
+		options.runtimeEngine = "docker"
+	}
+
+	active, err := unixSocketHasListener(options.socketPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: inspect local Runtime socket: %v\n", options.command, err)
+		return 1
+	}
+	if active {
+		return operation()
+	}
+	if options.externallyManagedReason != "" {
+		fmt.Fprintf(
+			stderr,
+			"%s: %s; start `gatemole daemon` with the required configuration before retrying.\n",
+			options.command,
+			options.externallyManagedReason,
+		)
+		return operation()
+	}
+
+	identity, err := runtimeidentity.Load(context.Background(), repo)
+	if err != nil {
+		// The command itself owns the established initialization guidance. This
+		// path is mostly defensive because callers load the identity first.
+		return operation()
+	}
+	transactionRoot, err := daemon.DefaultTransactionRoot(repo)
+	if err != nil {
+		fmt.Fprintf(stderr, "%s: select local transaction root: %v\n", options.command, err)
+		return 1
+	}
+
+	runtimeContext, cancelRuntime := context.WithCancel(context.Background())
+	runtimeDone := make(chan error, 1)
+	go func() {
+		runtimeDone <- daemon.Run(runtimeContext, daemon.Config{
+			DatabasePath:    filepath.Join(repo, ".gatemole", "kernel.db"),
+			SocketPath:      options.socketPath,
+			RepositoryRoot:  repo,
+			TransactionRoot: transactionRoot,
+			RuntimeProfile:  "development",
+			RuntimeEngine: repositoryExecutablePath(
+				repo,
+				options.runtimeEngine,
+			),
+			VerifierUID:              os.Getuid(),
+			VerifierGID:              os.Getgid(),
+			AllowUnsafeHostExecution: options.allowUnsafeHostExecution,
+			Stdout:                   io.Discard,
+		})
+	}()
+
+	started, startErr, runtimeExited := waitForAutomaticLocalRuntime(
+		options.socketPath,
+		identity.RuntimeID,
+		runtimeDone,
+	)
+	if !started {
+		cancelRuntime()
+		if !runtimeExited {
+			select {
+			case <-runtimeDone:
+			case <-time.After(localRuntimeShutdownTimeout):
+			}
+		}
+		if startErr == nil {
+			startErr = errors.New("startup did not complete")
+		}
+		fmt.Fprintf(stderr, "%s: start temporary local Runtime: %v\n", options.command, startErr)
+		return 1
+	}
+
+	fmt.Fprintf(
+		stderr,
+		"Local Runtime: started temporarily for `%s`; use `gatemole daemon` for a persistent or configured Runtime.\n",
+		options.command,
+	)
+	code := operation()
+	cancelRuntime()
+
+	select {
+	case runtimeErr := <-runtimeDone:
+		if runtimeErr != nil {
+			fmt.Fprintf(stderr, "%s: temporary local Runtime stopped with an error: %v\n", options.command, runtimeErr)
+			if code == 0 {
+				return 1
+			}
+		}
+	case <-time.After(localRuntimeShutdownTimeout):
+		fmt.Fprintf(stderr, "%s: temporary local Runtime did not stop cleanly\n", options.command)
+		if code == 0 {
+			return 1
+		}
+	}
+	return code
+}
+
+func waitForAutomaticLocalRuntime(
+	socketPath string,
+	runtimeID string,
+	runtimeDone <-chan error,
+) (started bool, err error, runtimeExited bool) {
+	deadline := time.NewTimer(localRuntimeStartupTimeout)
+	defer deadline.Stop()
+	ticker := time.NewTicker(20 * time.Millisecond)
+	defer ticker.Stop()
+	client := kernelclient.New(socketPath).WithExpectedRuntimeID(runtimeID)
+
+	for {
+		probeContext, cancelProbe := context.WithTimeout(
+			context.Background(),
+			250*time.Millisecond,
+		)
+		err := client.Health(probeContext)
+		cancelProbe()
+		if err == nil {
+			return true, nil, false
+		}
+
+		select {
+		case runtimeErr := <-runtimeDone:
+			return false, runtimeErr, true
+		case <-deadline.C:
+			return false, fmt.Errorf("Runtime was not ready within %s: %w", localRuntimeStartupTimeout, err), false
+		case <-ticker.C:
+		}
+	}
+}
+
+func unixSocketHasListener(socketPath string) (bool, error) {
+	info, err := os.Lstat(socketPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return false, nil
+	}
+	connection, err := net.DialTimeout("unix", socketPath, 250*time.Millisecond)
+	if err == nil {
+		_ = connection.Close()
+		return true, nil
+	}
+	if errors.Is(err, syscall.ECONNREFUSED) ||
+		errors.Is(err, syscall.ENOENT) {
+		return false, nil
+	}
+	// Let the daemon's stricter stale-socket recovery produce the authoritative
+	// error without sending any credentials to an unverified listener.
+	return false, nil
+}
+
+func automaticLocalRuntimeForRun(
+	repo string,
+	args []string,
+) automaticLocalRuntimeOptions {
+	options := automaticLocalRuntimeOptions{
+		command:       "run",
+		socketPath:    defaultKernelSocket(repo),
+		runtimeEngine: "docker",
+	}
+	if socket, explicit := commandFlagValue(args, "socket"); explicit {
+		options.socketPath = socket
+		options.externallyManagedReason = "an explicit daemon socket was selected"
+		return options
+	}
+	if value, ok := commandFlagValue(args, "require-enforcement-profile"); ok && value == "production" {
+		options.externallyManagedReason = "production enforcement requires a configured daemon"
+		return options
+	}
+	if value, ok := commandFlagValue(args, "model-provider"); ok && strings.TrimSpace(value) != "" {
+		options.externallyManagedReason = "model access requires a configured daemon broker"
+		return options
+	}
+	runtimeClass, _ := commandFlagValue(args, "runtime")
+	options.allowUnsafeHostExecution =
+		runtimeClass == "host" && hasCommandFlag(args, "unsafe-host")
+	return options
+}
+
+func automaticLocalRuntimeForAlias(
+	repo, alias string,
+	args []string,
+) automaticLocalRuntimeOptions {
+	options := automaticLocalRuntimeOptions{
+		command:       alias,
+		socketPath:    defaultKernelSocket(repo),
+		runtimeEngine: "docker",
+	}
+	if socket, explicit := commandFlagValue(args, "socket"); explicit {
+		options.socketPath = socket
+		options.externallyManagedReason = "an explicit daemon socket was selected"
+	}
+	return options
+}
+
+func commandFlagValue(args []string, name string) (string, bool) {
+	longName := "--" + name
+	shortName := "-" + name
+	for index := 0; index < len(args); index++ {
+		argument := args[index]
+		if argument == "--" {
+			return "", false
+		}
+		if argument == longName || argument == shortName {
+			if index+1 >= len(args) {
+				return "", true
+			}
+			return args[index+1], true
+		}
+		for _, prefix := range []string{longName + "=", shortName + "="} {
+			if strings.HasPrefix(argument, prefix) {
+				return strings.TrimPrefix(argument, prefix), true
+			}
+		}
+	}
+	return "", false
+}

--- a/internal/gatemole/local_runtime_cli_test.go
+++ b/internal/gatemole/local_runtime_cli_test.go
@@ -1,0 +1,133 @@
+package gatemole
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestProductCommandsAutomaticallyHostLocalDevelopmentRuntime(t *testing.T) {
+	repo, err := os.MkdirTemp("/tmp", "gm-auto-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(repo) })
+	repo = transactionRunRepositoryAt(t, repo)
+	runtimeBase := t.TempDir()
+	if err := os.Chmod(runtimeBase, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("XDG_RUNTIME_DIR", runtimeBase)
+	fakeRuntime := writeFakeOCIRuntime(t)
+	fakeRuntimeDirectory := t.TempDir()
+	if err := os.Symlink(
+		fakeRuntime,
+		filepath.Join(fakeRuntimeDirectory, "docker"),
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", fakeRuntimeDirectory+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	code := Main(
+		runtimeInitArgsForTest(
+			repo,
+			"/bin/sh", "-c",
+			"printf 'hello from the agent\\n' > agent-note.txt",
+		),
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("agent registration code=%d stderr=%s", code, stderr.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	code = Main([]string{
+		"--repo", repo,
+		"run",
+		"--id", "tx:auto-local-runtime",
+		"--intent", "Add a note through the local Runtime",
+		"--agent", "coding-agent",
+	}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("automatic local run code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Local Runtime: started temporarily") ||
+		!strings.Contains(stdout.String(), "Transaction: tx:auto-local-runtime") ||
+		!strings.Contains(stdout.String(), "Next: `gatemole review tx:auto-local-runtime`") {
+		t.Fatalf(
+			"run was not self-guiding:\nstdout=%s\nstderr=%s",
+			stdout.String(),
+			stderr.String(),
+		)
+	}
+	assertAutomaticRuntimeStopped(t, repo)
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Main(
+		[]string{"--repo", repo, "review", "tx:auto-local-runtime"},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("automatic local review code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "hello from the agent") ||
+		!strings.Contains(stdout.String(), "Exact diff: sha256:") {
+		t.Fatalf("review did not expose the frozen patch:\n%s", stdout.String())
+	}
+	assertAutomaticRuntimeStopped(t, repo)
+
+	stdout.Reset()
+	stderr.Reset()
+	code = Main(
+		[]string{"--repo", repo, "reject", "tx:auto-local-runtime"},
+		&stdout,
+		&stderr,
+	)
+	if code != 0 {
+		t.Fatalf("automatic local reject code=%d stderr=%s", code, stderr.String())
+	}
+	assertAutomaticRuntimeStopped(t, repo)
+}
+
+func TestAutomaticLocalRuntimeDoesNotReplaceExplicitDaemonSelection(t *testing.T) {
+	repo := transactionRunRepository(t)
+	customSocket := filepath.Join(t.TempDir(), "configured.sock")
+	var stdout, stderr bytes.Buffer
+	code := Main([]string{
+		"--repo", repo,
+		"run",
+		"--id", "tx:external-runtime",
+		"--intent", "Use the explicitly configured Runtime",
+		"--runtime", "host",
+		"--unsafe-host",
+		"--socket", customSocket,
+		"--",
+		"/bin/true",
+	}, &stdout, &stderr)
+	if code != 1 ||
+		!strings.Contains(stderr.String(), "an explicit daemon socket was selected") ||
+		strings.Contains(stderr.String(), "Local Runtime: started temporarily") {
+		t.Fatalf(
+			"explicit daemon selection was not preserved: code=%d stderr=%s",
+			code,
+			stderr.String(),
+		)
+	}
+	if _, err := os.Lstat(defaultKernelSocket(repo)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("default Runtime socket was created: %v", err)
+	}
+}
+
+func assertAutomaticRuntimeStopped(t *testing.T, repo string) {
+	t.Helper()
+	if _, err := os.Lstat(defaultKernelSocket(repo)); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("temporary Runtime socket remains after command: %v", err)
+	}
+}

--- a/internal/gatemole/runtime_onboarding_cli.go
+++ b/internal/gatemole/runtime_onboarding_cli.go
@@ -257,7 +257,19 @@ func runtimeInitCommand(
 	} else {
 		fmt.Fprintf(stdout, "Runtime state ignore is complete: %s\n", result.IgnorePath)
 	}
-	fmt.Fprintf(stdout, "Next: gatemole --repo %s doctor\n", result.Repository)
+	if result.Agent == "" {
+		fmt.Fprintln(
+			stdout,
+			"Next: register a digest-pinned agent profile with `gatemole runtime init --agent ...`.",
+		)
+	} else {
+		fmt.Fprintf(
+			stdout,
+			"Next: `gatemole --repo %s run --intent \"Describe the change\" --agent %s`\n",
+			result.Repository,
+			result.Agent,
+		)
+	}
 	return 0
 }
 
@@ -296,12 +308,15 @@ func writeRuntimeInitialization(
 
 	profilesPath := filepath.Join(repo, defaultAgentProfiles)
 	profileCreated := false
+	profileFileCreated := false
+	profileUpdated := false
+	var profileMutationInfo os.FileInfo
+	var originalProfiles []byte
 	if document != nil {
-		data, err := json.MarshalIndent(*document, "", "  ")
+		data, err := encodeAgentProfileDocument(*document)
 		if err != nil {
-			return runtimeInitResult{}, fmt.Errorf("encode agent profiles: %w", err)
+			return runtimeInitResult{}, err
 		}
-		data = append(data, '\n')
 		if info, err := os.Lstat(profilesPath); err == nil {
 			if !info.Mode().IsRegular() ||
 				info.Mode()&os.ModeSymlink != 0 {
@@ -315,12 +330,41 @@ func writeRuntimeInitialization(
 				return runtimeInitResult{}, err
 			}
 			existing, err := decodeAgentProfileDocument(existingData)
-			if err != nil ||
-				!reflect.DeepEqual(existing, *document) {
+			if err != nil {
+				return runtimeInitResult{}, err
+			}
+			merged, changed, err := mergeAgentProfileDocument(
+				existing,
+				*document,
+			)
+			if err != nil {
 				return runtimeInitResult{}, fmt.Errorf(
-					"%s already exists with different content; refusing to overwrite it",
+					"%s %w",
 					defaultAgentProfiles,
+					err,
 				)
+			}
+			if changed {
+				data, err = encodeAgentProfileDocument(merged)
+				if err != nil {
+					return runtimeInitResult{}, err
+				}
+				profileMutationInfo, err = replaceExistingRegularFile(
+					profilesPath,
+					info,
+					data,
+					0o600,
+				)
+				if err != nil {
+					return runtimeInitResult{}, fmt.Errorf(
+						"update %s: %w",
+						defaultAgentProfiles,
+						err,
+					)
+				}
+				originalProfiles = append([]byte(nil), existingData...)
+				profileCreated = true
+				profileUpdated = true
 			}
 		} else if os.IsNotExist(err) {
 			if err := writeExclusiveRegularFile(
@@ -335,11 +379,37 @@ func writeRuntimeInitialization(
 				)
 			}
 			profileCreated = true
+			profileFileCreated = true
+			profileMutationInfo, err = os.Lstat(profilesPath)
+			if err != nil {
+				_ = os.Remove(profilesPath)
+				return runtimeInitResult{}, fmt.Errorf(
+					"inspect created %s: %w",
+					defaultAgentProfiles,
+					err,
+				)
+			}
 		} else {
 			return runtimeInitResult{}, fmt.Errorf(
 				"inspect %s: %w",
 				defaultAgentProfiles,
 				err,
+			)
+		}
+	}
+	rollbackProfile := func() {
+		switch {
+		case profileFileCreated:
+			_ = removeRegularFileIfSame(
+				profilesPath,
+				profileMutationInfo,
+			)
+		case profileUpdated:
+			_, _ = replaceExistingRegularFile(
+				profilesPath,
+				profileMutationInfo,
+				originalProfiles,
+				0o600,
 			)
 		}
 	}
@@ -350,9 +420,7 @@ func writeRuntimeInitialization(
 	var originalIgnore []byte
 	if info, err := os.Lstat(ignorePath); err == nil {
 		if !info.Mode().IsRegular() || info.Mode()&os.ModeSymlink != 0 {
-			if profileCreated {
-				_ = os.Remove(profilesPath)
-			}
+			rollbackProfile()
 			return runtimeInitResult{}, fmt.Errorf(
 				"%s exists but is not a regular file",
 				runtimeIgnoreFile,
@@ -360,9 +428,7 @@ func writeRuntimeInitialization(
 		}
 		existing, err := os.ReadFile(ignorePath)
 		if err != nil {
-			if profileCreated {
-				_ = os.Remove(profilesPath)
-			}
+			rollbackProfile()
 			return runtimeInitResult{}, fmt.Errorf("read %s: %w", runtimeIgnoreFile, err)
 		}
 		originalIgnore = append([]byte(nil), existing...)
@@ -374,25 +440,19 @@ func writeRuntimeInitialization(
 				existing,
 				missing,
 			); err != nil {
-				if profileCreated {
-					_ = os.Remove(profilesPath)
-				}
+				rollbackProfile()
 				return runtimeInitResult{}, fmt.Errorf("update %s: %w", runtimeIgnoreFile, err)
 			}
 			ignoreUpdated = true
 		}
 	} else if os.IsNotExist(err) {
 		if err := writeExclusiveRegularFile(ignorePath, runtimeStateIgnore, 0o600); err != nil {
-			if profileCreated {
-				_ = os.Remove(profilesPath)
-			}
+			rollbackProfile()
 			return runtimeInitResult{}, fmt.Errorf("create %s: %w", runtimeIgnoreFile, err)
 		}
 		ignoreCreated = true
 	} else {
-		if profileCreated {
-			_ = os.Remove(profilesPath)
-		}
+		rollbackProfile()
 		return runtimeInitResult{}, fmt.Errorf("inspect %s: %w", runtimeIgnoreFile, err)
 	}
 
@@ -401,9 +461,7 @@ func writeRuntimeInitialization(
 		repo,
 	)
 	if err != nil {
-		if profileCreated {
-			_ = os.Remove(profilesPath)
-		}
+		rollbackProfile()
 		switch {
 		case ignoreCreated:
 			_ = os.Remove(ignorePath)
@@ -431,6 +489,48 @@ func writeRuntimeInitialization(
 		IgnoreCreated:          ignoreCreated,
 		IgnoreUpdated:          ignoreUpdated,
 	}, nil
+}
+
+func encodeAgentProfileDocument(
+	document agentProfileDocument,
+) ([]byte, error) {
+	data, err := json.MarshalIndent(document, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode agent profiles: %w", err)
+	}
+	return append(data, '\n'), nil
+}
+
+func mergeAgentProfileDocument(
+	existing agentProfileDocument,
+	candidate agentProfileDocument,
+) (agentProfileDocument, bool, error) {
+	if len(candidate.Profiles) != 1 {
+		return agentProfileDocument{}, false, errors.New(
+			"profile registration must contain exactly one profile",
+		)
+	}
+	requested := candidate.Profiles[0]
+	for _, current := range existing.Profiles {
+		if current.Name != requested.Name {
+			continue
+		}
+		if reflect.DeepEqual(current, requested) {
+			return existing, false, nil
+		}
+		return agentProfileDocument{}, false, fmt.Errorf(
+			"already contains profile %q with different content; refusing to overwrite it",
+			requested.Name,
+		)
+	}
+	existing.Profiles = append(existing.Profiles, requested)
+	if err := validateAgentProfileDocument(existing); err != nil {
+		return agentProfileDocument{}, false, fmt.Errorf(
+			"merged profile document is invalid: %w",
+			err,
+		)
+	}
+	return existing, true, nil
 }
 
 func missingRuntimeIgnoreEntries(data []byte) []string {
@@ -508,6 +608,72 @@ func appendRuntimeIgnoreEntries(
 		return err
 	}
 	return file.Sync()
+}
+
+func replaceExistingRegularFile(
+	path string,
+	expected os.FileInfo,
+	data []byte,
+	mode os.FileMode,
+) (os.FileInfo, error) {
+	directory := filepath.Dir(path)
+	temporary, err := os.CreateTemp(directory, ".gatemole-profile-*")
+	if err != nil {
+		return nil, err
+	}
+	temporaryPath := temporary.Name()
+	removeTemporary := true
+	defer func() {
+		_ = temporary.Close()
+		if removeTemporary {
+			_ = os.Remove(temporaryPath)
+		}
+	}()
+	if err := temporary.Chmod(mode); err != nil {
+		return nil, err
+	}
+	if _, err := temporary.Write(data); err != nil {
+		return nil, err
+	}
+	if err := temporary.Sync(); err != nil {
+		return nil, err
+	}
+	replacement, err := temporary.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if err := temporary.Close(); err != nil {
+		return nil, err
+	}
+	current, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if expected == nil ||
+		!current.Mode().IsRegular() ||
+		current.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(expected, current) {
+		return nil, errors.New("agent profile document changed before it could be updated")
+	}
+	if err := os.Rename(temporaryPath, path); err != nil {
+		return nil, err
+	}
+	removeTemporary = false
+	return replacement, nil
+}
+
+func removeRegularFileIfSame(path string, expected os.FileInfo) error {
+	current, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	if expected == nil ||
+		!current.Mode().IsRegular() ||
+		current.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(expected, current) {
+		return errors.New("agent profile document changed before rollback")
+	}
+	return os.Remove(path)
 }
 
 func writeExclusiveRegularFile(path string, data []byte, mode os.FileMode) error {
@@ -793,7 +959,7 @@ func runRuntimeDoctor(
 	case os.IsNotExist(socketErr):
 		socketStatus = "warn"
 		socketMessage =
-			"not running; start it with `gatemole daemon` when you are ready to execute"
+			"not running; local product commands start a temporary development Runtime automatically; use `gatemole daemon` for persistent or configured operation"
 	case socketErr != nil:
 		socketStatus = "fail"
 		socketMessage = "inspect daemon socket: " + socketErr.Error()

--- a/internal/gatemole/runtime_onboarding_cli_test.go
+++ b/internal/gatemole/runtime_onboarding_cli_test.go
@@ -160,6 +160,128 @@ func TestRuntimeInitCreatesStrictProfileAndIsIdempotent(t *testing.T) {
 	}
 }
 
+func TestRuntimeInitAddsAProfileWithoutReplacingExistingProfiles(t *testing.T) {
+	repo := runtimeGitRepoForTest(t)
+	firstArgs := runtimeInitArgsForTest(repo, "/opt/agent", "run")
+	var stdout, stderr bytes.Buffer
+	if code := Main(firstArgs, &stdout, &stderr); code != 0 {
+		t.Fatalf("first runtime init code=%d stderr=%s", code, stderr.String())
+	}
+
+	secondImage := "registry.example.invalid/review-agent@" +
+		"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+	secondSource :=
+		"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+	secondArgs := []string{
+		"--repo", repo,
+		"runtime", "init",
+		"--agent", "review-agent",
+		"--image", secondImage,
+		"--source-digest", secondSource,
+		"--",
+		"/opt/review-agent", "run",
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main(secondArgs, &stdout, &stderr); code != 0 {
+		t.Fatalf("second runtime init code=%d stderr=%s", code, stderr.String())
+	}
+
+	profilesPath := filepath.Join(repo, defaultAgentProfiles)
+	data, err := readAgentProfilesFile(profilesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	document, err := decodeAgentProfileDocument(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(document.Profiles) != 2 ||
+		document.Profiles[0].Name != "coding-agent" ||
+		document.Profiles[1].Name != "review-agent" ||
+		document.Profiles[1].OCIImage != secondImage {
+		t.Fatalf("profiles were not merged additively: %#v", document.Profiles)
+	}
+	original := append([]byte(nil), data...)
+
+	stdout.Reset()
+	stderr.Reset()
+	if code := Main(secondArgs, &stdout, &stderr); code != 0 ||
+		!strings.Contains(stdout.String(), "already initialized") {
+		t.Fatalf(
+			"second profile retry was not idempotent: code=%d stderr=%s",
+			code,
+			stderr.String(),
+		)
+	}
+	after, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(original, after) {
+		t.Fatal("identical second profile registration rewrote the document")
+	}
+}
+
+func TestRuntimeInitRollsBackAddedProfileWhenLaterInitializationFails(t *testing.T) {
+	repo := runtimeGitRepoForTest(t)
+	var stdout, stderr bytes.Buffer
+	if code := Main(
+		runtimeInitArgsForTest(repo, "/opt/agent"),
+		&stdout,
+		&stderr,
+	); code != 0 {
+		t.Fatalf("first runtime init code=%d stderr=%s", code, stderr.String())
+	}
+	profilesPath := filepath.Join(repo, defaultAgentProfiles)
+	originalProfiles, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(repo, ".gitignore"),
+		[]byte("/.gatemole/runtime.json\n"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	ignorePath := filepath.Join(repo, runtimeIgnoreFile)
+	if err := os.Remove(ignorePath); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(t.TempDir(), "ignore-target")
+	if err := os.WriteFile(target, []byte("unchanged\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(target, ignorePath); err != nil {
+		t.Fatal(err)
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	code := Main([]string{
+		"--repo", repo,
+		"runtime", "init",
+		"--agent", "review-agent",
+		"--image", "registry.example.invalid/review-agent@" +
+			"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+		"--source-digest",
+		"sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+		"--", "/opt/review-agent",
+	}, &stdout, &stderr)
+	if code != 1 || !strings.Contains(stderr.String(), "not a regular file") {
+		t.Fatalf("unsafe ignore code=%d stderr=%s", code, stderr.String())
+	}
+	afterProfiles, err := os.ReadFile(profilesPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(originalProfiles, afterProfiles) {
+		t.Fatal("failed initialization did not restore the original profiles")
+	}
+}
+
 func TestRuntimeInitIdentityOnlyPreservesExistingProfiles(t *testing.T) {
 	repo := runtimeGitRepoForTest(t)
 	if err := os.Mkdir(filepath.Join(repo, ".gatemole"), 0o700); err != nil {
@@ -432,6 +554,42 @@ func TestAppendRuntimeIgnoreEntriesRejectsPathReplacement(t *testing.T) {
 	}
 	if !bytes.Equal(after, targetData) {
 		t.Fatalf("replacement target was modified: %q", after)
+	}
+}
+
+func TestReplaceAgentProfilesRejectsPathReplacement(t *testing.T) {
+	directory := t.TempDir()
+	path := filepath.Join(directory, "agent-profiles.json")
+	if err := os.WriteFile(path, []byte("original\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	expected, err := os.Lstat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(path, path+".moved"); err != nil {
+		t.Fatal(err)
+	}
+	replacement := []byte("concurrent update\n")
+	if err := os.WriteFile(path, replacement, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = replaceExistingRegularFile(
+		path,
+		expected,
+		[]byte("must not overwrite\n"),
+		0o600,
+	)
+	if err == nil || !strings.Contains(err.Error(), "changed") {
+		t.Fatalf("replaced profile path was accepted: %v", err)
+	}
+	after, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(after, replacement) {
+		t.Fatalf("concurrent profile update was overwritten: %q", after)
 	}
 }
 

--- a/internal/gatemole/transaction_cli.go
+++ b/internal/gatemole/transaction_cli.go
@@ -98,8 +98,15 @@ func transactionTopLevelAliasCommand(
 		fmt.Fprintf(stderr, "%s: %v\n", alias, err)
 		return 1
 	}
-	return transactionAliasCommandWithFactory(
-		alias, repo, args, jsonOut, stdout, stderr, factory,
+	return withAutomaticLocalRuntime(
+		repo,
+		automaticLocalRuntimeForAlias(repo, alias, args),
+		stderr,
+		func() int {
+			return transactionAliasCommandWithFactory(
+				alias, repo, args, jsonOut, stdout, stderr, factory,
+			)
+		},
 	)
 }
 

--- a/internal/gatemole/transaction_run_cli.go
+++ b/internal/gatemole/transaction_run_cli.go
@@ -76,14 +76,25 @@ func runtimeRunCommand(repo string, args []string, jsonOut bool, stdout, stderr 
 		fmt.Fprintf(stderr, "run: %v\n", err)
 		return 1
 	}
-	return runtimeRunCommandWithFactories(
+	operation := func() int {
+		return runtimeRunCommandWithFactories(
+			repo,
+			args,
+			jsonOut,
+			stdout,
+			stderr,
+			transactionFactory,
+			kernelFactory,
+		)
+	}
+	if isLegacyRunSubcommand(args[0]) {
+		return operation()
+	}
+	return withAutomaticLocalRuntime(
 		repo,
-		args,
-		jsonOut,
-		stdout,
+		automaticLocalRuntimeForRun(repo, args),
 		stderr,
-		transactionFactory,
-		kernelFactory,
+		operation,
 	)
 }
 
@@ -605,6 +616,8 @@ func runtimeRunUsage(out io.Writer) {
 	fmt.Fprintln(out, "  run (--intent TEXT | --intent-file FILE) --image IMAGE -- COMMAND [ARG...]")
 	fmt.Fprintln(out, "  run (--intent TEXT | --intent-file FILE) --runtime host --unsafe-host -- COMMAND [ARG...]")
 	fmt.Fprintln(out, "")
+	fmt.Fprintln(out, "the default local development Runtime is hosted automatically for this command")
+	fmt.Fprintln(out, "custom sockets, model brokers, and production enforcement require a configured daemon")
 	fmt.Fprintln(out, "production callers should pass --require-enforcement-profile production")
 	fmt.Fprintln(out, "advanced lifecycle: gatemole tx <command>")
 	fmt.Fprintln(out, "low-level run records: gatemole kernel run <command>")
@@ -812,7 +825,9 @@ func renderTransactionRunResult(
 	}
 	fmt.Fprintf(
 		stdout,
-		"Agent execution: %s\nTransaction state: %s\nAttempt: %d\nEffects: %d\n",
+		"Transaction: %s\nNamespace: %s\nAgent execution: %s\nTransaction state: %s\nAttempt: %d\nEffects: %d\n",
+		result.Projection.Transaction.ID,
+		result.Projection.Transaction.Namespace,
 		result.Execution.Status,
 		result.Projection.Transaction.State,
 		result.Projection.Transaction.Attempt,
@@ -823,6 +838,20 @@ func renderTransactionRunResult(
 		for _, finding := range result.Decision.Findings {
 			fmt.Fprintf(stdout, "- %s: %s\n", finding.RuleID, finding.Summary)
 		}
+	}
+	if result.Projection.Transaction.State == model.TransactionCompletedNoEffect {
+		fmt.Fprintln(stdout, "Next: no effects were produced; nothing needs review or application.")
+	} else {
+		namespaceArgument := ""
+		if result.Projection.Transaction.Namespace != "local" {
+			namespaceArgument = " --namespace " + result.Projection.Transaction.Namespace
+		}
+		fmt.Fprintf(
+			stdout,
+			"Next: `gatemole review %s%s`\n",
+			result.Projection.Transaction.ID,
+			namespaceArgument,
+		)
 	}
 	return 0
 }

--- a/internal/gatemole/transaction_run_cli_test.go
+++ b/internal/gatemole/transaction_run_cli_test.go
@@ -1188,7 +1188,11 @@ func TestVerificationUsesReadOnlySnapshotAndRecordsMutationAttempt(t *testing.T)
 
 func transactionRunRepository(t *testing.T) string {
 	t.Helper()
-	repo := t.TempDir()
+	return transactionRunRepositoryAt(t, t.TempDir())
+}
+
+func transactionRunRepositoryAt(t *testing.T, repo string) string {
+	t.Helper()
 	auth := filepath.Join(repo, "internal", "auth")
 	if err := os.MkdirAll(auth, 0o750); err != nil {
 		t.Fatal(err)

--- a/internal/kernel/client/client.go
+++ b/internal/kernel/client/client.go
@@ -79,6 +79,22 @@ func (c *Client) WithExpectedRuntimeID(runtimeID string) *Client {
 	return &cloned
 }
 
+// Health confirms that the local HTTP server is accepting authenticated Unix
+// connections. It deliberately does not run OCI-engine readiness checks; task
+// preflight remains the authoritative check for a selected agent image.
+func (c *Client) Health(ctx context.Context) error {
+	var result struct {
+		Status string `json:"status"`
+	}
+	if err := c.do(ctx, http.MethodGet, "/healthz", nil, &result); err != nil {
+		return err
+	}
+	if result.Status != "ok" {
+		return errors.New("gatemoled health response is invalid")
+	}
+	return nil
+}
+
 func (c *Client) CreateRun(ctx context.Context, event model.RunEvent) (reducer.Projection, error) {
 	var projection reducer.Projection
 	err := c.do(ctx, http.MethodPost, "/v0/runs", event, &projection)


### PR DESCRIPTION
## Summary

- automatically host a command-scoped development Runtime for primary local commands while reusing an existing daemon
- make `runtime init` add named agent profiles without overwriting existing profiles
- print the durable transaction ID and next review command, with Codex and edge deployment guidance

## Safety

- explicit sockets, production enforcement, and model-broker workloads remain externally managed
- digest-pinned OCI preflight and task admission remain unchanged
- profile updates are atomic, conflict-safe, and rollback only the exact inode written by the invocation

## Testing

- `go test -p 1 ./...`
